### PR TITLE
Made isolatedModules always false

### DIFF
--- a/lib/IncrementalChecker.js
+++ b/lib/IncrementalChecker.js
@@ -28,7 +28,8 @@ module.exports = IncrementalChecker;
 
 IncrementalChecker.loadProgramConfig = function (configFile) {
   return ts.parseJsonConfigFileContent(
-    ts.readConfigFile(configFile, ts.sys.readFile).config,
+    // Regardless of the setting in the tsconfig.json we want isolatedModules to be false
+    Object.assign(ts.readConfigFile(configFile, ts.sys.readFile).config, { isolatedModules: false }),
     ts.sys,
     path.dirname(configFile)
   );


### PR DESCRIPTION
so it can be set to true in the tsconfig.json without affecting typechecking.  I think it's as simple as this - do correct me if I'm wrong!

Resolves https://github.com/Realytics/fork-ts-checker-webpack-plugin/issues/17

BTW your build is *nix specific (the `NODE_ENV=test ` in the `package.json`).  I haven't changed it but you could make it cross platform easily with [cross-env](https://www.npmjs.com/package/cross-env)