### PR TITLE
Fix link to travis in the README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
  - yarn build
  - yarn add $WEBPACK $TSLOADER $VUELOADER -D
 env:
- - WEBPACK=webpack@^4.0.0 TSLOADER=ts-loader@^4.0.0 VUELOADER=vue-loader@^14.1.0
+ - WEBPACK=webpack@^4.0.0 TSLOADER=ts-loader@4.3.0 VUELOADER=vue-loader@^14.1.0
  - WEBPACK=webpack@^3.10.0 TSLOADER=ts-loader@^3.4.0 VUELOADER=vue-loader@^13.5.0
  - WEBPACK=webpack@^2.7.0 TSLOADER=ts-loader@^3.4.0 VUELOADER=vue-loader@^13.5.0
 deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.4.2
+ * Format messages when `async` is false
+
 ## v0.4.1
  * Fix webpack 4 hooks bug
 

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,0 +1,9 @@
+# How To Deploy
+
+The deployment process is easy - you have to:
+
+- update version in package.json to `0.4.2` (or different package number)
+- update [`CHANGELOG.md`](CHANGELOG.md)
+- go to [Releases](https://github.com/Realytics/fork-ts-checker-webpack-plugin/releases) and Draft new release with tag name `v0.4.2` and a description as in the CHANGELOG.md
+
+Travis will detect the new tag name and release a new version to npm.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fork TS Checker Webpack Plugin
 [![Npm version](https://img.shields.io/npm/v/fork-ts-checker-webpack-plugin.svg?style=flat-square)](https://www.npmjs.com/package/fork-ts-checker-webpack-plugin)
-[![Build Status](https://travis-ci.org/Realytics/fork-ts-checker-webpack-plugin.svg?branch=master)](https://travis-ci.org/realytics/fork-ts-checker-webpack-plugin)
+[![Build Status](https://travis-ci.org/Realytics/fork-ts-checker-webpack-plugin.svg?branch=master)](https://travis-ci.org/Realytics/fork-ts-checker-webpack-plugin)
 
 Webpack plugin that runs typescript type checker on a separate process.
  

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "mock-require": "^2.0.2",
     "rimraf": "^2.5.4",
     "sinon": "^2.3.1",
-    "ts-loader": "^4.0.0-beta.0",
+    "ts-loader": "4.3.0",
     "tslint": "^5.0.0",
     "typescript": "^2.6.2",
     "vue": "^2.5.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "files": [

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -12,7 +12,7 @@ var webpackMajorVersion = require('./webpackVersion')();
 
 describe('[INTEGRATION] vue', function () {
   this.timeout(60000);
-  process.setMaxListeners(20);   
+  process.setMaxListeners(0);   
   var plugin;
   var files;
   var compiler;
@@ -164,7 +164,7 @@ describe('[INTEGRATION] vue', function () {
       var source = checker.program.getSourceFile(sourceFilePath);
       expect(source).to.not.be.undefined;
       // remove padding lines
-      var text = source.text.replace(/^\s*\/\/.*$\n/gm, '');
+      var text = source.text.replace(/^\s*\/\/.*$\r*\n/gm, '');
       expect(text.startsWith('/* OK */')).to.be.true;
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,14 +1159,6 @@ enhanced-resolve@^4.0.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^4.0.0-beta.4:
-  version "4.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.0.0-beta.4.tgz#17e14aea8ded4d6daa4a6bff67f2d38fcca76452"
-  dependencies:
-    graceful-fs "^4.1.2"
-    memory-fs "^0.4.0"
-    tapable "^1.0.0-beta.4"
-
 errno@^0.1.3, errno@^0.1.4:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.6.tgz#c386ce8a6283f14fc09563b71560908c9bf53026"
@@ -3892,10 +3884,6 @@ tapable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
 
-tapable@^1.0.0-beta.4:
-  version "1.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0-beta.5.tgz#9bc844b856487e03345b7d3361288aefd97f8303"
-
 tar-pack@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
@@ -3973,12 +3961,12 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-ts-loader@^4.0.0-beta.0:
-  version "4.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-4.0.0-beta.0.tgz#971c0097b4392094c0ad946937183c8a930669c1"
+ts-loader@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-4.3.0.tgz#4e3ba172783d1256d3a23bdfadde011a795fae9e"
   dependencies:
     chalk "^2.3.0"
-    enhanced-resolve "^4.0.0-beta.4"
+    enhanced-resolve "^4.0.0"
     loader-utils "^1.0.2"
     micromatch "^3.1.4"
     semver "^5.0.1"
@@ -4195,8 +4183,8 @@ vue-hot-reload-api@^2.2.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.2.4.tgz#683bd1d026c0d3b3c937d5875679e9a87ec6cd8f"
 
 vue-loader@^14.1.0:
-  version "14.1.1"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-14.1.1.tgz#331f197fcea790d6b8662c29b850806e7eb29342"
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-14.2.3.tgz#3b39645c322d956e287d8d36eb77475f78c9b8e0"
   dependencies:
     consolidate "^0.14.0"
     hash-sum "^1.0.2"


### PR DESCRIPTION
This amends the `.travis.yml` to to work with the 4.3.0 version of ts-loader until the problems with 4.3.1 have been resolved.  Once fixed, the `.travis.yml` changes can be reverted. See details here:

https://github.com/vuejs/vue-cli/issues/1399#issuecomment-394139721

Also:

- fixes link to travis in the README. Turns out Travis really care about case sensitivity 😄 
- makes vue tests run on Windows (\r\n instead of just \n)