### PR TITLE
Correctly handle linterOptions.exclude from tslint config, if present (#61)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/lodash.isfunction": "^3.0.3",
     "@types/lodash.isstring": "^4.0.3",
     "@types/lodash.startswith": "^4.2.3",
+    "@types/minimatch": "^3.0.1",
     "@types/node": "^8.0.26",
     "@types/webpack": "^3.0.10",
     "chai": "^3.5.0",
@@ -75,6 +76,7 @@
     "lodash.endswith": "^4.2.1",
     "lodash.isfunction": "^3.0.8",
     "lodash.isstring": "^4.0.1",
-    "lodash.startswith": "^4.2.1"
+    "lodash.startswith": "^4.2.1",
+    "minimatch": "^3.0.4"
   }
 }

--- a/test/unit/IncrementalChecker.spec.js
+++ b/test/unit/IncrementalChecker.spec.js
@@ -1,0 +1,43 @@
+var describe = require('mocha').describe;
+var it = require('mocha').it;
+var expect = require('chai').expect;
+var path = require('path');
+var minimatch = require('minimatch');
+
+var IncrementalChecker = require('../../lib/IncrementalChecker');
+
+describe('[UNIT] IncrementalChecker', function () {
+  describe('isFileExcluded', function() {
+    it('should properly filter definition files and listed exclusions', function() {
+      var linterConfig = {
+        linterOptions: {
+          exclude: [
+            'src/formatter/**/*.ts'
+          ]
+        }
+      };
+
+      var exclusions = linterConfig.linterOptions.exclude.map(function(pattern) {
+        return new minimatch.Minimatch(path.resolve(pattern));
+      });
+
+      var testPaths = [
+        'src/formatter/codeframeFormatter.ts',
+        'src/formatter/defaultFormatter.ts',
+        'src/service.ts',
+        'node_modules/tslint/lib/configuration.d.ts',
+      ].map(function(p) {
+        return path.resolve(p);
+      });
+
+      var pathsAreExcluded = testPaths.map(function(p) {
+        return IncrementalChecker.isFileExcluded(p, exclusions);
+      });
+
+      expect(pathsAreExcluded[0]).to.be.true;
+      expect(pathsAreExcluded[1]).to.be.true;
+      expect(pathsAreExcluded[2]).to.be.false;
+      expect(pathsAreExcluded[3]).to.be.true;
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,10 @@
   version "4.14.74"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.74.tgz#ac3bd8db988e7f7038e5d22bd76a7ba13f876168"
 
+"@types/minimatch@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.1.tgz#b683eb60be358304ef146f5775db4c0e3696a550"
+
 "@types/node@*", "@types/node@^8.0.26":
   version "8.0.26"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.26.tgz#4d58be925306fd22b1141085535a0268b8beb189"


### PR DESCRIPTION
Refers to #61 :

Tslint currently supports particular linter options to be set in the `tslint.json`. These are handled automatically when using the CLI, but most of them have to be handled manually when using the `Linter` API.
The parameter for manually excluding files is `linterOptions.exclude` (description can be found in the [docs](https://github.com/palantir/tslint/blob/77191671fef18cfe6fcdd5d817b006161259c2d9/docs/usage/configuration/index.md)). Excluding files is sometimes required, e.g. in case a module provides type definitions that refer to plain `ts` files or when using `ts` source files from those modules directly - in both cases, those might conform to different linter settings, and thus might cause the linting process to fail.

This PR adds some code to pick up this config entry if present, and filter out files that should not be linted according to the provided patterns. If follows the approach that `tslint` itself uses:

https://github.com/palantir/tslint/blob/5634a074f72bd82854bc5439a3a27388b05b64d3/src/runner.ts#L193-L196
https://github.com/palantir/tslint/blob/5634a074f72bd82854bc5439a3a27388b05b64d3/src/runner.ts#L223-L229

Uses the same glob matching library as tslint, the dependency is now just explicitly listed.