### PR TITLE
Ability to work with .vue files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,11 @@ jspm_packages
 
 # Optional npm cache directory
 .npm
+package-lock.json
 
 # Optional REPL history
 .node_repl_history
 
-# IDEA directory
+# Editor directories and files
 .idea
+.vscode

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "ts-loader": "^2.1.0",
     "tslint": "^5.0.0",
     "typescript": "^2.1.0",
-    "vue-parser": "0.0.3",
     "webpack": "^3.0.0"
   },
   "peerDependencies": {
@@ -77,6 +76,7 @@
     "lodash.isfunction": "^3.0.8",
     "lodash.isstring": "^4.0.1",
     "lodash.startswith": "^4.2.1",
-    "minimatch": "^3.0.4"
+    "minimatch": "^3.0.4",
+    "vue-parser": "0.0.3"    
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ts-loader": "^2.1.0",
     "tslint": "^5.0.0",
     "typescript": "^2.1.0",
+    "vue-parser": "0.0.3",
     "webpack": "^3.0.0"
   },
   "peerDependencies": {

--- a/src/IncrementalChecker.ts
+++ b/src/IncrementalChecker.ts
@@ -9,7 +9,7 @@ import WorkSet = require('./WorkSet');
 import NormalizedMessage = require('./NormalizedMessage');
 import CancellationToken = require('./CancellationToken');
 import minimatch = require('minimatch');
-import * as vueParser from 'vue-parser';
+import vueParser = require('vue-parser');
 
 // Need some augmentation here - linterOptions.exclude is not (yet) part of the official
 // types for tslint.

--- a/src/IncrementalChecker.ts
+++ b/src/IncrementalChecker.ts
@@ -9,6 +9,7 @@ import WorkSet = require('./WorkSet');
 import NormalizedMessage = require('./NormalizedMessage');
 import CancellationToken = require('./CancellationToken');
 import minimatch = require('minimatch');
+import * as vueParser from 'vue-parser';
 
 // Need some augmentation here - linterOptions.exclude is not (yet) part of the official
 // types for tslint.
@@ -107,7 +108,46 @@ class IncrementalChecker {
         });
       }
 
-      return files.getData(filePath).source;
+      let source = files.getData(filePath).source;
+
+      // get typescript contents from Vue file
+      if (path.extname(filePath) === '.vue') {
+        const parsed = vueParser.parse(source.text, 'script', { lang: 'ts' });
+        source = ts.createSourceFile(filePath, parsed, languageVersion);
+      }
+
+      return source;
+    };
+
+    host.fileExists = function fileExists(fileName) {
+      return ts.sys.fileExists(fileName);
+    };
+
+    host.readFile = function readFile(fileName) {
+    return ts.sys.readFile(fileName);
+    };
+
+    host.resolveModuleNames = (moduleNames, containingFile) => {
+      const resolvedModules: ts.ResolvedModule[] = [];
+
+      for (const moduleName of moduleNames) {
+        // Try to use standard resolution.
+        const result = ts.resolveModuleName(moduleName, containingFile, programConfig.options, {
+          fileExists: host.fileExists,
+          readFile: host.readFile
+        });
+
+        if (result.resolvedModule) {
+          resolvedModules.push(result.resolvedModule);
+        } else {
+          // For non-ts extensions.
+          resolvedModules.push({
+            resolvedFileName: moduleName,
+            extension: '.ts'
+          } as ts.ResolvedModuleFull);
+        }
+      }
+      return resolvedModules;
     };
 
     return ts.createProgram(


### PR DESCRIPTION
Hi guys, 

This PR adds ability to work with `.vue` files. The files are parsed in such a way as line numbers are preserved. Just ensure the script tag is set `ts` in your `.vue` files, for example:  

```js
<script lang="ts">
  // ...
</script>
```
For a quick test, I created a `temp` branch with the built `lib` folder included. So you can install like this:  

`npm install git://github.com/prograhammer/fork-ts-checker-webpack-plugin.git#temp --save-dev
`

If you are testing in Webpack, (in addition to this plugin) you'll need something like this in your rules:

      {
        test: /\.ts$/,
        loader: 'ts-loader',
        include: [resolve('src'), resolve('test')],
        options: {
          appendTsSuffixTo: [/\.vue$/],
          transpileOnly: true
        }
      },
      {
        test: /\.vue$/,
        loader: 'vue-loader',
        options: vueLoaderConfig
      },

I also currently use [tslint-config-standard](https://github.com/blakeembrey/tslint-config-standard) so my `tslint.json` looks something like:  

```json
{
    "defaultSeverity": "error",
    "extends": [
      "tslint-config-standard"
    ]
}
```
I'll try to put together a simple typescript example project for you to test with as well.  If you are working in **VSCode**, you'll need extensions [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) and [TSLint Vue](https://marketplace.visualstudio.com/items?itemName=prograhammer.tslint-vue) (a forked extension which I also currently maintain) and the editor will match the output you get from this `fork-ts-checker-webpack-plugin`.

Let me know what more you need. Also, if Vue functionality is too specific for this repo, I can do a fork and release it seperately via `npm` instead.

Thanks!