### PR TITLE
Service is killed when webpack watch is done

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -146,6 +146,10 @@ ForkTsCheckerWebpackPlugin.prototype.pluginStart = function () {
 };
 
 ForkTsCheckerWebpackPlugin.prototype.pluginStop = function () {
+  this.compiler.plugin('watch-close', function () {
+    this.killService();
+  }.bind(this));
+
   this.compiler.plugin('done', function () {
     if (!this.isWatching) {
       this.killService();

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "typescript": "^2.1.0",
-    "webpack": "^2.0.0 || ^3.0.0"
+    "webpack": "^2.3.0 || ^3.0.0"
   },
   "dependencies": {
     "babel-code-frame": "^6.22.0",


### PR DESCRIPTION
This fixes #27 by making sure the service is killed when the watch
task emits the "watch-close" event.
This fix only works with webpack >= 2.3.0 otherwise it's effectively a
noop because the event will never be emitted.