### PR TITLE
Format messages when `async` is false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -626,7 +626,7 @@ class ForkTsCheckerWebpackPlugin {
             message.getSeverity().toUpperCase() + ' ' + message.getFormattedCode() + ': ' +
             message.getContent()
           ),
-          message: '(' + message.getLine() + ',' + message.getCharacter() + '): ' + message.getContent(),
+          message: this.formatter(message, this.useColors),
           location: {
             line: message.getLine(),
             character: message.getCharacter()


### PR DESCRIPTION
This PR lets the plugin respect the `formatter` option passed to it when `async` is false. This is especially beneficial for users of webpack-dev-server's overlay, since it gives a much better indication of what went wrong during development.