### PR TITLE
Fix clicking on URLs in the terminal (for VS Code users)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ If `false`, disables built-in colors in logger messages. Default: `true`.
 * **logger** `object`:
 Logger instance. It should be object that implements method: `error`, `warn`, `info`. Default: `console`.
 
-* **formatter** `'default' | 'codeframe' | Function`:
+* **formatter** `'default' | 'codeframe' | ((message: NormalizedMessage, useColors: boolean) => string)`:
 Formatter for diagnostics and lints. By default uses `default` formatter. You can also pass your own formatter as a function
-(see `lib/NormalizedMessage.js` and `lib/formatter/` for api reference).
+(see `src/NormalizedMessage.js` and `src/formatter/` for api reference).
 
 * **formatterOptions** `object`:
 Options passed to formatters (currently only `codeframe` - see [available options](https://www.npmjs.com/package/babel-code-frame#options))
@@ -112,7 +112,7 @@ number **can increase checking time**. Default: `ForkTsCheckerWebpackPlugin.ONE_
 
 ## Notifier
 
-You may already be using the excellent [webpack-notifier](https://github.com/Turbo87/webpack-notifier) plugin to make build failures more obvious in the form of system notifications. There's an equivalent notifier plugin designed to work with the `fork-ts-checker-webpack-plugin`.  It is the `fork-ts-checker-notifier-webpack-plugin` and can be found [here](https://github.com/johnnyreilly/fork-ts-checker-notifier-webpack-plugin). This notifier deliberately has a similar API as the `webpack-notifier` plugin to make migration easier.
+You may already be using the excellent [webpack-notifier](https://github.com/Turbo87/webpack-notifier) plugin to make build failures more obvious in the form of system notifications. There's an equivalent notifier plugin designed to work with the `fork-ts-checker-webpack-plugin`.  It is the `fork-ts-checker-notifier-webpack-plugin` and can be found [here](https://github.com/johnnyreilly/fork-ts-checker-notifier-webpack-plugin). This notifier desrcerately has a similar API as the `webpack-notifier` plugin to make migration easier.
 
 ## Known Issue Watching Non-Emitting Files
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ number **can increase checking time**. Default: `ForkTsCheckerWebpackPlugin.ONE_
 
 ## Notifier
 
-You may already be using the excellent [webpack-notifier](https://github.com/Turbo87/webpack-notifier) plugin to make build failures more obvious in the form of system notifications. There's an equivalent notifier plugin designed to work with the `fork-ts-checker-webpack-plugin`.  It is the `fork-ts-checker-notifier-webpack-plugin` and can be found [here](https://github.com/johnnyreilly/fork-ts-checker-notifier-webpack-plugin). This notifier desrcerately has a similar API as the `webpack-notifier` plugin to make migration easier.
+You may already be using the excellent [webpack-notifier](https://github.com/Turbo87/webpack-notifier) plugin to make build failures more obvious in the form of system notifications. There's an equivalent notifier plugin designed to work with the `fork-ts-checker-webpack-plugin`.  It is the `fork-ts-checker-notifier-webpack-plugin` and can be found [here](https://github.com/johnnyreilly/fork-ts-checker-notifier-webpack-plugin). This notifier deliberately has a similar API as the `webpack-notifier` plugin to make migration easier.
 
 ## Known Issue Watching Non-Emitting Files
 

--- a/src/formatter/codeframeFormatter.ts
+++ b/src/formatter/codeframeFormatter.ts
@@ -32,7 +32,7 @@ export = function createCodeframeFormatter(options: any) {
     }
 
     return (
-      messageColor(message.getSeverity().toUpperCase() + ' at ' + message.getFile()) + os.EOL +
+      messageColor(message.getSeverity().toUpperCase() + ' in ' + message.getFile()) + os.EOL +
       positionColor(message.getLine() + ':' + message.getCharacter()) + ' ' + message.getContent() +
       (frame ? os.EOL + frame : '')
     );

--- a/src/formatter/defaultFormatter.ts
+++ b/src/formatter/defaultFormatter.ts
@@ -12,12 +12,13 @@ export = function createDefaultFormatter() {
   return function defaultFormatter(message: NormalizedMessage, useColors: boolean) {
     const colors = new chalk.constructor({enabled: useColors});
     const messageColor = message.isWarningSeverity() ? colors.bold.yellow : colors.bold.red;
-    const numberColor = colors.bold.cyan;
+    const fileAndNumberColor = colors.bold.cyan;
     const codeColor = colors.grey;
 
     return [
-      messageColor(message.getSeverity().toUpperCase() + ' in ' + message.getFile()),
-      '(' + numberColor(`${message.getLine()}`) + ',' + numberColor(`${message.getCharacter()}`) + '): ' +
+      messageColor(`${message.getSeverity().toUpperCase()} in `) +
+      fileAndNumberColor(`${message.getFile()}(${message.getLine()},${message.getCharacter()})`) +
+      messageColor(': '),
       codeColor(message.getFormattedCode() + ': ') + message.getContent()
     ].join(os.EOL);
   };

--- a/src/formatter/defaultFormatter.ts
+++ b/src/formatter/defaultFormatter.ts
@@ -16,8 +16,8 @@ export = function createDefaultFormatter() {
     const codeColor = colors.grey;
 
     return [
-      messageColor(message.getSeverity().toUpperCase() + ' at ' + message.getFile()) +
-      '(' + numberColor(`${message.getLine()}`) + ',' + numberColor(`${message.getCharacter()}`) + '): ',
+      messageColor(message.getSeverity().toUpperCase() + ' in ' + message.getFile()),
+      '(' + numberColor(`${message.getLine()}`) + ',' + numberColor(`${message.getCharacter()}`) + '): ' +
       codeColor(message.getFormattedCode() + ': ') + message.getContent()
     ].join(os.EOL);
   };

--- a/src/formatter/defaultFormatter.ts
+++ b/src/formatter/defaultFormatter.ts
@@ -18,7 +18,7 @@ export = function createDefaultFormatter() {
     return [
       messageColor(`${message.getSeverity().toUpperCase()} in `) +
       fileAndNumberColor(`${message.getFile()}(${message.getLine()},${message.getCharacter()})`) +
-      messageColor(': '),
+      messageColor(':'),
       codeColor(message.getFormattedCode() + ': ') + message.getContent()
     ].join(os.EOL);
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import createDefaultFormatter = require('./formatter/defaultFormatter');
 import createCodeframeFormatter = require('./formatter/codeframeFormatter');
 import Message from './Message';
 
+type Formatter = (message: NormalizedMessage, useColors: boolean) => string;
+
 interface Options {
   tsconfig: string;
   tslint: string | true;
@@ -22,7 +24,7 @@ interface Options {
   ignoreLints: string[];
   colors: boolean;
   logger: Console;
-  formatter: 'default' | 'codeframe' | Function;
+  formatter: 'default' | 'codeframe' | Formatter;
   formatterOptions: any;
   silent: boolean;
   checkSyntacticErrors: boolean;
@@ -58,7 +60,7 @@ class ForkTsCheckerWebpackPlugin {
   memoryLimit: number;
   useColors: boolean;
   colors: chalk.Chalk;
-  formatter: Function;
+  formatter: Formatter;
 
   tsconfigPath: string;
   tslintPath: string;
@@ -100,8 +102,9 @@ class ForkTsCheckerWebpackPlugin {
     this.memoryLimit = options.memoryLimit || ForkTsCheckerWebpackPlugin.DEFAULT_MEMORY_LIMIT;
     this.useColors = options.colors !== false; // default true
     this.colors = new chalk.constructor({ enabled: this.useColors });
-    this.formatter = (options.formatter && isFunction(options.formatter)) ?
-      options.formatter : ForkTsCheckerWebpackPlugin.createFormatter(options.formatter || 'default', options.formatterOptions || {});
+    this.formatter = (options.formatter && isFunction(options.formatter))
+      ? options.formatter
+      : ForkTsCheckerWebpackPlugin.createFormatter(options.formatter as 'default' | 'codeframe' || 'default', options.formatterOptions || {});
 
     this.tsconfigPath = undefined;
     this.tslintPath = undefined;
@@ -125,7 +128,7 @@ class ForkTsCheckerWebpackPlugin {
     this.tslintVersion = this.tslint ? require('tslint').Linter.VERSION : undefined;
   }
 
-  static createFormatter(type: Function | 'default' | 'codeframe', options: any) {
+  static createFormatter(type: 'default' | 'codeframe', options: any) {
     switch (type) {
       case 'default':
         return createDefaultFormatter();

--- a/test/unit/codeframeFormatter.spec.js
+++ b/test/unit/codeframeFormatter.spec.js
@@ -47,7 +47,7 @@ describe('[UNIT] formatter/codeframeFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'ERROR at some/file.ts' + os.EOL +
+      'ERROR in some/file.ts' + os.EOL +
       '1:7 Some diagnostic content' + os.EOL +
       '  > 1 | class SomeClass {' + os.EOL +
       '      |       ^' + os.EOL +
@@ -72,7 +72,7 @@ describe('[UNIT] formatter/codeframeFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'WARNING at some/file.ts' + os.EOL +
+      'WARNING in some/file.ts' + os.EOL +
       '2:11 Some lint content' + os.EOL +
       '    1 | class SomeClass {' + os.EOL +
       '  > 2 |   private someProperty: boolean;' + os.EOL +
@@ -98,7 +98,7 @@ describe('[UNIT] formatter/codeframeFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'WARNING at some/unknown-file.ts' + os.EOL +
+      'WARNING in some/unknown-file.ts' + os.EOL +
       '2:11 Some lint content'
     );
   });

--- a/test/unit/defaultFormatter.spec.js
+++ b/test/unit/defaultFormatter.spec.js
@@ -22,8 +22,8 @@ describe('[UNIT] formatter/defaultFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'ERROR at /some/file.ts(1,5): ' + os.EOL +
-      'TS123: Some diagnostic content'
+      'ERROR in /some/file.ts' + os.EOL +
+      '(1,5): TS123: Some diagnostic content'
     );
   });
 
@@ -41,8 +41,8 @@ describe('[UNIT] formatter/defaultFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'WARNING at /some/file.ts(2,6): ' + os.EOL +
-      'some-lint-rule: Some lint content'
+      'WARNING in /some/file.ts' + os.EOL +
+      '(2,6): some-lint-rule: Some lint content'
     );
   });
 });

--- a/test/unit/defaultFormatter.spec.js
+++ b/test/unit/defaultFormatter.spec.js
@@ -22,8 +22,8 @@ describe('[UNIT] formatter/defaultFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'ERROR in /some/file.ts' + os.EOL +
-      '(1,5): TS123: Some diagnostic content'
+      'ERROR in /some/file.ts(1,5):' + os.EOL +
+      'TS123: Some diagnostic content'
     );
   });
 
@@ -41,8 +41,8 @@ describe('[UNIT] formatter/defaultFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'WARNING in /some/file.ts' + os.EOL +
-      '(2,6): some-lint-rule: Some lint content'
+      'WARNING in /some/file.ts(2,6):' + os.EOL +
+      'some-lint-rule: Some lint content'
     );
   });
 });


### PR DESCRIPTION
**EDIT: I misunderstood the original problem as I did this PR.  I've left most of what I've written in place but please do read all the way to the end.  It will all make a little more sense then I promise 😄**

The motivation behind this PR has very little to do with getting reported errors closer to ts-loader's "style".  (I honestly have no opinion on the style as is.) This PR essentially flows from my addiction to using VS Code as my editor.  Let me explain.  At present the formatted output of an error looks like this:

```
ERROR at C:/work/fx-online/src/FxOnline.App/src/containers/deposits/account/GiveNotice/index.tsx(190,44):
no-use-before-declare: variable 'form' used before declaration
```

Which is great in terms of information.  However; there's a gotcha.  When using the integrated terminal in VS Code I like being able to click on a file in the terminal and navigate straight there.  The existing formatting in the `defaultFormatter` puts the parens and error location information in with the path itself.  And VS Code doesn't interpret it as a link. :cry: 

~~The change I've made moves the parens onto the next line.  This is more like what ts-loader does and also the `codeframeFormatter` too.  The new output looks like this:~~


~~ERROR in C:/work/fx-online/src/FxOnline.App/src/containers/deposits/account/GiveNotice/index.tsx
(190,44): no-use-before-declare: variable 'form' used before declaration~~

**EDIT: I misunderstood the reason this wasn't "clickable" - read on and you'll see more.**

This is clickable in VS Code :+1:  I've also changed " at " to " in " as I thought it was a little clearer.  If you prefer " at " I'm more than happy to revert that.  

My team is running with this fork locally now (`yarn link`ing our way to glory)

What do you think about this?  I'd really like to get this merged.  More generally I think there could be some work done to allow people to supply their own formatters but in a future PR perhaps.