### PR TITLE
fix(vue): resolve src attribute on the script block on Vue files

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,10 +71,10 @@
     "ts-loader": "4.3.0",
     "tslint": "^5.0.0",
     "typescript": "^2.6.2",
-    "vue": "^2.5.9",
+    "vue": "^2.5.16",
     "vue-class-component": "^6.1.1",
     "vue-loader": "^15.2.4",
-    "vue-template-compiler": "^2.5.9",
+    "vue-template-compiler": "^2.5.16",
     "webpack": "^4.0.0"
   },
   "peerDependencies": {
@@ -92,7 +92,6 @@
     "lodash.startswith": "^4.2.1",
     "minimatch": "^3.0.4",
     "resolve": "^1.5.0",
-    "tapable": "^1.0.0",
-    "vue-parser": "^1.1.5"
+    "tapable": "^1.0.0"
   }
 }

--- a/src/VueProgram.ts
+++ b/src/VueProgram.ts
@@ -228,7 +228,9 @@ class VueProgram {
       const src = script.attrs.src.replace(/\.tsx?$/i, '');
       return {
         scriptKind,
-        content: `// tslint:disable\nexport { default } from '${src}';`
+        content: '// tslint:disable\n'
+          + `export { default } from '${src}';\n`
+          + `export * from '${src}';\n`
       };
     }
 

--- a/src/VueProgram.ts
+++ b/src/VueProgram.ts
@@ -216,7 +216,7 @@ class VueProgram {
     if (!script) {
       return {
         scriptKind: ts.ScriptKind.JS,
-        content: '// tslint:disable\nexport default {};\n'
+        content: '/* tslint:disable */\nexport default {};\n'
       };
     }
 
@@ -228,8 +228,14 @@ class VueProgram {
       const src = script.attrs.src.replace(/\.tsx?$/i, '');
       return {
         scriptKind,
-        content: '// tslint:disable\n'
+
+        // For now, ignore the error when the src file is not found
+        // since it will produce incorrect code location.
+        // It's not a large problem since it's handled on webpack side.
+        content: '/* tslint:disable */\n'
+          + '// @ts-ignore\n'
           + `export { default } from '${src}';\n`
+          + '// @ts-ignore\n'
           + `export * from '${src}';\n`
       };
     }

--- a/src/VueProgram.ts
+++ b/src/VueProgram.ts
@@ -196,9 +196,9 @@ class VueProgram {
   }
 
   private static resolveScriptBlock(content: string): ResolvedScript {
-    // We need to import vue-template-compiler lazily because it is cannot be included it
+    // We need to import vue-template-compiler lazily because it cannot be included it
     // as direct dependency because it is an optional dependency of fork-ts-checker-webpack-plugin.
-    // Since its version must not mismatch with user-installed vue-template-compiler,
+    // Since its version must not mismatch with user-installed Vue.js,
     // we should let the users install vue-template-compiler by themselves.
     let parser: typeof vueCompiler;
     try {

--- a/src/VueProgram.ts
+++ b/src/VueProgram.ts
@@ -196,10 +196,10 @@ class VueProgram {
   }
 
   private static resolveScriptBlock(content: string): ResolvedScript {
-    // We need to import vue-template-compiler dinamically because cannot include it as direct dependency.
-    // The reason is that it should not mismatch the versions with user-installed vue-template-compiler
-    // while it is an optional dependency for fork-ts-checker-webpack-plugin.
-    // So here we load the compiler and throws when it is not in the user's dependencies.
+    // We need to import vue-template-compiler lazily because it is cannot be included it
+    // as direct dependency because it is an optional dependency of fork-ts-checker-webpack-plugin.
+    // Since its version must not mismatch with user-installed vue-template-compiler,
+    // we should let the users install vue-template-compiler by themselves.
     let parser: typeof vueCompiler;
     try {
       // tslint:disable-next-line

--- a/src/VueProgram.ts
+++ b/src/VueProgram.ts
@@ -216,7 +216,7 @@ class VueProgram {
     if (!script) {
       return {
         scriptKind: ts.ScriptKind.JS,
-        content: '// tslint:disable\nexport default {};\n',
+        content: '// tslint:disable\nexport default {};\n'
       };
     }
 
@@ -224,9 +224,11 @@ class VueProgram {
 
     // There is src attribute
     if (script.attrs.src) {
+      // import path cannot be end with '.ts[x]'
+      const src = script.attrs.src.replace(/\.tsx?$/i, '');
       return {
         scriptKind,
-        content: `// tslint:disable\nexport { default } from '${src}';`,
+        content: `// tslint:disable\nexport { default } from '${src}';`
       };
     }
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -9,7 +9,7 @@
         "suppressImplicitAnyIndexErrors": true,
         "strictNullChecks": false,
         "lib": [
-            "es5", "es2015.core"
+            "es5", "es2015.core", "dom"
         ],
         "module": "commonjs",
         "moduleResolution": "node",

--- a/src/types/vue-template-compiler.d.ts
+++ b/src/types/vue-template-compiler.d.ts
@@ -1,0 +1,227 @@
+/**
+ * This declaration is copied from https://github.com/vuejs/vue/pull/7918
+ * which may included vue-template-compiler v2.6.0.
+ */
+declare module 'vue-template-compiler' {
+  import Vue, { VNode } from "vue"
+
+  /*
+  * Template compilation options / results
+  */
+  interface CompilerOptions {
+    modules?: ModuleOptions[];
+    directives?: Record<string, DirectiveFunction>;
+    preserveWhitespace?: boolean;
+  }
+
+  interface CompiledResult {
+    ast: ASTElement | undefined;
+    render: string;
+    staticRenderFns: string[];
+    errors: string[];
+    tips: string[];
+  }
+
+  interface CompiledResultFunctions {
+    render: () => VNode;
+    staticRenderFns: (() => VNode)[];
+  }
+
+  interface ModuleOptions {
+    preTransformNode: (el: ASTElement) => ASTElement | undefined;
+    transformNode: (el: ASTElement) => ASTElement | undefined;
+    postTransformNode: (el: ASTElement) => void;
+    genData: (el: ASTElement) => string;
+    transformCode?: (el: ASTElement, code: string) => string;
+    staticKeys?: string[];
+  }
+
+  type DirectiveFunction = (node: ASTElement, directiveMeta: ASTDirective) => void;
+
+  /*
+  * AST Types
+  */
+
+  /**
+   * - 0: FALSE - whole sub tree un-optimizable
+   * - 1: FULL - whole sub tree optimizable
+   * - 2: SELF - self optimizable but has some un-optimizable children
+   * - 3: CHILDREN - self un-optimizable but have fully optimizable children
+   * - 4: PARTIAL - self un-optimizable with some un-optimizable children
+   */
+  export type SSROptimizability = 0 | 1 | 2 | 3 | 4
+
+  export interface ASTModifiers {
+    [key: string]: boolean;
+  }
+
+  export interface ASTIfCondition {
+    exp: string | undefined;
+    block: ASTElement;
+  }
+
+  export interface ASTElementHandler {
+    value: string;
+    params?: any[];
+    modifiers: ASTModifiers | undefined;
+  }
+
+  export interface ASTElementHandlers {
+    [key: string]: ASTElementHandler | ASTElementHandler[];
+  }
+
+  export interface ASTDirective {
+    name: string;
+    rawName: string;
+    value: string;
+    arg: string | undefined;
+    modifiers: ASTModifiers | undefined;
+  }
+
+  export type ASTNode = ASTElement | ASTText | ASTExpression;
+
+  export interface ASTElement {
+    type: 1;
+    tag: string;
+    attrsList: { name: string; value: any }[];
+    attrsMap: Record<string, any>;
+    parent: ASTElement | undefined;
+    children: ASTNode[];
+
+    processed?: true;
+
+    static?: boolean;
+    staticRoot?: boolean;
+    staticInFor?: boolean;
+    staticProcessed?: boolean;
+    hasBindings?: boolean;
+
+    text?: string;
+    attrs?: { name: string; value: any }[];
+    props?: { name: string; value: string }[];
+    plain?: boolean;
+    pre?: true;
+    ns?: string;
+
+    component?: string;
+    inlineTemplate?: true;
+    transitionMode?: string | null;
+    slotName?: string;
+    slotTarget?: string;
+    slotScope?: string;
+    scopedSlots?: Record<string, ASTElement>;
+
+    ref?: string;
+    refInFor?: boolean;
+
+    if?: string;
+    ifProcessed?: boolean;
+    elseif?: string;
+    else?: true;
+    ifConditions?: ASTIfCondition[];
+
+    for?: string;
+    forProcessed?: boolean;
+    key?: string;
+    alias?: string;
+    iterator1?: string;
+    iterator2?: string;
+
+    staticClass?: string;
+    classBinding?: string;
+    staticStyle?: string;
+    styleBinding?: string;
+    events?: ASTElementHandlers;
+    nativeEvents?: ASTElementHandlers;
+
+    transition?: string | true;
+    transitionOnAppear?: boolean;
+
+    model?: {
+      value: string;
+      callback: string;
+      expression: string;
+    };
+
+    directives?: ASTDirective[];
+
+    forbidden?: true;
+    once?: true;
+    onceProcessed?: boolean;
+    wrapData?: (code: string) => string;
+    wrapListeners?: (code: string) => string;
+
+    // 2.4 ssr optimization
+    ssrOptimizability?: SSROptimizability;
+
+    // weex specific
+    appendAsTree?: boolean;
+  }
+
+  export interface ASTExpression {
+    type: 2;
+    expression: string;
+    text: string;
+    tokens: (string | Record<string, any>)[];
+    static?: boolean;
+    // 2.4 ssr optimization
+    ssrOptimizability?: SSROptimizability;
+  }
+
+  export interface ASTText {
+    type: 3;
+    text: string;
+    static?: boolean;
+    isComment?: boolean;
+    // 2.4 ssr optimization
+    ssrOptimizability?: SSROptimizability;
+  }
+
+  /*
+  * SFC parser related types
+  */
+  interface SFCParserOptions {
+    pad?: true | 'line' | 'space';
+  }
+
+  export interface SFCBlock {
+    type: string;
+    content: string;
+    attrs: Record<string, string>;
+    start?: number;
+    end?: number;
+    lang?: string;
+    src?: string;
+    scoped?: boolean;
+    module?: string | boolean;
+  }
+
+  export interface SFCDescriptor {
+    template: SFCBlock | undefined;
+    script: SFCBlock | undefined;
+    styles: SFCBlock[];
+    customBlocks: SFCBlock[];
+  }
+
+  /*
+  * Exposed functions
+  */
+  export function compile(
+    template: string,
+    options?: CompilerOptions
+  ): CompiledResult;
+
+  export function compileToFunctions(template: string): CompiledResultFunctions;
+
+  export function ssrCompile(
+    template: string,
+    options?: CompilerOptions
+  ): CompiledResult;
+
+  export function ssrCompileToFunctions(template: string): CompiledResultFunctions;
+
+  export function parseComponent(
+    file: string,
+    options?: SFCParserOptions
+  ): SFCDescriptor;
+}

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -167,7 +167,7 @@ describe('[INTEGRATION] vue', function () {
       var source = checker.program.getSourceFile(sourceFilePath);
       expect(source).to.not.be.undefined;
       // remove padding lines
-      var text = source.text.replace(/^\s*\/\/.*$\r*\n/gm, '');
+      var text = source.text.replace(/^\s*\/\/.*$\r*\n/gm, '').trim();
       expect(text.startsWith('/* OK */')).to.be.true;
     });
   });

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -154,11 +154,13 @@ describe('[INTEGRATION] vue', function () {
     });
   });
 
-  it('should resolve src attribute and check referred source', function (callback) {
+  it('should resolve src attribute but not report not found error', function (callback) {
     createCompiler({ vue: true, tsconfig: 'tsconfig-attrs.json' });
 
     compiler.run(function(error, stats) {
-      expect(stats.compilation.errors.length).to.be.equal(1);
+      const errors = stats.compilation.errors;
+      expect(errors.length).to.be.equal(1);
+      expect(errors[0].file).to.match(/test\/integration\/vue\/src\/attrs\/test.ts$/);
       callback();
     });
   });

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -154,6 +154,15 @@ describe('[INTEGRATION] vue', function () {
     });
   });
 
+  it('should resolve src attribute and check referred source', function (callback) {
+    createCompiler({ vue: true, tsconfig: 'tsconfig-attrs.json' });
+
+    compiler.run(function(error, stats) {
+      expect(stats.compilation.errors.length).to.be.equal(1);
+      callback();
+    });
+  });
+
   [
     'example-ts.vue',
     'example-tsx.vue',

--- a/test/integration/vue/src/attrs/NotFound.vue
+++ b/test/integration/vue/src/attrs/NotFound.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>Hello</div>
+</template>
+
+<script lang="ts" src="./notfound.ts"></script>

--- a/test/integration/vue/src/attrs/Test.vue
+++ b/test/integration/vue/src/attrs/Test.vue
@@ -1,0 +1,1 @@
+<script lang="ts" src="./test.ts"></script>

--- a/test/integration/vue/src/attrs/test.ts
+++ b/test/integration/vue/src/attrs/test.ts
@@ -1,0 +1,2 @@
+const a: number = "";
+export default { a }

--- a/test/integration/vue/tsconfig-attrs.json
+++ b/test/integration/vue/tsconfig-attrs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {},
+  "include": [
+      "src/attrs/Test.vue"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/integration/vue/tsconfig-attrs.json
+++ b/test/integration/vue/tsconfig-attrs.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {},
   "include": [
-      "src/attrs/Test.vue"
+      "src/attrs/Test.vue",
+      "src/attrs/NotFound.vue"
   ],
   "exclude": [
     "node_modules"

--- a/test/unit/VueProgram.spec.js
+++ b/test/unit/VueProgram.spec.js
@@ -47,7 +47,7 @@ describe('[UNIT] VueProgram', function () {
     var options = {};
     var moduleName = '@/test.vue';
 
-    resolvedModuleName = VueProgram.resolveNonTsModuleName(moduleName, containingFile, basedir, options);
+    var resolvedModuleName = VueProgram.resolveNonTsModuleName(moduleName, containingFile, basedir, options);
     expect(resolvedModuleName).to.be.equal('/base/dir/src/test.vue');
 
     options.baseUrl = '/baseurl1';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2882,12 +2882,6 @@ parse-glob@^3.0.4:
     is-extglob "^1.0.0"
     is-glob "^2.0.0"
 
-parse5@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  dependencies:
-    "@types/node" "*"
-
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -4210,12 +4204,6 @@ vue-loader@^15.2.4:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
-vue-parser@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/vue-parser/-/vue-parser-1.1.6.tgz#3063c8431795664ebe429c23b5506899706e6355"
-  dependencies:
-    parse5 "^3.0.3"
-
 vue-style-loader@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.0.tgz#7588bd778e2c9f8d87bfc3c5a4a039638da7a863"
@@ -4223,9 +4211,9 @@ vue-style-loader@^4.1.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.5.9:
-  version "2.5.13"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.13.tgz#12a2aa0ecd6158ac5e5f14d294b0993f399c3d38"
+vue-template-compiler@^2.5.16:
+  version "2.5.16"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.16.tgz#93b48570e56c720cdf3f051cc15287c26fbd04cb"
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -4234,9 +4222,9 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
 
-vue@^2.5.9:
-  version "2.5.13"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.13.tgz#95bd31e20efcf7a7f39239c9aa6787ce8cf578e1"
+vue@^2.5.16:
+  version "2.5.16"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.16.tgz#07edb75e8412aaeed871ebafa99f4672584a0085"
 
 watchpack@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
This PR fixes #111 and https://github.com/vuejs/vue-cli/issues/1104. Also probably fixes #85.

I've replaced `vue-parser` with [`vue-template-compiler`](https://www.npmjs.com/package/vue-template-compiler) which is Vue official package for parsing `.vue` file. Because `vue-parser` looks not maintained and it would be better to use officially provided lib for consistency.

I didn't include `vue-template-compiler` in dependencies because there is a known issue that mismatching with user-installed `vue` version.
The users should not feel inconvenience by this because [`vue-loader`](https://github.com/vuejs/vue-loader) (official webpack loader for `.vue` file) enforces the users to install `vue-template-compiler` due to this issue. That means if the users want to use `vue` option of this plugin, they already install `vue-template-compiler` by themselves.