### PR TITLE
Use minimum peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Webpack plugin that runs typescript type checker on a separate process.
  
 ## Installation
-This plugin requires minimum **webpack 2.3**, **typescript 2.1** and optionally **tslint 5.0**
+This plugin requires minimum **webpack 2.3**, **typescript 2.1** and optionally **tslint 4.0**
 ```sh
 npm install --save-dev fork-ts-checker-webpack-plugin
 ```

--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
     "webpack": "^4.0.0"
   },
   "peerDependencies": {
-    "tslint": "^4.0.0 || ^5.0.0",
-    "typescript": "^2.1.0",
-    "webpack": "^2.3.0 || ^3.0.0 || ^4.0.0"
+    "tslint": ">= 4.0.0",
+    "typescript": ">= 2.1.0",
+    "webpack": ">= 2.3.0"
   },
   "dependencies": {
     "babel-code-frame": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
     "webpack": "^4.0.0"
   },
   "peerDependencies": {
-    "tslint": ">= 4.0.0",
-    "typescript": ">= 2.1.0",
-    "webpack": ">= 2.3.0"
+    "tslint": "^4.0.0 || ^5.0.0",
+    "typescript": "^2.1.0",
+    "webpack": "^2.3.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "babel-code-frame": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "sinon": "^2.3.1",
     "ts-loader": "4.3.0",
     "tslint": "^5.0.0",
-    "typescript": "^2.6.2",
+    "typescript": "^3.0.1",
     "vue": "^2.5.16",
     "vue-class-component": "^6.1.1",
     "vue-loader": "^15.2.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "tslint": "^4.0.0 || ^5.0.0",
-    "typescript": "^2.1.0",
+    "typescript": "^2.1.0 || ^3.0.0",
     "webpack": "^2.3.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,9 +4046,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.6.2:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
+typescript@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
Fixes #133.

I have used TypeScript 3 with this loader in a CRA-TS app and ran the build and test steps test no issues so far. Let me know if there's anything else we need to change or test.