### PR TITLE
Use the `alwaysStat` option of chokidar to ensure stats is passed

### DIFF
--- a/lib/FilesWatcher.js
+++ b/lib/FilesWatcher.js
@@ -22,7 +22,7 @@ FilesWatcher.prototype.watch = function () {
   this.watchers = this.watchPaths.map(function (watchPath) {
     return chokidar.watch(
       watchPath,
-      { persistent: true }
+      { persistent: true, alwaysStat: true }
     )
     .on('change', function (filePath, stats) {
       if (this.isFileSupported(filePath)) {


### PR DESCRIPTION
While testing the plugin on OS X (and appreciating the idea and effort you put into it, it reduces the initial build time on our project to a little over 10s compared to 30s before), I noticed an error in incremental changes in the callback of the chokidar `change` event.

It appears that OSX doesn't always pass the stats object, however there is an option in chokidar that ensures exactly that. That being said, we could instead manually pull the stats object inside the `isFileSupported` condition to avoid it being loaded even though the file is unsupported.

https://www.npmjs.com/package/chokidar#performance

```
TypeError: Cannot read property 'mtime' of undefined
    at IncrementalChecker.<anonymous> (<dev>/frontend/node_modules/fork-ts-checker-webpack-plugin/lib/IncrementalChecker.js:84:95)
    at <dev>/frontend/node_modules/fork-ts-checker-webpack-plugin/lib/FilesWatcher.js:30:11
    at Array.forEach (native)
    at FilesWatcher.<anonymous> (<dev>/frontend/node_modules/fork-ts-checker-webpack-plugin/lib/FilesWatcher.js:29:42)
    at emitOne (events.js:96:13)
    at FSWatcher.emit (events.js:188:7)
    at FSWatcher.<anonymous> (<dev>/frontend/node_modules/chokidar/index.js:191:15)
    at FSWatcher._emit (<dev>/frontend/node_modules/chokidar/index.js:233:5)
    at FSWatcher.<anonymous> (<dev>/frontend/node_modules/chokidar/lib/fsevents-handler.js:204:14)
    at addOrChange (<dev>/frontend/node_modules/chokidar/lib/fsevents-handler.js:210:7)
```