### PR TITLE
Remove typescript and tslint from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,6 @@
     "webpack": "^4.0.0"
   },
   "peerDependencies": {
-    "tslint": "^4.0.0 || ^5.0.0",
-    "typescript": "^2.1.0",
     "webpack": "^2.3.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Was also discussed in #102,

Our problem with those peerDeps, is that we optionally use typescript in our build process, so just by having this package in the dependencies, it throws the error `typescript is required`.

<img width="300" alt="screen shot 2018-03-29 at 11 26 03" src="https://user-images.githubusercontent.com/7217420/38081308-04bdd48a-3344-11e8-9320-48f47bb3e53e.png">


It should be like [ts-loader](https://github.com/TypeStrong/ts-loader/blob/master/package.json), typescript is required but it's up to the user to install it.

Thre README is fine since it says it explicitly to install also typescript.

Closes #102 