### PR TITLE
Add async flag in options + v0.2.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.2.5
+ * Add `async` option - more information in `README.md`
+
 ## v0.2.4
  * Fix `ESLint: "fork-ts-checker-webpack-plugin" is not published.` issue
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ Path to *tslint.json* file or `true`. If `true`, uses `path.resolve(compiler.opt
 
 * **watch** `string | string[]`: 
 Directories or files to watch by service. Not necessary but improves performance (reduces number of `fs.stat` calls).
-                                  
+
+* **async** `boolean`:
+True by default - `async: false` can block webpack's emit to wait for type checker/linter and to add errors to the webpack's compilation.
+We recommend to use it in projects where type checking is faster than webpack's build - it's better for integration with other plugins.
+
 * **ignoreDiagnostics** `number[]`:
 List of typescript diagnostic codes to ignore.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,8 @@ function ForkTsCheckerWebpackPlugin (options) {
   this.ignoreDiagnostics = options.ignoreDiagnostics || [];
   this.ignoreLints = options.ignoreLints || [];
   this.logger = options.logger || console;
-  this.silent = !!options.silent;
+  this.silent = options.silent === true; // default false
+  this.async = options.async !== false; // default true
   this.workersNumber = options.workers || ForkTsCheckerWebpackPlugin.ONE_CPU;
   this.memoryLimit = options.memoryLimit || ForkTsCheckerWebpackPlugin.DEFAULT_MEMORY_LIMIT;
   this.colors = new chalk.constructor({ enabled: options.colors === undefined ? true : !!options.colors });
@@ -171,7 +172,7 @@ ForkTsCheckerWebpackPlugin.prototype.pluginCompile = function () {
 
 ForkTsCheckerWebpackPlugin.prototype.pluginEmit = function () {
   this.compiler.plugin('emit', function (compilation, callback) {
-    if (this.isWatching) {
+    if (this.isWatching && this.async) {
       callback();
       return;
     }
@@ -188,7 +189,7 @@ ForkTsCheckerWebpackPlugin.prototype.pluginEmit = function () {
 
 ForkTsCheckerWebpackPlugin.prototype.pluginDone = function () {
   this.compiler.plugin('done', function () {
-    if (!this.isWatching) {
+    if (!this.isWatching || !this.async) {
       return;
     }
 
@@ -306,7 +307,7 @@ ForkTsCheckerWebpackPlugin.prototype.handleServiceMessage = function (message) {
   this.compiler.applyPlugins('fork-ts-checker-receive', this.diagnostics, this.lints);
 
   if (this.compilationDone) {
-    this.isWatching ? this.doneCallback() : this.emitCallback();
+    (this.isWatching && this.async) ? this.doneCallback() : this.emitCallback();
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "files": [

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -84,12 +84,23 @@ describe('[INTEGRATION] index', function () {
     compiler.run(function() {});
   });
 
-
   it('should not block emit on watch mode', function (callback) {
     var compiler = createCompiler();
     var watching = compiler.watch({}, function() {});
 
     compiler.plugin('fork-ts-checker-done', function () {
+      watching.close(function() {
+        expect(true).to.be.true;
+        callback();
+      });
+    });
+  });
+
+  it('should block emit if async flag is false', function (callback) {
+    var compiler = createCompiler({ async: false });
+    var watching = compiler.watch({}, function() {});
+
+    compiler.plugin('fork-ts-checker-emit', function () {
       watching.close(function() {
         expect(true).to.be.true;
         callback();


### PR DESCRIPTION
Adds async flag - see #26 

* **async** `boolean`:
True by default - `async: false` can block webpack's emit to wait for type checker/linter and to add errors to the webpack's compilation.
We recommend to use it in projects where type checking is faster than webpack's build - it's better for integration with other plugins.


