### PR TITLE
Pass parent enviornment vars to forked processes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -242,13 +242,17 @@ ForkTsCheckerWebpackPlugin.prototype.spawnService = function () {
     [],
     {
       execArgv: this.workersNumber > 1 ? [] : ['--max-old-space-size=' + this.memoryLimit],
-      env: {
-        TSCONFIG: this.tsconfigPath,
-        TSLINT: this.tslintPath || '',
-        WATCH: this.isWatching ? this.watchPaths.join('|') : '',
-        WORK_DIVISION: Math.max(1, this.workersNumber),
-        MEMORY_LIMIT: this.memoryLimit
-      },
+      env: Object.assign(
+        {},
+        process.env,
+        {
+          TSCONFIG: this.tsconfigPath,
+          TSLINT: this.tslintPath || '',
+          WATCH: this.isWatching ? this.watchPaths.join('|') : '',
+          WORK_DIVISION: Math.max(1, this.workersNumber),
+          MEMORY_LIMIT: this.memoryLimit
+        }
+      ),
       stdio: ['inherit', 'inherit', 'inherit', 'ipc']
     }
   );


### PR DESCRIPTION
Fix for https://github.com/Realytics/fork-ts-checker-webpack-plugin/issues/41