### PR TITLE
File system lag can cause Invalid source file errors to slip through

### DIFF
--- a/src/IncrementalChecker.ts
+++ b/src/IncrementalChecker.ts
@@ -238,7 +238,11 @@ class IncrementalChecker {
       try {
         this.linter.lint(fileName, undefined, this.linterConfig);
       } catch (e) {
-        if (fs.existsSync(fileName)) {
+        if (
+          fs.existsSync(fileName) &&
+          !e.message.trim().startsWith("Invalid source file") &&
+          /(.tsx?|.jsx?|.vue)$/.match(fileName)
+        ) {
           // it's not because file doesn't exist - throw error
           throw e;
         }

--- a/src/IncrementalChecker.ts
+++ b/src/IncrementalChecker.ts
@@ -241,7 +241,7 @@ class IncrementalChecker {
         if (
           fs.existsSync(fileName) &&
           !e.message.trim().startsWith("Invalid source file") &&
-          /(.tsx?|.jsx?|.vue)$/.match(fileName)
+          fileName.match(/(.tsx?|.jsx?|.vue)$/)
         ) {
           // it's not because file doesn't exist - throw error
           throw e;


### PR DESCRIPTION
When using jetbrains idea on windows the save -> filesystem -> tslint process can be a bit lagging resulting in a partially written file being read by tslint when in watch mode. This causes a `Invalid source file: ${FilePath}. Ensure that the files supplied to lint have a .ts, .tsx, .d.ts, .js or .jsx extension.` fatal exception. When the file doesn't exist you are already ignoring errors (presumablly this error would be one of them). This PR expands that to also ignore the error when the filesystem isn't keeping up.