### PR TITLE
Fix webpack4 hooks not being initialized properly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -280,14 +280,14 @@ class ForkTsCheckerWebpackPlugin {
     }
     this.compiler.hooks.forkTsCheckerServiceBeforeStart = new AsyncSeriesHook([]);
 
-    this.compiler.hooks.forkTsCheckerCancel = new SyncHook([]);
-    this.compiler.hooks.forkTsCheckerServiceStartError = new SyncHook([]);
-    this.compiler.hooks.forkTsCheckerWaiting = new SyncHook([]);
-    this.compiler.hooks.forkTsCheckerServiceStart = new SyncHook([]);
-    this.compiler.hooks.forkTsCheckerReceive = new SyncHook([]);
+    this.compiler.hooks.forkTsCheckerCancel = new SyncHook(['cancellationToken']);
+    this.compiler.hooks.forkTsCheckerServiceStartError = new SyncHook(['error']);
+    this.compiler.hooks.forkTsCheckerWaiting = new SyncHook(['hasTsLint']);
+    this.compiler.hooks.forkTsCheckerServiceStart = new SyncHook(['tsconfigPath', 'tslintPath', 'watchPaths', 'workersNumber', 'memoryLimit']);
+    this.compiler.hooks.forkTsCheckerReceive = new SyncHook(['diagnostics', 'lints']);
     this.compiler.hooks.forkTsCheckerServiceOutOfMemory = new SyncHook([]);
-    this.compiler.hooks.forkTsCheckerEmit = new SyncHook([]);
-    this.compiler.hooks.forkTsCheckerDone = new SyncHook([]);
+    this.compiler.hooks.forkTsCheckerEmit = new SyncHook(['diagnostics', 'lints', 'elapsed']);
+    this.compiler.hooks.forkTsCheckerDone = new SyncHook(['diagnostics', 'lints', 'elapsed']);
 
     // for backwards compatibility
     this.compiler._pluginCompat.tap(checkerPluginName, (options: any) => {


### PR DESCRIPTION
webpack4 hooks should be initialized with the corresponding callback params listed in [the 'Plugin Hooks' section of the README.md](https://github.com/Realytics/fork-ts-checker-webpack-plugin#plugin-hooks) 

I managed to find a reference of the usage of `SyncHook` [here](https://github.com/webpack/webpack/issues/6064#issuecomment-349405474)

This was discovered while I was using `fork-ts-checker-notifier-webpack-plugin`, where tapping `compiler.hooks.forkTsCheckerReceive` yielded `undefined` for `diagnostics` and `lints`