### PR TITLE
Allow webpack 3 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     "ts-loader": "^2.1.0",
     "tslint": "^5.0.0",
     "typescript": "^2.1.0",
-    "webpack": "^2.0.0"
+    "webpack": "^3.0.0"
   },
   "peerDependencies": {
     "typescript": "^2.1.0",
-    "webpack": "^2.0.0"
+    "webpack": "^2.0.0 || ^3.0.0"
   },
   "dependencies": {
     "chalk": "^1.1.3",


### PR DESCRIPTION
Webpack 3 just got released: https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b

AFAIK there are no breaking changes that affect this plugin.

ps thanks for creating this, it's really sped up our build times! 😄 