### PR TITLE
Avoid false positive of no-consecutive-blank-lines TSLint rule in Vue file

### DIFF
--- a/src/VueProgram.ts
+++ b/src/VueProgram.ts
@@ -195,7 +195,7 @@ class VueProgram {
     }
   }
 
-  private static resolveScriptBlock(content: string): ResolvedScript {
+  static resolveScriptBlock(content: string): ResolvedScript {
     // We need to import vue-template-compiler lazily because it cannot be included it
     // as direct dependency because it is an optional dependency of fork-ts-checker-webpack-plugin.
     // Since its version must not mismatch with user-installed Vue.js,
@@ -209,7 +209,7 @@ class VueProgram {
     }
 
     const { script } = parser.parseComponent(content, {
-      pad: 'line'
+      pad: 'space'
     });
 
     // No <script> block
@@ -240,9 +240,15 @@ class VueProgram {
       };
     }
 
+    // Pad blank lines to retain diagnostics location
+    // We need to prepend `//` for each line to avoid
+    // false positive of no-consecutive-blank-lines TSLint rule
+    const offset = content.slice(0, script.start).split(/\r?\n/g).length;
+    const paddedContent = Array(offset).join('//\n') + script.content.slice(script.start);
+
     return {
       scriptKind,
-      content: script.content
+      content: paddedContent
     };
   }
 }

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -145,6 +145,17 @@ describe('[INTEGRATION] vue', function () {
     });
   });
 
+  it('should not report no-consecutive-blank-lines tslint rule', function (callback) {
+    createCompiler({ tslint: true, vue: true });
+
+    compiler.run(function(error, stats) {
+      stats.compilation.warnings.forEach(function(warning) {
+        expect(warning.rawMessage).to.not.match(/no-consecutive-blank-lines/);
+      });
+      callback();
+    });
+  });
+
   it('should find syntactic errors when checkSyntacticErrors is true', function (callback) {
     createCompiler({ tslint: true, vue: true, checkSyntacticErrors: true });
     

--- a/test/unit/VueProgram.spec.js
+++ b/test/unit/VueProgram.spec.js
@@ -1,3 +1,4 @@
+var ts = require('typescript');
 var describe = require('mocha').describe;
 var it = require('mocha').it;
 var expect = require('chai').expect;
@@ -63,5 +64,50 @@ describe('[UNIT] VueProgram', function () {
     options.paths = { '@/*': ['src1/src2/*'] }    
     resolvedModuleName = VueProgram.resolveNonTsModuleName(moduleName, containingFile, basedir, options);
     expect(resolvedModuleName).to.be.equal('/baseurl3/src1/src2/test.vue');
+  });
+
+  it('should extract script block', function() {
+    var content = [
+      '<script lang="ts">',
+      'import Vue from "vue";',
+      'export default Vue.extend({});',
+      '</script>'
+    ].join('\n');
+
+    var result = VueProgram.resolveScriptBlock(content);
+
+    expect(result.scriptKind).to.be.equal(ts.ScriptKind.TS);
+    expect(result.content).to.be.equal([
+      '',
+      'import Vue from "vue";',
+      'export default Vue.extend({});',
+      ''
+    ].join('\n'));
+  });
+
+  it('should pad lines', function() {
+    var content = [
+      '<template>',
+      '  <p>Hello</p>',
+      '</template>',
+      '',
+      '<script lang="ts">',
+      'import Vue from "vue";',
+      'export default Vue.extend({});',
+      '</script>'
+    ].join('\n');
+
+    var result = VueProgram.resolveScriptBlock(content);
+
+    expect(result.content).to.be.equal([
+      '//',
+      '//',
+      '//',
+      '//',
+      '',
+      'import Vue from "vue";',
+      'export default Vue.extend({});',
+      ''
+    ].join('\n'));
   });
 });


### PR DESCRIPTION
fix https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/130#issuecomment-411216056

Now `VueProgram` adds `//` for each blank line to avoid that the tslint reports false positive no-consecutive-blank-lines warning.

Input:

```vue
<template>
  <p>Hello</p>
</template>

<script lang="ts">
import Vue from 'vue';
export default Vue.extend({});
</script>
```

Resolved TypeScript  code:

```ts
//
//
//
//

import Vue from 'vue';
export default Vue.extend({});

```