### PR TITLE
Make options Partial<Options>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.4.6
+
+ * [Fix(types): Make options Partial<Options> ](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/141) (#140)
+
 ## v0.4.5
 
  * [Fix(types): Add types to the plugin](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/139) (#137)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ class ForkTsCheckerWebpackPlugin {
 
   vue: boolean;
 
-  constructor(options: Options) {
+  constructor(options: Partial<Options>) {
     options = options || {} as Options;
     this.options = Object.assign({}, options);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ class ForkTsCheckerWebpackPlugin {
   static ONE_CPU_FREE = Math.max(1, ForkTsCheckerWebpackPlugin.ALL_CPUS - 1);
   static TWO_CPUS_FREE = Math.max(1, ForkTsCheckerWebpackPlugin.ALL_CPUS - 2);
 
-  options: Options;
+  options: Partial<Options>;
   tsconfig: string;
   tslint: string | true;
   watch: string[];
@@ -104,7 +104,7 @@ class ForkTsCheckerWebpackPlugin {
 
   vue: boolean;
 
-  constructor(options: Partial<Options>) {
+  constructor(options?: Partial<Options>) {
     options = options || {} as Options;
     this.options = Object.assign({}, options);
 


### PR DESCRIPTION
When working with webpack.config.ts ts complains when you try to pass a partial object literal.
This fixes that.
