### PR TITLE
Support jsx in vue

### DIFF
--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -147,4 +147,93 @@ describe('[INTEGRATION] vue', function () {
       callback();
     });
   });
+
+  [
+    'example-ts.vue',
+    'example-tsx.vue',
+    'example-js.vue',
+    'example-jsx.vue',
+    'example-nolang.vue'
+  ].forEach(fileName => {
+    it('should be able to extract script from ' + fileName, function () {
+      createCompiler({ vue: true, tsconfig: 'tsconfig-langs.json' });
+      var sourceFilePath = path.resolve(compiler.context, 'src/langs/' + fileName)
+      var source = checker.program.getSourceFile(sourceFilePath);
+      expect(source).to.not.be.undefined;
+      // remove padding lines
+      var text = source.text.replace(/^\s*\/\/.*$\n/gm, '');
+      expect(text.startsWith('/* OK */')).to.be.true;
+    });
+  });
+
+  function groupByFileName(errors) {
+    var ret = {
+      'example-ts.vue': [],
+      'example-tsx.vue': [],
+      'example-js.vue': [],
+      'example-jsx.vue': [],
+      'example-nolang.vue': []
+    };
+    for (var error of errors) {
+      ret[path.basename(error.file)].push(error);
+    }
+    return ret;
+  }
+
+  describe('should be able to compile *.vue with each lang', function () {
+    var errors;
+    before(function(callback) {
+      createCompiler({ vue: true, tsconfig: 'tsconfig-langs.json' });
+      compiler.run(function(error, stats) {
+        errors = groupByFileName(stats.compilation.errors);
+        callback();
+      });
+    });
+    it("lang=ts", function() {
+      expect(errors['example-ts.vue'].length).to.be.equal(0);
+    })
+    it("lang=tsx", function() {
+      expect(errors['example-tsx.vue'].length).to.be.equal(0);
+    });
+    it("lang=js", function() {
+      expect(errors['example-js.vue'].length).to.be.equal(0);
+    });
+    it("lang=jsx", function() {
+      expect(errors['example-jsx.vue'].length).to.be.equal(0);
+    });
+    it("no lang", function() {
+      expect(errors['example-nolang.vue'].length).to.be.equal(0);
+    });
+  });
+
+  describe('should be able to detect errors in *.vue', function () {
+    var errors;
+    before(function(callback) {
+      // tsconfig-langs-strict.json === tsconfig-langs.json + noUnusedLocals
+      createCompiler({ vue: true, tsconfig: 'tsconfig-langs-strict.json' });
+      compiler.run(function(error, stats) {
+        errors = groupByFileName(stats.compilation.errors);
+        callback();
+      });
+    });
+    it("lang=ts", function() {
+      expect(errors['example-ts.vue'].length).to.be.equal(1);
+      expect(errors['example-ts.vue'][0].rawMessage).to.match(/'a' is declared but/);
+    })
+    it("lang=tsx", function() {
+      expect(errors['example-tsx.vue'].length).to.be.equal(1);
+      expect(errors['example-tsx.vue'][0].rawMessage).to.match(/'a' is declared but/);
+    });
+    it("lang=js", function() {
+      expect(errors['example-js.vue'].length).to.be.equal(0);
+    });
+    it("lang=jsx", function() {
+      expect(errors['example-jsx.vue'].length).to.be.equal(0);
+    });
+    it("no lang", function() {
+      expect(errors['example-nolang.vue'].length).to.be.equal(0);
+    });
+  });
+
+
 });

--- a/test/integration/vue/src/langs/example-js.vue
+++ b/test/integration/vue/src/langs/example-js.vue
@@ -1,0 +1,17 @@
+<template>
+<div>Example</div>
+</template>
+
+<script lang="js">
+/* OK */
+import Vue from "vue";
+export default Vue.extend({
+  name: "ExampleJs",
+  methods: {
+    foo() {
+      const a = 1; // noUnusedLocals
+    }
+  }
+});
+</script>
+

--- a/test/integration/vue/src/langs/example-jsx.vue
+++ b/test/integration/vue/src/langs/example-jsx.vue
@@ -1,0 +1,11 @@
+<script lang="jsx">
+/* OK */
+import Vue from "vue";
+export default Vue.extend({
+  name: "ExampleJsx",
+  render() {
+    const a = 1; // noUnusedLocals
+    return <div>Example</div>;
+  }
+});
+</script>

--- a/test/integration/vue/src/langs/example-nolang.vue
+++ b/test/integration/vue/src/langs/example-nolang.vue
@@ -1,0 +1,17 @@
+<template>
+<div>Example</div>
+</template>
+
+<script>
+/* OK */
+import Vue from "vue";
+export default Vue.extend({
+  name: "ExampleNolang",
+  methods: {
+    foo() {
+      const a = 1; // noUnusedLocals
+    }
+  }
+});
+</script>
+

--- a/test/integration/vue/src/langs/example-ts.vue
+++ b/test/integration/vue/src/langs/example-ts.vue
@@ -1,0 +1,18 @@
+<template>
+<div>{{ text }}</div>
+</template>
+
+<script lang="ts">
+/* OK */
+import Vue from "vue";
+export default Vue.extend({
+  name: "ExampleJs",
+  computed: {
+    text(): string {
+      const a = 1; // noUnusedLocals
+      return "Example";
+    }
+  }
+});
+</script>
+

--- a/test/integration/vue/src/langs/example-tsx.vue
+++ b/test/integration/vue/src/langs/example-tsx.vue
@@ -1,0 +1,11 @@
+<script lang="tsx">
+/* OK */
+import Vue, { VNode } from "vue";
+export default Vue.extend({
+  name: "ExampleTsx",
+  render(): VNode {
+    const a = 1; // noUnusedLocals
+    return <div>Example</div>;
+  }
+});
+</script>

--- a/test/integration/vue/src/langs/index.ts
+++ b/test/integration/vue/src/langs/index.ts
@@ -1,0 +1,6 @@
+import Vue from "vue";
+import ExampleTsx from "./example-tsx.vue";
+
+new Vue({
+    components: { ExampleTsx }
+});

--- a/test/integration/vue/tsconfig-langs-strict.json
+++ b/test/integration/vue/tsconfig-langs-strict.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+      "jsx": "preserve",
+      "noUnusedLocals": true
+  },
+  "include": [
+      "src/langs/*.ts",
+      "src/langs/*.vue"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/integration/vue/tsconfig-langs.json
+++ b/test/integration/vue/tsconfig-langs.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-      "experimentalDecorators": true
+      "jsx": "preserve"
   },
   "include": [
-      "src/*.ts",
-      "src/*.vue"
+      "src/langs/*.ts",
+      "src/langs/*.vue"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Currently, this plugin can't compile vue SFC with lang other than "ts" or "js"

- If lang is "tsx" or "jsx", compilation errors are raised.
- if lang is not specfied, content of <script> is ignored. 

This PR will fix this problem.
