### PR TITLE
Export main plugin class and update all imports ? = require(?) to named exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.4.10
+
+* [Allow fork-ts-checker-webpack-plugin to be imported in .ts files using ESM import syntax](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/163) (#163)
+
 ## v0.4.9
 
 * [Set "compilationDone" before resolving "forkTsCheckerServiceBeforeStart"](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/146) (#146)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/src/CancellationToken.ts
+++ b/src/CancellationToken.ts
@@ -1,15 +1,15 @@
-import crypto = require('crypto');
-import fs = require('fs');
-import os = require('os');
-import path = require('path');
-import ts = require('typescript');
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as ts from 'typescript';
 
 interface CancellationTokenData {
   isCancelled: boolean;
   cancellationFileName: string;
 }
 
-class CancellationToken {
+export class CancellationToken {
   isCancelled: boolean;
   cancellationFileName: string;
   lastCancellationCheckTime: number;
@@ -72,5 +72,3 @@ class CancellationToken {
     }
   }
 }
-
-export = CancellationToken;

--- a/src/FilesRegister.ts
+++ b/src/FilesRegister.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 
 interface DataShape {
   source: ts.SourceFile;
@@ -6,7 +6,7 @@ interface DataShape {
   lints: any[];
 }
 
-class FilesRegister {
+export class FilesRegister {
   files: { [filePath: string]: { mtime: number; data: DataShape; }};
   dataFactory: (_data?: any) => DataShape; // It doesn't seem that the _data parameter is ever used?
 
@@ -74,4 +74,4 @@ class FilesRegister {
     }
   }
 }
-export = FilesRegister;
+

--- a/src/FilesWatcher.ts
+++ b/src/FilesWatcher.ts
@@ -1,8 +1,8 @@
-import chokidar = require('chokidar');
-import path = require('path');
+import * as chokidar from 'chokidar';
+import * as path from 'path';
 import startsWith = require('lodash.startswith');
 
-class FilesWatcher {
+export class FilesWatcher {
   watchPaths: string[];
   watchExtensions: string[];
   watchers: chokidar.FSWatcher[];
@@ -71,5 +71,3 @@ class FilesWatcher {
     }
   }
 }
-
-export = FilesWatcher;

--- a/src/IncrementalChecker.ts
+++ b/src/IncrementalChecker.ts
@@ -1,26 +1,26 @@
-import fs = require('fs');
+import * as fs from 'fs';
 import endsWith = require('lodash.endswith');
-import path = require('path');
-import ts = require('typescript');
-import tslintTypes = require('tslint'); // Imported for types alone; actual requires take place in methods below
-import FilesRegister = require('./FilesRegister');
-import FilesWatcher = require('./FilesWatcher');
-import WorkSet = require('./WorkSet');
-import NormalizedMessage = require('./NormalizedMessage');
-import CancellationToken = require('./CancellationToken');
-import minimatch = require('minimatch');
-import VueProgram = require('./VueProgram');
+import * as path from 'path';
+import * as ts from 'typescript';
+import { Configuration, Linter } from 'tslint'; // Imported for types alone; actual requires take place in methods below
+import { FilesRegister } from './FilesRegister';
+import { FilesWatcher } from './FilesWatcher';
+import { WorkSet } from './WorkSet';
+import { NormalizedMessage } from './NormalizedMessage';
+import { CancellationToken } from './CancellationToken';
+import * as minimatch from 'minimatch';
+import { VueProgram } from './VueProgram';
 
 // Need some augmentation here - linterOptions.exclude is not (yet) part of the official
 // types for tslint.
-interface ConfigurationFile extends tslintTypes.Configuration.IConfigurationFile {
+interface ConfigurationFile extends Configuration.IConfigurationFile {
   linterOptions?: {
     typeCheck?: boolean;
     exclude?: string[];
   };
 }
 
-class IncrementalChecker {
+export class IncrementalChecker {
   programConfigFile: string;
   linterConfigFile: string | false;
   watchPaths: string[];
@@ -29,7 +29,7 @@ class IncrementalChecker {
   checkSyntacticErrors: boolean;
   files: FilesRegister;
 
-  linter: tslintTypes.Linter;
+  linter: Linter;
   linterConfig: ConfigurationFile;
   linterExclusions: minimatch.IMinimatch[];
 
@@ -78,7 +78,7 @@ class IncrementalChecker {
   }
 
   static loadLinterConfig(configFile: string): ConfigurationFile {
-    const tslint: typeof tslintTypes = require('tslint');
+    const tslint = require('tslint');
 
     return tslint.Configuration.loadConfigurationFromPath(configFile) as ConfigurationFile;
   }
@@ -124,7 +124,7 @@ class IncrementalChecker {
   }
 
   static createLinter(program: ts.Program) {
-    const tslint: typeof tslintTypes = require('tslint');
+    const tslint = require('tslint');
 
     return new tslint.Linter({ fix: false }, program);
   }
@@ -279,5 +279,3 @@ class IncrementalChecker {
     );
   }
 }
-
-export = IncrementalChecker;

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -1,6 +1,6 @@
-import NormalizedMessage = require('./NormalizedMessage');
+import { NormalizedMessage } from './NormalizedMessage';
 
-export default interface Message {
+export interface Message {
     diagnostics: NormalizedMessage[];
     lints: NormalizedMessage[];
 }

--- a/src/NormalizedMessage.ts
+++ b/src/NormalizedMessage.ts
@@ -1,6 +1,5 @@
-// Imported for types alone; actual requires take place in methods below
-import tsTypes = require('typescript');
-import tslintTypes = require('tslint');
+import { Diagnostic, DiagnosticCategory, flattenDiagnosticMessageText } from 'typescript';
+import { RuleFailure } from 'tslint';
 
 type ErrorType = 'diagnostic' | 'lint';
 type Severity = 'error' | 'warning';
@@ -15,7 +14,7 @@ interface NormalizedMessageJson {
   character: number;
 }
 
-class NormalizedMessage {
+export class NormalizedMessage {
   static TYPE_DIAGNOSTIC: ErrorType = 'diagnostic';
   static TYPE_LINT: ErrorType = 'lint';
 
@@ -42,8 +41,7 @@ class NormalizedMessage {
   }
 
   // message types
-  static createFromDiagnostic(diagnostic: tsTypes.Diagnostic) {
-    const ts: typeof tsTypes = require('typescript');
+  static createFromDiagnostic(diagnostic: Diagnostic) {
     let file: string;
     let line: number;
     let character: number;
@@ -57,15 +55,15 @@ class NormalizedMessage {
     return new NormalizedMessage({
       type: NormalizedMessage.TYPE_DIAGNOSTIC,
       code: diagnostic.code,
-      severity: ts.DiagnosticCategory[diagnostic.category].toLowerCase() as Severity,
-      content: ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+      severity: DiagnosticCategory[diagnostic.category].toLowerCase() as Severity,
+      content: flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
       file: file,
       line: line,
       character: character
     });
   }
 
-  static createFromLint(lint: tslintTypes.RuleFailure) {
+  static createFromLint(lint: RuleFailure) {
     const position = lint.getStartPosition().getLineAndCharacter();
 
     return new NormalizedMessage({
@@ -216,5 +214,3 @@ class NormalizedMessage {
     return this.character;
   }
 }
-
-export = NormalizedMessage;

--- a/src/VueProgram.ts
+++ b/src/VueProgram.ts
@@ -1,17 +1,17 @@
-import fs = require('fs');
-import path = require('path');
-import ts = require('typescript');
-import FilesRegister = require('./FilesRegister');
-import FilesWatcher = require('./FilesWatcher');
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+import { FilesRegister } from './FilesRegister';
+import { FilesWatcher } from './FilesWatcher';
 // tslint:disable-next-line
-import vueCompiler = require('vue-template-compiler');
+import * as vueCompiler from 'vue-template-compiler';
 
 interface ResolvedScript {
   scriptKind: ts.ScriptKind;
   content: string;
 }
 
-class VueProgram {
+export class VueProgram {
   static loadProgramConfig(configFile: string) {
     const extraExtensions = ['vue'];
 
@@ -252,5 +252,3 @@ class VueProgram {
     };
   }
 }
-
-export = VueProgram;

--- a/src/WorkResult.ts
+++ b/src/WorkResult.ts
@@ -1,6 +1,6 @@
-import Message from './Message';
+import { Message } from './Message';
 
-class WorkResult {
+export class WorkResult {
   workResult: {};
   workDomain: any[];
 
@@ -47,5 +47,3 @@ class WorkResult {
     }, initial);
   }
 }
-
-export = WorkResult;

--- a/src/WorkSet.ts
+++ b/src/WorkSet.ts
@@ -1,6 +1,6 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 
-class WorkSet {
+export class WorkSet {
   workDomain: ReadonlyArray<ts.SourceFile> | string[];
   workNumber: number;
   workDivision: number;
@@ -28,5 +28,3 @@ class WorkSet {
     }
   }
 }
-
-export = WorkSet;

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -1,10 +1,10 @@
-import childProcess = require('child_process');
-import path = require('path');
-import process = require('process');
+import * as childProcess from 'child_process';
+import * as path from 'path';
+import * as process from 'process';
 
-import WorkResult = require('./WorkResult');
-import NormalizedMessage = require('./NormalizedMessage');
-import Message from './Message';
+import { WorkResult } from './WorkResult';
+import { NormalizedMessage } from './NormalizedMessage';
+import { Message } from './Message';
 
 // fork workers...
 const division = parseInt(process.env.WORK_DIVISION, 10);

--- a/src/formatter/codeframeFormatter.ts
+++ b/src/formatter/codeframeFormatter.ts
@@ -1,8 +1,8 @@
-import os = require('os');
+import * as os from 'os';
 import codeFrame = require('babel-code-frame');
 import chalk from 'chalk';
-import fs = require('fs');
-import NormalizedMessage = require('../NormalizedMessage');
+import * as fs from 'fs';
+import { NormalizedMessage } from '../NormalizedMessage';
 
 /**
  * Create new code frame formatter.
@@ -10,7 +10,7 @@ import NormalizedMessage = require('../NormalizedMessage');
  * @param options Options for babel-code-frame - see https://www.npmjs.com/package/babel-code-frame
  * @returns {codeframeFormatter}
  */
-export = function createCodeframeFormatter(options: any) {
+export function createCodeframeFormatter(options: any) {
   return function codeframeFormatter(message: NormalizedMessage, useColors: boolean) {
     const colors = new chalk.constructor({enabled: useColors});
     const messageColor = message.isWarningSeverity() ? colors.bold.yellow : colors.bold.red;

--- a/src/formatter/defaultFormatter.ts
+++ b/src/formatter/defaultFormatter.ts
@@ -1,14 +1,14 @@
 
 import chalk from 'chalk';
-import os = require('os');
-import NormalizedMessage = require('../NormalizedMessage');
+import * as os from 'os';
+import { NormalizedMessage } from '../NormalizedMessage';
 
 /**
  * Creates new default formatter.
  *
  * @returns {defaultFormatter}
  */
-export = function createDefaultFormatter() {
+export function createDefaultFormatter() {
   return function defaultFormatter(message: NormalizedMessage, useColors: boolean) {
     const colors = new chalk.constructor({enabled: useColors});
     const messageColor = message.isWarningSeverity() ? colors.bold.yellow : colors.bold.red;

--- a/src/index.ts
+++ b/src/index.ts
@@ -704,3 +704,7 @@ export class ForkTsCheckerWebpackPlugin {
 }
 
 export default ForkTsCheckerWebpackPlugin
+
+if (module && module.exports) {
+    module.exports = exports.default
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,20 @@
-import path = require('path');
-import process = require('process');
-import childProcess = require('child_process');
+import * as path from 'path';
+import * as process from 'process';
+import * as childProcess from 'child_process';
 import chalk, { Chalk } from 'chalk';
-import fs = require('fs');
-import os = require('os');
+import * as fs from 'fs';
+import * as os from 'os';
 import * as webpack from 'webpack';
 import isString = require('lodash.isstring');
 import isFunction = require('lodash.isfunction');
-import CancellationToken = require('./CancellationToken');
-import NormalizedMessage = require('./NormalizedMessage');
-import createDefaultFormatter = require('./formatter/defaultFormatter');
-import createCodeframeFormatter = require('./formatter/codeframeFormatter');
-import Message from './Message';
+import { CancellationToken } from './CancellationToken';
+import { NormalizedMessage } from './NormalizedMessage';
+import { createDefaultFormatter } from './formatter/defaultFormatter';
+import { createCodeframeFormatter } from './formatter/codeframeFormatter';
+import { Message } from './Message';
 
-const AsyncSeriesHook = require("tapable").AsyncSeriesHook;
-const SyncHook = require("tapable").SyncHook;
+import { AsyncSeriesHook } from 'tapable';
+import { SyncHook } from 'tapable';
 
 const checkerPluginName = 'fork-ts-checker-webpack-plugin';
 
@@ -63,7 +63,7 @@ interface Options {
  *
  * Options description in README.md
  */
-class ForkTsCheckerWebpackPlugin {
+export class ForkTsCheckerWebpackPlugin {
   static DEFAULT_MEMORY_LIMIT = 2048;
   static ONE_CPU = 1;
   static ALL_CPUS = os.cpus() ? os.cpus().length : 1;
@@ -703,4 +703,4 @@ class ForkTsCheckerWebpackPlugin {
   }
 }
 
-export = ForkTsCheckerWebpackPlugin;
+export default ForkTsCheckerWebpackPlugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ interface Options {
  *
  * Options description in README.md
  */
-export class ForkTsCheckerWebpackPlugin {
+class ForkTsCheckerWebpackPlugin {
   static DEFAULT_MEMORY_LIMIT = 2048;
   static ONE_CPU = 1;
   static ALL_CPUS = os.cpus() ? os.cpus().length : 1;
@@ -703,8 +703,6 @@ export class ForkTsCheckerWebpackPlugin {
   }
 }
 
-export default ForkTsCheckerWebpackPlugin
+export = ForkTsCheckerWebpackPlugin
 
-if (module && module.exports) {
-    module.exports = exports.default
-}
+namespace ForkTsCheckerWebpackPlugin {}

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,8 +1,8 @@
-import process = require('process');
-import ts = require('typescript');
-import IncrementalChecker = require('./IncrementalChecker');
-import CancellationToken = require('./CancellationToken');
-import NormalizedMessage = require('./NormalizedMessage');
+import * as process from 'process';
+import * as ts from 'typescript';
+import { IncrementalChecker } from './IncrementalChecker';
+import { CancellationToken } from './CancellationToken';
+import { NormalizedMessage } from './NormalizedMessage';
 
 const checker = new IncrementalChecker(
   process.env.TSCONFIG,

--- a/src/types/vue-template-compiler.d.ts
+++ b/src/types/vue-template-compiler.d.ts
@@ -3,7 +3,7 @@
  * which may included vue-template-compiler v2.6.0.
  */
 declare module 'vue-template-compiler' {
-  import Vue, { VNode } from "vue"
+  import Vue, { VNode } from 'vue';
 
   /*
   * Template compilation options / results

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -4,7 +4,7 @@ var it = require('mocha').it;
 var chai = require('chai');
 var path = require('path');
 var webpack = require('webpack');
-var ForkTsCheckerWebpackPlugin = require('../../lib/index');
+var ForkTsCheckerWebpackPlugin = require('../../lib/index').ForkTsCheckerWebpackPlugin;
 
 chai.config.truncateThreshold = 0;
 var expect = chai.expect;

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -4,7 +4,7 @@ var it = require('mocha').it;
 var chai = require('chai');
 var path = require('path');
 var webpack = require('webpack');
-var ForkTsCheckerWebpackPlugin = require('../../lib/index').ForkTsCheckerWebpackPlugin;
+var ForkTsCheckerWebpackPlugin = require('../../lib/index');
 
 chai.config.truncateThreshold = 0;
 var expect = chai.expect;

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -5,8 +5,8 @@ var expect = require('chai').expect;
 var path = require('path');
 var webpack = require('webpack');
 var process = require('process');
-var ForkTsCheckerWebpackPlugin = require('../../lib/index');
-var IncrementalChecker = require('../../lib/IncrementalChecker');
+var ForkTsCheckerWebpackPlugin = require('../../lib/index').ForkTsCheckerWebpackPlugin;
+var IncrementalChecker = require('../../lib/IncrementalChecker').IncrementalChecker;
 
 var webpackMajorVersion = require('./webpackVersion')();
 

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 var path = require('path');
 var webpack = require('webpack');
 var process = require('process');
-var ForkTsCheckerWebpackPlugin = require('../../lib/index').ForkTsCheckerWebpackPlugin;
+var ForkTsCheckerWebpackPlugin = require('../../lib/index');
 var IncrementalChecker = require('../../lib/IncrementalChecker').IncrementalChecker;
 
 var webpackMajorVersion = require('./webpackVersion')();

--- a/test/unit/CancellationToken.spec.js
+++ b/test/unit/CancellationToken.spec.js
@@ -7,7 +7,7 @@ var beforeEach = require('mocha').beforeEach;
 var afterEach = require('mocha').afterEach;
 var expect = require('chai').expect;
 var mockFs = require('mock-fs');
-var CancellationToken = require('../../lib/CancellationToken');
+var CancellationToken = require('../../lib/CancellationToken').CancellationToken;
 
 describe('[UNIT] CancellationToken', function () {
   beforeEach(function () {

--- a/test/unit/FileRegister.spec.js
+++ b/test/unit/FileRegister.spec.js
@@ -2,7 +2,7 @@ var describe = require('mocha').describe;
 var it = require('mocha').it;
 var beforeEach = require('mocha').beforeEach;
 var expect = require('chai').expect;
-var FilesRegister = require('../../lib/FilesRegister');
+var FilesRegister = require('../../lib/FilesRegister').FilesRegister;
 
 describe('[UNIT] FilesRegister', function () {
   var register;

--- a/test/unit/FilesWatcher.spec.js
+++ b/test/unit/FilesWatcher.spec.js
@@ -19,7 +19,7 @@ describe('[UNIT] FilesWatcher', function () {
     watchStub = sinon.stub().returns(watcherStub);
 
     mockRequire('chokidar', { watch: watchStub });
-    FilesWatcher = mockRequire.reRequire('../../lib/FilesWatcher');
+    FilesWatcher = mockRequire.reRequire('../../lib/FilesWatcher').FilesWatcher;
 
     watcher = new FilesWatcher(
       ['/test', '/bar'],

--- a/test/unit/IncrementalChecker.spec.js
+++ b/test/unit/IncrementalChecker.spec.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var path = require('path');
 var minimatch = require('minimatch');
 
-var IncrementalChecker = require('../../lib/IncrementalChecker');
+var IncrementalChecker = require('../../lib/IncrementalChecker').IncrementalChecker;
 
 describe('[UNIT] IncrementalChecker', function () {
   describe('isFileExcluded', function() {

--- a/test/unit/NormalizedMessage.spec.js
+++ b/test/unit/NormalizedMessage.spec.js
@@ -2,7 +2,7 @@ var describe = require('mocha').describe;
 var it = require('mocha').it;
 var beforeEach = require('mocha').beforeEach;
 var expect = require('chai').expect;
-var NormalizedMessage = require('../../lib/NormalizedMessage');
+var NormalizedMessage = require('../../lib/NormalizedMessage').NormalizedMessage;
 
 describe('[UNIT] NormalizedMessage', function () {
   var diagnosticMessage;

--- a/test/unit/VueProgram.spec.js
+++ b/test/unit/VueProgram.spec.js
@@ -2,7 +2,7 @@ var ts = require('typescript');
 var describe = require('mocha').describe;
 var it = require('mocha').it;
 var expect = require('chai').expect;
-var VueProgram = require('../../lib/VueProgram');
+var VueProgram = require('../../lib/VueProgram').VueProgram;
 
 describe('[UNIT] VueProgram', function () {
   it('should determine if file is a Vue file', function() {
@@ -56,12 +56,12 @@ describe('[UNIT] VueProgram', function () {
     expect(resolvedModuleName).to.be.equal('/baseurl1/src/test.vue');
 
     options.baseUrl = '/baseurl2';    
-    options.paths = { '@/*': ['src1/*'] }    
+    options.paths = { '@/*': ['src1/*'] };
     resolvedModuleName = VueProgram.resolveNonTsModuleName(moduleName, containingFile, basedir, options);
     expect(resolvedModuleName).to.be.equal('/baseurl2/src1/test.vue');
 
     options.baseUrl = '/baseurl3';    
-    options.paths = { '@/*': ['src1/src2/*'] }    
+    options.paths = { '@/*': ['src1/src2/*'] };
     resolvedModuleName = VueProgram.resolveNonTsModuleName(moduleName, containingFile, basedir, options);
     expect(resolvedModuleName).to.be.equal('/baseurl3/src1/src2/test.vue');
   });

--- a/test/unit/WorkResult.spec.js
+++ b/test/unit/WorkResult.spec.js
@@ -3,7 +3,7 @@ var it = require('mocha').it;
 var beforeEach = require('mocha').beforeEach;
 var expect = require('chai').expect;
 var sinon = require('sinon');
-var WorkResult = require('../../lib/WorkResult');
+var WorkResult = require('../../lib/WorkResult').WorkResult;
 
 describe('[UNIT] WorkResult', function () {
   var result;

--- a/test/unit/WorkSet.spec.js
+++ b/test/unit/WorkSet.spec.js
@@ -1,7 +1,7 @@
 var describe = require('mocha').describe;
 var it = require('mocha').it;
 var expect = require('chai').expect;
-var WorkSet = require('../../lib/WorkSet');
+var WorkSet = require('../../lib/WorkSet').WorkSet;
 
 describe('[UNIT] WorkSet', function () {
   function testForDomainAndDivision (domain, divisions) {

--- a/test/unit/codeframeFormatter.spec.js
+++ b/test/unit/codeframeFormatter.spec.js
@@ -6,8 +6,8 @@ var beforeEach = require('mocha').beforeEach;
 var afterEach = require('mocha').afterEach;
 var expect = require('chai').expect;
 var mockFs = require('mock-fs');
-var NormalizedMessage = require('../../lib/NormalizedMessage');
-var createCodeframeFormatter = require('../../lib/formatter/codeframeFormatter');
+var NormalizedMessage = require('../../lib/NormalizedMessage').NormalizedMessage;
+var createCodeframeFormatter = require('../../lib/formatter/codeframeFormatter').createCodeframeFormatter;
 
 describe('[UNIT] formatter/codeframeFormatter', function () {
 

--- a/test/unit/defaultFormatter.spec.js
+++ b/test/unit/defaultFormatter.spec.js
@@ -3,8 +3,8 @@ var describe = require('mocha').describe;
 var it = require('mocha').it;
 var os = require('os');
 var expect = require('chai').expect;
-var NormalizedMessage = require('../../lib/NormalizedMessage');
-var createDefaultFormatter = require('../../lib/formatter/defaultFormatter');
+var NormalizedMessage = require('../../lib/NormalizedMessage').NormalizedMessage;
+var createDefaultFormatter = require('../../lib/formatter/defaultFormatter').createDefaultFormatter;
 
 describe('[UNIT] formatter/defaultFormatter', function () {
 


### PR DESCRIPTION
this PR allows the types exposed by this plugin to be effectively used inside a .ts file.

the imports can be as:

```ts
import { ForkTsCheckerWebpackPlugin } from 'fork-ts-checker-webpack-plugin'
import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin'
import * as ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin'
```

currently only this variants are allowed:

```ts
const  ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
```

this PR also updates all commonjs style imports to named imports/export and closes #162