### PR TITLE
Fix log message when tslint is on.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -226,8 +226,8 @@ ForkTsCheckerWebpackPlugin.prototype.pluginDone = function () {
       if (!this.silent && this.logger) {
         this.logger.info(
           this.tslint
-            ? 'Type checking in progress...'
-            : 'Type checking and linting in progress...'
+            ? 'Type checking and linting in progress...'
+            : 'Type checking in progress...'
         );
       }
     }


### PR DESCRIPTION
I just noticed this log message is incorrectly flipped. Here's the fix.