### PR TITLE
Improve module resolution of *.vue

### DIFF
--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -234,4 +234,42 @@ describe('[INTEGRATION] vue', function () {
       expect(errors['example-nolang.vue'].length).to.be.equal(0);
     });
   });
+
+  describe('should resolve *.vue in the same way as TypeScript', function() {
+    var errors;
+    before(function(callback) {
+      createCompiler({ vue: true, tsconfig: 'tsconfig-imports.json' });
+      compiler.run(function(error, stats) {
+        errors = stats.compilation.errors;
+        callback();
+      });
+    });
+
+    it('should be able to import by relative path', function() {
+      expect(
+        errors.filter(e => e.rawMessage.indexOf('./Component1.vue') >= 0).length
+      ).to.be.equal(0);
+    });
+    it('should be able to import by path from baseUrl', function() {
+      expect(
+        errors.filter(e => e.rawMessage.indexOf('imports/Component2.vue') >= 0).length
+      ).to.be.equal(0);
+    });
+    it('should be able to import by compilerOptions.paths setting', function() {
+      expect(
+        errors.filter(e => e.rawMessage.indexOf('@/Component3.vue') >= 0).length
+      ).to.be.equal(0);
+    });
+    it('should be able to import by compilerOptions.paths setting (by array)', function() {
+      expect(
+        errors.filter(e => e.rawMessage.indexOf('foo/Foo1.vue') >= 0).length
+      ).to.be.equal(0);
+      expect(
+        errors.filter(e => e.rawMessage.indexOf('foo/Foo2.vue') >= 0).length
+      ).to.be.equal(0);
+    });
+    it('should not report any compilation errors', function() {
+      expect(errors.length).to.be.equal(0);
+    });
+  });
 });

--- a/test/integration/vue/src/imports/Component1.vue
+++ b/test/integration/vue/src/imports/Component1.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>This is Component1</div>
+</template>

--- a/test/integration/vue/src/imports/Component2.vue
+++ b/test/integration/vue/src/imports/Component2.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>This is Component2</div>
+</template>

--- a/test/integration/vue/src/imports/Component3.vue
+++ b/test/integration/vue/src/imports/Component3.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>This is Component3</div>
+</template>

--- a/test/integration/vue/src/imports/Test.vue
+++ b/test/integration/vue/src/imports/Test.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+// resolve by relative path
+import Component1 from "./Component1.vue";            // imports/Component1.vue
+
+// resolve by path from baseUrl(./src)
+import Component2 from "imports/Component2.vue";      // imports/Component2.vue
+
+// resolve by compilerOptions.paths
+//  { "@/*": ["imports/*"] }
+import Component3 from "@/Component3.vue";            // imports/Component3.vue
+
+// resolve by compilerOptions.paths
+// { "foo/*": ["imports/foo1/*", "imports/foo2/*"] }
+import Foo1 from "foo/Foo1.vue";                      // imports/foo1/Foo1.vue
+import Foo2 from "foo/Foo2.vue";                      // imports/foo2/Foo2.vue
+
+export default {
+  name: "ImportTest",
+  components: {
+    Component1,
+    Component2,
+    Component3,
+    Foo1,
+    Foo2
+  }
+};
+</script>
+

--- a/test/integration/vue/src/imports/foo1/Foo1.vue
+++ b/test/integration/vue/src/imports/foo1/Foo1.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>This is Foo1</div>
+</template>

--- a/test/integration/vue/src/imports/foo2/Foo2.vue
+++ b/test/integration/vue/src/imports/foo2/Foo2.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>This is Foo2</div>
+</template>

--- a/test/integration/vue/tsconfig-imports.json
+++ b/test/integration/vue/tsconfig-imports.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+      "baseUrl": "./src",
+      "moduleResolution": "node",
+      "paths": {
+          "@/*": ["imports/*"],
+          "foo/*": [
+              "imports/foo1/*",
+              "imports/foo2/*"
+          ]
+      }
+  },
+  "include": [
+      "imports/Test.vue"
+  ],
+  "exclude": [
+      "node_modules"
+  ]
+}


### PR DESCRIPTION
Now, module resolution implementation of *.vue is in `VueProgram.resolveNonTsModuleName()`.
But this implementation is not same as TypeScript's one, so in some cases it can't resolve modules.

For example:
- TypeScript allows importing modules by path from compilerOptions.baseUrl, but this doesn't.
- TypeScript allows defining path mappings by compilerOptions.paths, but this doesn't
  (This will be partially supported by #86)

Concrete examples are in `test/integration/vue/imports/Test.vue`
(compilerOptions is in `test/integration/vue/tsconfig-imports.json`)

Document about TypeScript's module resolution is [here]( https://www.typescriptlang.org/docs/handbook/module-resolution.html)

This PR will be improve module resolution of *.vue.
This just delegates it to TypeScript's module resolution, so *.vue will be resolved as well as ts modules are resolved

I guess #88 may be fixed by this  PR.
