### PR TITLE
Support linting + formatting with pre-commit hook

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,28 +1,14 @@
 {
-    "parserOptions": {
-        "ecmaVersion": 6,
-        "ecmaFeatures": {
-            "experimentalObjectRestSpread": true
-        }
-    },
-    "env": {
-        "node": true,
-        "mocha": true,
-        "es6": true
-    },
-    "extends": "eslint:recommended",
-    "rules": {
-        "indent": [
-            "error",
-            2
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ]
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
     }
+  },
+  "env": {
+    "node": true,
+    "mocha": true,
+    "es6": true
+  },
+  "extends": "eslint:recommended"
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,14 @@
 {
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "ecmaFeatures": {
+            "experimentalObjectRestSpread": true
+        }
+    },
     "env": {
-        "node": true
+        "node": true,
+        "mocha": true,
+        "es6": true
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+    "singleQuote": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,7 @@
 {
-    "singleQuote": true
+  "singleQuote": true,
+  "semi": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 80
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install:
  - yarn install
  - yarn build
  - yarn add $WEBPACK $TSLOADER $VUELOADER -D
+ - yarn lint
 env:
  - WEBPACK=webpack@^4.0.0 TSLOADER=ts-loader@^4.3.0 VUELOADER=vue-loader@^15.2.4
  - WEBPACK=webpack@^3.10.0 TSLOADER=ts-loader@^3.4.0 VUELOADER=vue-loader@^13.5.0

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "test": "npm run build && npm run test:unit && npm run test:integration",
     "test:watch": "mocha -R spec --watch ./test/unit",
     "test:coverage": "rimraf coverage && istanbul cover -root lib --include-all-sources mocha -- -R spec ./test/unit ./test/integration",
-    "lint": "eslint ./lib ./test",
-    "lint:fix": "eslint ./lib ./test --fix"
+    "lint": "tslint --project src/tsconfig.json && eslint ./test",
+    "lint:fix": "tslint --project src/tsconfig.json --fix && eslint ./test --fix"
   },
   "repository": {
     "url": "https://github.com/Realytics/fork-ts-checker-webpack-plugin.git",
@@ -61,15 +61,19 @@
     "@types/webpack": "^4.4.9",
     "chai": "^3.5.0",
     "css-loader": "^0.28.7",
-    "eslint": "^3.19.0",
+    "eslint": "^5.7.0",
+    "husky": "^1.1.2",
     "istanbul": "^0.4.5",
+    "lint-staged": "^7.3.0",
     "mocha": "^3.4.1",
     "mock-fs": "^4.3.0",
     "mock-require": "^2.0.2",
+    "prettier": "^1.14.3",
     "rimraf": "^2.5.4",
     "sinon": "^2.3.1",
     "ts-loader": "4.3.0",
-    "tslint": "^5.0.0",
+    "tslint": "^5.11.0",
+    "tslint-config-prettier": "^1.15.0",
     "typescript": "^3.0.1",
     "vue": "^2.5.16",
     "vue-class-component": "^6.1.1",
@@ -93,5 +97,25 @@
     "minimatch": "^3.0.4",
     "resolve": "^1.5.0",
     "tapable": "^1.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "concurrent": false,
+    "linters": {
+      "*.js": [
+        "eslint --fix"
+      ],
+      "*.ts": [
+        "tslint --fix"
+      ],
+      "*.{js,ts}": [
+        "prettier --write",
+        "git add"
+      ]
+    }
   }
 }

--- a/src/CancellationToken.ts
+++ b/src/CancellationToken.ts
@@ -15,15 +15,13 @@ export class CancellationToken {
   lastCancellationCheckTime: number;
   constructor(cancellationFileName: string, isCancelled: boolean) {
     this.isCancelled = !!isCancelled;
-    this.cancellationFileName = cancellationFileName || crypto.randomBytes(64).toString('hex');
+    this.cancellationFileName =
+      cancellationFileName || crypto.randomBytes(64).toString('hex');
     this.lastCancellationCheckTime = 0;
   }
 
   static createFromJSON(json: CancellationTokenData) {
-    return new CancellationToken(
-      json.cancellationFileName,
-      json.isCancelled
-    );
+    return new CancellationToken(json.cancellationFileName, json.isCancelled);
   }
 
   toJSON() {

--- a/src/FilesRegister.ts
+++ b/src/FilesRegister.ts
@@ -7,7 +7,7 @@ interface DataShape {
 }
 
 export class FilesRegister {
-  files: { [filePath: string]: { mtime: number; data: DataShape; }};
+  files: { [filePath: string]: { mtime: number; data: DataShape } };
   dataFactory: (_data?: any) => DataShape; // It doesn't seem that the _data parameter is ever used?
 
   constructor(dataFactory: (_data?: any) => DataShape) {
@@ -74,4 +74,3 @@ export class FilesRegister {
     }
   }
 }
-

--- a/src/FilesWatcher.ts
+++ b/src/FilesWatcher.ts
@@ -24,10 +24,8 @@ export class FilesWatcher {
     }
 
     this.watchers = this.watchPaths.map((watchPath: string) => {
-      return chokidar.watch(
-        watchPath,
-        { persistent: true, alwaysStat: true }
-      )
+      return chokidar
+        .watch(watchPath, { persistent: true, alwaysStat: true })
         .on('change', (filePath: string, stats: any) => {
           if (this.isFileSupported(filePath)) {
             (this.listeners['change'] || []).forEach(changeListener => {
@@ -67,7 +65,9 @@ export class FilesWatcher {
 
   off(event: string, listener: Function) {
     if (this.listeners[event]) {
-      this.listeners[event] = this.listeners[event].filter(oldListener => oldListener !== listener);
+      this.listeners[event] = this.listeners[event].filter(
+        oldListener => oldListener !== listener
+      );
     }
   }
 }

--- a/src/IncrementalChecker.ts
+++ b/src/IncrementalChecker.ts
@@ -61,17 +61,19 @@ export class IncrementalChecker {
 
     // it's shared between compilations
     this.files = new FilesRegister(() => ({
-        // data shape
-        source: undefined,
-        linted: false,
-        lints: []
+      // data shape
+      source: undefined,
+      linted: false,
+      lints: []
     }));
   }
 
   static loadProgramConfig(configFile: string) {
     return ts.parseJsonConfigFileContent(
       // Regardless of the setting in the tsconfig.json we want isolatedModules to be false
-      Object.assign(ts.readConfigFile(configFile, ts.sys.readFile).config, { isolatedModules: false }),
+      Object.assign(ts.readConfigFile(configFile, ts.sys.readFile).config, {
+        isolatedModules: false
+      }),
       ts.sys,
       path.dirname(configFile)
     );
@@ -80,7 +82,9 @@ export class IncrementalChecker {
   static loadLinterConfig(configFile: string): ConfigurationFile {
     const tslint = require('tslint');
 
-    return tslint.Configuration.loadConfigurationFromPath(configFile) as ConfigurationFile;
+    return tslint.Configuration.loadConfigurationFromPath(
+      configFile
+    ) as ConfigurationFile;
   }
 
   static createProgram(
@@ -107,7 +111,7 @@ export class IncrementalChecker {
 
       // get source file only if there is no source in files register
       if (!files.has(filePath) || !files.getData(filePath).source) {
-        files.mutateData(filePath, (data) => {
+        files.mutateData(filePath, data => {
           data.source = realGetSourceFile(filePath, languageVersion, onError);
         });
       }
@@ -129,13 +133,21 @@ export class IncrementalChecker {
     return new tslint.Linter({ fix: false }, program);
   }
 
-  static isFileExcluded(filePath: string, linterExclusions: minimatch.IMinimatch[]): boolean {
-    return endsWith(filePath, '.d.ts') || linterExclusions.some(matcher => matcher.match(filePath));
+  static isFileExcluded(
+    filePath: string,
+    linterExclusions: minimatch.IMinimatch[]
+  ): boolean {
+    return (
+      endsWith(filePath, '.d.ts') ||
+      linterExclusions.some(matcher => matcher.match(filePath))
+    );
   }
 
   nextIteration() {
     if (!this.watcher) {
-      const watchExtensions = this.vue ? ['.ts', '.tsx', '.vue'] : ['.ts', '.tsx'];
+      const watchExtensions = this.vue
+        ? ['.ts', '.tsx', '.vue']
+        : ['.ts', '.tsx'];
       this.watcher = new FilesWatcher(this.watchPaths, watchExtensions);
 
       // connect watcher with register
@@ -150,13 +162,20 @@ export class IncrementalChecker {
     }
 
     if (!this.linterConfig && this.linterConfigFile) {
-      this.linterConfig = IncrementalChecker.loadLinterConfig(this.linterConfigFile);
+      this.linterConfig = IncrementalChecker.loadLinterConfig(
+        this.linterConfigFile
+      );
 
-      if (this.linterConfig.linterOptions && this.linterConfig.linterOptions.exclude) {
+      if (
+        this.linterConfig.linterOptions &&
+        this.linterConfig.linterOptions.exclude
+      ) {
         // Pre-build minimatch patterns to avoid additional overhead later on.
         // Note: Resolving the path is required to properly match against the full file paths,
         // and also deals with potential cross-platform problems regarding path separators.
-        this.linterExclusions = this.linterConfig.linterOptions.exclude.map(pattern => new minimatch.Minimatch(path.resolve(pattern)));
+        this.linterExclusions = this.linterConfig.linterOptions.exclude.map(
+          pattern => new minimatch.Minimatch(path.resolve(pattern))
+        );
       }
     }
 
@@ -168,7 +187,9 @@ export class IncrementalChecker {
   }
 
   loadVueProgram() {
-    this.programConfig = this.programConfig || VueProgram.loadProgramConfig(this.programConfigFile);
+    this.programConfig =
+      this.programConfig ||
+      VueProgram.loadProgramConfig(this.programConfigFile);
 
     return VueProgram.createProgram(
       this.programConfig,
@@ -180,9 +201,16 @@ export class IncrementalChecker {
   }
 
   loadDefaultProgram() {
-    this.programConfig = this.programConfig || IncrementalChecker.loadProgramConfig(this.programConfigFile);
+    this.programConfig =
+      this.programConfig ||
+      IncrementalChecker.loadProgramConfig(this.programConfigFile);
 
-    return IncrementalChecker.createProgram(this.programConfig, this.files, this.watcher, this.program);
+    return IncrementalChecker.createProgram(
+      this.programConfig,
+      this.files,
+      this.watcher,
+      this.program
+    );
   }
 
   hasLinter() {
@@ -195,7 +223,11 @@ export class IncrementalChecker {
     const filesToCheck = this.program.getSourceFiles();
 
     // calculate subset of work to do
-    const workSet = new WorkSet(filesToCheck, this.workNumber, this.workDivision);
+    const workSet = new WorkSet(
+      filesToCheck,
+      this.workNumber,
+      this.workDivision
+    );
 
     // check given work set
     workSet.forEach(sourceFile => {
@@ -203,10 +235,18 @@ export class IncrementalChecker {
         cancellationToken.throwIfCancellationRequested();
       }
 
-      const diagnosticsToRegister: ReadonlyArray<ts.Diagnostic> = this.checkSyntacticErrors
+      const diagnosticsToRegister: ReadonlyArray<ts.Diagnostic> = this
+        .checkSyntacticErrors
         ? []
-          .concat(this.program.getSemanticDiagnostics(sourceFile, cancellationToken))
-          .concat(this.program.getSyntacticDiagnostics(sourceFile, cancellationToken))
+            .concat(
+              this.program.getSemanticDiagnostics(sourceFile, cancellationToken)
+            )
+            .concat(
+              this.program.getSyntacticDiagnostics(
+                sourceFile,
+                cancellationToken
+              )
+            )
         : this.program.getSemanticDiagnostics(sourceFile, cancellationToken);
 
       diagnostics.push.apply(diagnostics, diagnosticsToRegister);
@@ -224,12 +264,20 @@ export class IncrementalChecker {
     }
 
     // select files to lint
-    const filesToLint = this.files.keys().filter(filePath =>
-      !this.files.getData(filePath).linted && !IncrementalChecker.isFileExcluded(filePath, this.linterExclusions)
-    );
+    const filesToLint = this.files
+      .keys()
+      .filter(
+        filePath =>
+          !this.files.getData(filePath).linted &&
+          !IncrementalChecker.isFileExcluded(filePath, this.linterExclusions)
+      );
 
     // calculate subset of work to do
-    const workSet = new WorkSet(filesToLint, this.workNumber, this.workDivision);
+    const workSet = new WorkSet(
+      filesToLint,
+      this.workNumber,
+      this.workDivision
+    );
 
     // lint given work set
     workSet.forEach(fileName => {
@@ -239,11 +287,11 @@ export class IncrementalChecker {
         this.linter.lint(fileName, undefined, this.linterConfig);
       } catch (e) {
         if (
-            fs.existsSync(fileName) &&
-            // check the error type due to file system lag
-            !(e instanceof Error) &&
-            !(e.constructor.name === 'FatalError') &&
-            !(e.message && e.message.trim().startsWith("Invalid source file"))
+          fs.existsSync(fileName) &&
+          // check the error type due to file system lag
+          !(e instanceof Error) &&
+          !(e.constructor.name === 'FatalError') &&
+          !(e.message && e.message.trim().startsWith('Invalid source file'))
         ) {
           // it's not because file doesn't exist - throw error
           throw e;
@@ -269,9 +317,13 @@ export class IncrementalChecker {
     });
 
     // get all lints
-    const lints = this.files.keys().reduce((innerLints, filePath) =>
-      innerLints.concat(this.files.getData(filePath).lints),
-      []);
+    const lints = this.files
+      .keys()
+      .reduce(
+        (innerLints, filePath) =>
+          innerLints.concat(this.files.getData(filePath).lints),
+        []
+      );
 
     // normalize and deduplicate lints
     return NormalizedMessage.deduplicate(

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -1,6 +1,6 @@
 import { NormalizedMessage } from './NormalizedMessage';
 
 export interface Message {
-    diagnostics: NormalizedMessage[];
-    lints: NormalizedMessage[];
+  diagnostics: NormalizedMessage[];
+  lints: NormalizedMessage[];
 }

--- a/src/NormalizedMessage.ts
+++ b/src/NormalizedMessage.ts
@@ -1,4 +1,8 @@
-import { Diagnostic, DiagnosticCategory, flattenDiagnosticMessageText } from 'typescript';
+import {
+  Diagnostic,
+  DiagnosticCategory,
+  flattenDiagnosticMessageText
+} from 'typescript';
 import { RuleFailure } from 'tslint';
 
 type ErrorType = 'diagnostic' | 'lint';
@@ -47,7 +51,9 @@ export class NormalizedMessage {
     let character: number;
     if (diagnostic.file) {
       file = diagnostic.file.fileName;
-      const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+      const position = diagnostic.file.getLineAndCharacterOfPosition(
+        diagnostic.start
+      );
       line = position.line + 1;
       character = position.character + 1;
     }
@@ -55,11 +61,13 @@ export class NormalizedMessage {
     return new NormalizedMessage({
       type: NormalizedMessage.TYPE_DIAGNOSTIC,
       code: diagnostic.code,
-      severity: DiagnosticCategory[diagnostic.category].toLowerCase() as Severity,
+      severity: DiagnosticCategory[
+        diagnostic.category
+      ].toLowerCase() as Severity,
       content: flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
-      file: file,
-      line: line,
-      character: character
+      file,
+      line,
+      character
     });
   }
 
@@ -91,13 +99,31 @@ export class NormalizedMessage {
 
     return (
       NormalizedMessage.compareTypes(messageA.getType(), messageB.getType()) ||
-      NormalizedMessage.compareOptionalStrings(messageA.getFile(), messageB.getFile()) ||
-      NormalizedMessage.compareSeverities(messageA.getSeverity(), messageB.getSeverity()) ||
-      NormalizedMessage.compareNumbers(messageA.getLine(), messageB.getLine()) ||
-      NormalizedMessage.compareNumbers(messageA.getCharacter(), messageB.getCharacter()) ||
+      NormalizedMessage.compareOptionalStrings(
+        messageA.getFile(),
+        messageB.getFile()
+      ) ||
+      NormalizedMessage.compareSeverities(
+        messageA.getSeverity(),
+        messageB.getSeverity()
+      ) ||
+      NormalizedMessage.compareNumbers(
+        messageA.getLine(),
+        messageB.getLine()
+      ) ||
+      NormalizedMessage.compareNumbers(
+        messageA.getCharacter(),
+        messageB.getCharacter()
+      ) ||
       // code can be string (lint failure) or number (typescript error) - should the following line cater for this in some way?
-      NormalizedMessage.compareOptionalStrings(messageA.getCode() as string, messageB.getCode() as string) ||
-      NormalizedMessage.compareOptionalStrings(messageA.getContent(), messageB.getContent()) ||
+      NormalizedMessage.compareOptionalStrings(
+        messageA.getCode() as string,
+        messageB.getCode() as string
+      ) ||
+      NormalizedMessage.compareOptionalStrings(
+        messageA.getContent(),
+        messageB.getContent()
+      ) ||
       0 /* EqualTo */
     );
   }
@@ -107,11 +133,11 @@ export class NormalizedMessage {
   }
 
   static deduplicate(messages: NormalizedMessage[]) {
-    return messages
-      .sort(NormalizedMessage.compare)
-      .filter((message, index) => {
-        return index === 0 || !NormalizedMessage.equals(message, messages[index - 1]);
-      });
+    return messages.sort(NormalizedMessage.compare).filter((message, index) => {
+      return (
+        index === 0 || !NormalizedMessage.equals(message, messages[index - 1])
+      );
+    });
   }
 
   static compareTypes(typeA: ErrorType, typeB: ErrorType) {
@@ -126,7 +152,7 @@ export class NormalizedMessage {
   }
 
   static compareSeverities(severityA: Severity, severityB: Severity) {
-    const priorities = [severityA, severityB].map((type) => {
+    const priorities = [severityA, severityB].map(type => {
       return [
         NormalizedMessage.SEVERITY_WARNING /* 0 */,
         NormalizedMessage.SEVERITY_ERROR /* 1 */

--- a/src/WorkResult.ts
+++ b/src/WorkResult.ts
@@ -15,7 +15,9 @@ export class WorkResult {
 
   set(workName: number, result: any) {
     if (!this.supports(workName)) {
-      throw new Error('Cannot set result - work "' + workName + '" is not supported.');
+      throw new Error(
+        'Cannot set result - work "' + workName + '" is not supported.'
+      );
     }
 
     this.workResult[workName] = result;
@@ -27,7 +29,9 @@ export class WorkResult {
 
   get(workName: number) {
     if (!this.supports(workName)) {
-      throw new Error('Cannot get result - work "' + workName + '" is not supported.');
+      throw new Error(
+        'Cannot get result - work "' + workName + '" is not supported.'
+      );
     }
 
     return this.workResult[workName];

--- a/src/WorkSet.ts
+++ b/src/WorkSet.ts
@@ -8,7 +8,11 @@ export class WorkSet {
   workBegin: number;
   workEnd: number;
 
-  constructor(workDomain: ReadonlyArray<ts.SourceFile> | string[], workNumber: number, workDivision: number) {
+  constructor(
+    workDomain: ReadonlyArray<ts.SourceFile> | string[],
+    workNumber: number,
+    workDivision: number
+  ) {
     this.workDomain = workDomain;
     this.workNumber = workNumber;
     this.workDivision = workDivision;

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -12,15 +12,11 @@ const workers: childProcess.ChildProcess[] = [];
 
 for (let num = 0; num < division; num++) {
   workers.push(
-    childProcess.fork(
-      path.resolve(__dirname, './service.js'),
-      [],
-      {
-        execArgv: ['--max-old-space-size=' + process.env.MEMORY_LIMIT],
-        env: Object.assign({}, process.env, { WORK_NUMBER: num }),
-        stdio: ['inherit', 'inherit', 'inherit', 'ipc']
-      }
-    )
+    childProcess.fork(path.resolve(__dirname, './service.js'), [], {
+      execArgv: ['--max-old-space-size=' + process.env.MEMORY_LIMIT],
+      env: Object.assign({}, process.env, { WORK_NUMBER: num }),
+      stdio: ['inherit', 'inherit', 'inherit', 'ipc']
+    })
   );
 }
 
@@ -46,13 +42,10 @@ process.on('message', (message: Message) => {
 workers.forEach(worker => {
   worker.on('message', (message: Message) => {
     // set result from worker
-    result.set(
-      worker.pid,
-      {
-        diagnostics: message.diagnostics.map(NormalizedMessage.createFromJSON),
-        lints: message.lints.map(NormalizedMessage.createFromJSON)
-      }
-    );
+    result.set(worker.pid, {
+      diagnostics: message.diagnostics.map(NormalizedMessage.createFromJSON),
+      lints: message.lints.map(NormalizedMessage.createFromJSON)
+    });
 
     // if we have result from all workers, send merged
     if (result.hasAll()) {

--- a/src/formatter/codeframeFormatter.ts
+++ b/src/formatter/codeframeFormatter.ts
@@ -11,12 +11,20 @@ import { NormalizedMessage } from '../NormalizedMessage';
  * @returns {codeframeFormatter}
  */
 export function createCodeframeFormatter(options: any) {
-  return function codeframeFormatter(message: NormalizedMessage, useColors: boolean) {
-    const colors = new chalk.constructor({enabled: useColors});
-    const messageColor = message.isWarningSeverity() ? colors.bold.yellow : colors.bold.red;
+  return function codeframeFormatter(
+    message: NormalizedMessage,
+    useColors: boolean
+  ) {
+    const colors = new chalk.constructor({ enabled: useColors });
+    const messageColor = message.isWarningSeverity()
+      ? colors.bold.yellow
+      : colors.bold.red;
     const positionColor = colors.dim;
 
-    const source = message.getFile() && fs.existsSync(message.getFile()) && fs.readFileSync(message.getFile(), 'utf-8');
+    const source =
+      message.getFile() &&
+      fs.existsSync(message.getFile()) &&
+      fs.readFileSync(message.getFile(), 'utf-8');
     let frame = '';
 
     if (source) {
@@ -26,15 +34,20 @@ export function createCodeframeFormatter(options: any) {
         message.character,
         Object.assign({}, options || {}, { highlightCode: useColors })
       )
-      .split('\n')
-      .map(str => '  ' + str)
-      .join(os.EOL);
+        .split('\n')
+        .map(str => '  ' + str)
+        .join(os.EOL);
     }
 
     return (
-      messageColor(message.getSeverity().toUpperCase() + ' in ' + message.getFile()) + os.EOL +
-      positionColor(message.getLine() + ':' + message.getCharacter()) + ' ' + message.getContent() +
+      messageColor(
+        message.getSeverity().toUpperCase() + ' in ' + message.getFile()
+      ) +
+      os.EOL +
+      positionColor(message.getLine() + ':' + message.getCharacter()) +
+      ' ' +
+      message.getContent() +
       (frame ? os.EOL + frame : '')
     );
   };
-};
+}

--- a/src/formatter/defaultFormatter.ts
+++ b/src/formatter/defaultFormatter.ts
@@ -1,4 +1,3 @@
-
 import chalk from 'chalk';
 import * as os from 'os';
 import { NormalizedMessage } from '../NormalizedMessage';
@@ -9,17 +8,24 @@ import { NormalizedMessage } from '../NormalizedMessage';
  * @returns {defaultFormatter}
  */
 export function createDefaultFormatter() {
-  return function defaultFormatter(message: NormalizedMessage, useColors: boolean) {
-    const colors = new chalk.constructor({enabled: useColors});
-    const messageColor = message.isWarningSeverity() ? colors.bold.yellow : colors.bold.red;
+  return function defaultFormatter(
+    message: NormalizedMessage,
+    useColors: boolean
+  ) {
+    const colors = new chalk.constructor({ enabled: useColors });
+    const messageColor = message.isWarningSeverity()
+      ? colors.bold.yellow
+      : colors.bold.red;
     const fileAndNumberColor = colors.bold.cyan;
     const codeColor = colors.grey;
 
     return [
       messageColor(`${message.getSeverity().toUpperCase()} in `) +
-      fileAndNumberColor(`${message.getFile()}(${message.getLine()},${message.getCharacter()})`) +
-      messageColor(':'),
+        fileAndNumberColor(
+          `${message.getFile()}(${message.getLine()},${message.getCharacter()})`
+        ) +
+        messageColor(':'),
       codeColor(message.getFormattedCode() + ': ') + message.getContent()
     ].join(os.EOL);
   };
-};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,7 @@ import { createDefaultFormatter } from './formatter/defaultFormatter';
 import { createCodeframeFormatter } from './formatter/codeframeFormatter';
 import { Message } from './Message';
 
-import { AsyncSeriesHook } from 'tapable';
-import { SyncHook } from 'tapable';
+import { AsyncSeriesHook, SyncHook } from 'tapable';
 
 const checkerPluginName = 'fork-ts-checker-webpack-plugin';
 
@@ -111,13 +110,18 @@ class ForkTsCheckerWebpackPlugin {
   vue: boolean;
 
   constructor(options?: Partial<Options>) {
-    options = options || {} as Options;
+    options = options || ({} as Options);
     this.options = Object.assign({}, options);
 
     this.tsconfig = options.tsconfig || './tsconfig.json';
-    this.tslint = options.tslint ?
-      options.tslint === true ? './tslint.json' : options.tslint : undefined;
-    this.watch = isString(options.watch) ? [options.watch] : options.watch || [];
+    this.tslint = options.tslint
+      ? options.tslint === true
+        ? './tslint.json'
+        : options.tslint
+      : undefined;
+    this.watch = isString(options.watch)
+      ? [options.watch]
+      : options.watch || [];
     this.ignoreDiagnostics = options.ignoreDiagnostics || [];
     this.ignoreLints = options.ignoreLints || [];
     this.logger = options.logger || console;
@@ -125,12 +129,17 @@ class ForkTsCheckerWebpackPlugin {
     this.async = options.async !== false; // default true
     this.checkSyntacticErrors = options.checkSyntacticErrors === true; // default false
     this.workersNumber = options.workers || ForkTsCheckerWebpackPlugin.ONE_CPU;
-    this.memoryLimit = options.memoryLimit || ForkTsCheckerWebpackPlugin.DEFAULT_MEMORY_LIMIT;
+    this.memoryLimit =
+      options.memoryLimit || ForkTsCheckerWebpackPlugin.DEFAULT_MEMORY_LIMIT;
     this.useColors = options.colors !== false; // default true
     this.colors = new chalk.constructor({ enabled: this.useColors });
-    this.formatter = (options.formatter && isFunction(options.formatter))
-      ? options.formatter
-      : ForkTsCheckerWebpackPlugin.createFormatter(options.formatter as 'default' | 'codeframe' || 'default', options.formatterOptions || {});
+    this.formatter =
+      options.formatter && isFunction(options.formatter)
+        ? options.formatter
+        : ForkTsCheckerWebpackPlugin.createFormatter(
+            (options.formatter as 'default' | 'codeframe') || 'default',
+            options.formatterOptions || {}
+          );
 
     this.tsconfigPath = undefined;
     this.tslintPath = undefined;
@@ -151,7 +160,9 @@ class ForkTsCheckerWebpackPlugin {
     this.doneCallback = this.createDoneCallback();
 
     this.typescriptVersion = require('typescript').version;
-    this.tslintVersion = this.tslint ? require('tslint').Linter.VERSION : undefined;
+    this.tslintVersion = this.tslint
+      ? require('tslint').Linter.VERSION
+      : undefined;
 
     this.vue = options.vue === true; // default false
   }
@@ -163,7 +174,9 @@ class ForkTsCheckerWebpackPlugin {
       case 'codeframe':
         return createCodeframeFormatter(options);
       default:
-        throw new Error('Unknown "' + type + '" formatter. Available are: default, codeframe.');
+        throw new Error(
+          'Unknown "' + type + '" formatter. Available are: default, codeframe.'
+        );
     }
   }
 
@@ -171,7 +184,9 @@ class ForkTsCheckerWebpackPlugin {
     this.compiler = compiler;
 
     this.tsconfigPath = this.computeContextPath(this.tsconfig);
-    this.tslintPath = this.tslint ? this.computeContextPath(this.tslint as string) : null;
+    this.tslintPath = this.tslint
+      ? this.computeContextPath(this.tslint as string)
+      : null;
     this.watchPaths = this.watch.map(this.computeContextPath.bind(this));
 
     // validate config
@@ -181,7 +196,9 @@ class ForkTsCheckerWebpackPlugin {
     // validate logger
     if (this.logger) {
       if (!this.logger.error || !this.logger.warn || !this.logger.info) {
-        throw new Error('Invalid logger object - doesn\'t provide `error`, `warn` or `info` method.');
+        throw new Error(
+          "Invalid logger object - doesn't provide `error`, `warn` or `info` method."
+        );
       }
     }
 
@@ -197,31 +214,37 @@ class ForkTsCheckerWebpackPlugin {
     } else {
       if (!tsconfigOk) {
         throw new Error(
-          'Cannot find "' + this.tsconfigPath + '" file. Please check webpack and ForkTsCheckerWebpackPlugin configuration. \n' +
-          'Possible errors: \n' +
-          '  - wrong `context` directory in webpack configuration' +
-          ' (if `tsconfig` is not set or is a relative path in fork plugin configuration)\n' +
-          '  - wrong `tsconfig` path in fork plugin configuration' +
-          ' (should be a relative or absolute path)'
+          'Cannot find "' +
+            this.tsconfigPath +
+            '" file. Please check webpack and ForkTsCheckerWebpackPlugin configuration. \n' +
+            'Possible errors: \n' +
+            '  - wrong `context` directory in webpack configuration' +
+            ' (if `tsconfig` is not set or is a relative path in fork plugin configuration)\n' +
+            '  - wrong `tsconfig` path in fork plugin configuration' +
+            ' (should be a relative or absolute path)'
         );
       }
       if (!tslintOk) {
         throw new Error(
-          'Cannot find "' + this.tslintPath + '" file. Please check webpack and ForkTsCheckerWebpackPlugin configuration. \n' +
-          'Possible errors: \n' +
-          '  - wrong `context` directory in webpack configuration' +
-          ' (if `tslint` is not set or is a relative path in fork plugin configuration)\n' +
-          '  - wrong `tslint` path in fork plugin configuration' +
-          ' (should be a relative or absolute path)\n' +
-          '  - `tslint` path is not set to false in fork plugin configuration' +
-          ' (if you want to disable tslint support)'
+          'Cannot find "' +
+            this.tslintPath +
+            '" file. Please check webpack and ForkTsCheckerWebpackPlugin configuration. \n' +
+            'Possible errors: \n' +
+            '  - wrong `context` directory in webpack configuration' +
+            ' (if `tslint` is not set or is a relative path in fork plugin configuration)\n' +
+            '  - wrong `tslint` path in fork plugin configuration' +
+            ' (should be a relative or absolute path)\n' +
+            '  - `tslint` path is not set to false in fork plugin configuration' +
+            ' (if you want to disable tslint support)'
         );
       }
     }
   }
 
   computeContextPath(filePath: string) {
-    return path.isAbsolute(filePath) ? filePath : path.resolve(this.compiler.options.context, filePath);
+    return path.isAbsolute(filePath)
+      ? filePath
+      : path.resolve(this.compiler.options.context, filePath);
   }
 
   pluginStart() {
@@ -261,7 +284,7 @@ class ForkTsCheckerWebpackPlugin {
       // webpack 4
       this.compiler.hooks.watchClose.tap(checkerPluginName, watchClose);
       this.compiler.hooks.done.tap(checkerPluginName, done);
-      } else {
+    } else {
       // webpack 2 / 3
       this.compiler.plugin('watch-close', watchClose);
       this.compiler.plugin('done', done);
@@ -273,27 +296,54 @@ class ForkTsCheckerWebpackPlugin {
   }
 
   registerCustomHooks() {
-    if (this.compiler.hooks.forkTsCheckerServiceBeforeStart
-      || this.compiler.hooks.forkTsCheckerCancel
-      || this.compiler.hooks.forkTsCheckerServiceStartError
-      || this.compiler.hooks.forkTsCheckerWaiting
-      || this.compiler.hooks.forkTsCheckerServiceStart
-      || this.compiler.hooks.forkTsCheckerReceive
-      || this.compiler.hooks.forkTsCheckerServiceOutOfMemory
-      || this.compiler.hooks.forkTsCheckerDone
-      || this.compiler.hooks.forkTsCheckerEmit) {
-      throw new Error('fork-ts-checker-webpack-plugin hooks are already in use');
+    if (
+      this.compiler.hooks.forkTsCheckerServiceBeforeStart ||
+      this.compiler.hooks.forkTsCheckerCancel ||
+      this.compiler.hooks.forkTsCheckerServiceStartError ||
+      this.compiler.hooks.forkTsCheckerWaiting ||
+      this.compiler.hooks.forkTsCheckerServiceStart ||
+      this.compiler.hooks.forkTsCheckerReceive ||
+      this.compiler.hooks.forkTsCheckerServiceOutOfMemory ||
+      this.compiler.hooks.forkTsCheckerDone ||
+      this.compiler.hooks.forkTsCheckerEmit
+    ) {
+      throw new Error(
+        'fork-ts-checker-webpack-plugin hooks are already in use'
+      );
     }
-    this.compiler.hooks.forkTsCheckerServiceBeforeStart = new AsyncSeriesHook([]);
+    this.compiler.hooks.forkTsCheckerServiceBeforeStart = new AsyncSeriesHook(
+      []
+    );
 
-    this.compiler.hooks.forkTsCheckerCancel = new SyncHook(['cancellationToken']);
-    this.compiler.hooks.forkTsCheckerServiceStartError = new SyncHook(['error']);
+    this.compiler.hooks.forkTsCheckerCancel = new SyncHook([
+      'cancellationToken'
+    ]);
+    this.compiler.hooks.forkTsCheckerServiceStartError = new SyncHook([
+      'error'
+    ]);
     this.compiler.hooks.forkTsCheckerWaiting = new SyncHook(['hasTsLint']);
-    this.compiler.hooks.forkTsCheckerServiceStart = new SyncHook(['tsconfigPath', 'tslintPath', 'watchPaths', 'workersNumber', 'memoryLimit']);
-    this.compiler.hooks.forkTsCheckerReceive = new SyncHook(['diagnostics', 'lints']);
+    this.compiler.hooks.forkTsCheckerServiceStart = new SyncHook([
+      'tsconfigPath',
+      'tslintPath',
+      'watchPaths',
+      'workersNumber',
+      'memoryLimit'
+    ]);
+    this.compiler.hooks.forkTsCheckerReceive = new SyncHook([
+      'diagnostics',
+      'lints'
+    ]);
     this.compiler.hooks.forkTsCheckerServiceOutOfMemory = new SyncHook([]);
-    this.compiler.hooks.forkTsCheckerEmit = new SyncHook(['diagnostics', 'lints', 'elapsed']);
-    this.compiler.hooks.forkTsCheckerDone = new SyncHook(['diagnostics', 'lints', 'elapsed']);
+    this.compiler.hooks.forkTsCheckerEmit = new SyncHook([
+      'diagnostics',
+      'lints',
+      'elapsed'
+    ]);
+    this.compiler.hooks.forkTsCheckerDone = new SyncHook([
+      'diagnostics',
+      'lints',
+      'elapsed'
+    ]);
 
     // for backwards compatibility
     this.compiler._pluginCompat.tap(checkerPluginName, (options: any) => {
@@ -324,7 +374,9 @@ class ForkTsCheckerWebpackPlugin {
           if (this.cancellationToken) {
             // request cancellation if there is not finished job
             this.cancellationToken.requestCancellation();
-            this.compiler.hooks.forkTsCheckerCancel.call(this.cancellationToken);
+            this.compiler.hooks.forkTsCheckerCancel.call(
+              this.cancellationToken
+            );
           }
           this.checkDone = false;
 
@@ -340,7 +392,12 @@ class ForkTsCheckerWebpackPlugin {
             this.service.send(this.cancellationToken);
           } catch (error) {
             if (!this.silent && this.logger) {
-              this.logger.error(this.colors.red('Cannot start checker service: ' + (error ? error.toString() : 'Unknown error')));
+              this.logger.error(
+                this.colors.red(
+                  'Cannot start checker service: ' +
+                    (error ? error.toString() : 'Unknown error')
+                )
+              );
             }
 
             this.compiler.hooks.forkTsCheckerServiceStartError.call(error);
@@ -351,32 +408,49 @@ class ForkTsCheckerWebpackPlugin {
       // webpack 2 / 3
       this.compiler.plugin('compile', () => {
         this.compilationDone = false;
-        this.compiler.applyPluginsAsync('fork-ts-checker-service-before-start', () => {
-          if (this.cancellationToken) {
-            // request cancellation if there is not finished job
-            this.cancellationToken.requestCancellation();
-            this.compiler.applyPlugins('fork-ts-checker-cancel', this.cancellationToken);
-          }
-          this.checkDone = false;
+        this.compiler.applyPluginsAsync(
+          'fork-ts-checker-service-before-start',
+          () => {
+            if (this.cancellationToken) {
+              // request cancellation if there is not finished job
+              this.cancellationToken.requestCancellation();
+              this.compiler.applyPlugins(
+                'fork-ts-checker-cancel',
+                this.cancellationToken
+              );
+            }
+            this.checkDone = false;
 
-          this.started = process.hrtime();
+            this.started = process.hrtime();
 
-          // create new token for current job
-          this.cancellationToken = new CancellationToken(undefined, undefined);
-          if (!this.service || !this.service.connected) {
-            this.spawnService();
-          }
-
-          try {
-            this.service.send(this.cancellationToken);
-          } catch (error) {
-            if (!this.silent && this.logger) {
-              this.logger.error(this.colors.red('Cannot start checker service: ' + (error ? error.toString() : 'Unknown error')));
+            // create new token for current job
+            this.cancellationToken = new CancellationToken(
+              undefined,
+              undefined
+            );
+            if (!this.service || !this.service.connected) {
+              this.spawnService();
             }
 
-            this.compiler.applyPlugins('fork-ts-checker-service-start-error', error);
+            try {
+              this.service.send(this.cancellationToken);
+            } catch (error) {
+              if (!this.silent && this.logger) {
+                this.logger.error(
+                  this.colors.red(
+                    'Cannot start checker service: ' +
+                      (error ? error.toString() : 'Unknown error')
+                  )
+                );
+              }
+
+              this.compiler.applyPlugins(
+                'fork-ts-checker-service-start-error',
+                error
+              );
+            }
           }
-        });
+        );
       });
     }
   }
@@ -409,28 +483,33 @@ class ForkTsCheckerWebpackPlugin {
   pluginDone() {
     if ('hooks' in this.compiler) {
       // webpack 4
-      this.compiler.hooks.done.tap(checkerPluginName, (_stats: webpack.Stats) => {
-        if (!this.isWatching || !this.async) {
-          return;
-        }
-
-        if (this.checkDone) {
-          this.doneCallback();
-        } else {
-          if (this.compiler) {
-            this.compiler.hooks.forkTsCheckerWaiting.call(this.tslint !== false);
+      this.compiler.hooks.done.tap(
+        checkerPluginName,
+        (_stats: webpack.Stats) => {
+          if (!this.isWatching || !this.async) {
+            return;
           }
-          if (!this.silent && this.logger) {
-            this.logger.info(
-              this.tslint
-                ? 'Type checking and linting in progress...'
-                : 'Type checking in progress...'
-            );
-          }
-        }
 
-        this.compilationDone = true;
-      });
+          if (this.checkDone) {
+            this.doneCallback();
+          } else {
+            if (this.compiler) {
+              this.compiler.hooks.forkTsCheckerWaiting.call(
+                this.tslint !== false
+              );
+            }
+            if (!this.silent && this.logger) {
+              this.logger.info(
+                this.tslint
+                  ? 'Type checking and linting in progress...'
+                  : 'Type checking in progress...'
+              );
+            }
+          }
+
+          this.compilationDone = true;
+        }
+      );
     } else {
       // webpack 2 / 3
       this.compiler.plugin('done', () => {
@@ -463,23 +542,25 @@ class ForkTsCheckerWebpackPlugin {
 
   spawnService() {
     this.service = childProcess.fork(
-      path.resolve(__dirname, this.workersNumber > 1 ? './cluster.js' : './service.js'),
+      path.resolve(
+        __dirname,
+        this.workersNumber > 1 ? './cluster.js' : './service.js'
+      ),
       [],
       {
-        execArgv: this.workersNumber > 1 ? [] : ['--max-old-space-size=' + this.memoryLimit],
-        env: Object.assign(
-          {},
-          process.env,
-          {
-            TSCONFIG: this.tsconfigPath,
-            TSLINT: this.tslintPath || '',
-            WATCH: this.isWatching ? this.watchPaths.join('|') : '',
-            WORK_DIVISION: Math.max(1, this.workersNumber),
-            MEMORY_LIMIT: this.memoryLimit,
-            CHECK_SYNTACTIC_ERRORS: this.checkSyntacticErrors,
-            VUE: this.vue
-          }
-        ),
+        execArgv:
+          this.workersNumber > 1
+            ? []
+            : ['--max-old-space-size=' + this.memoryLimit],
+        env: Object.assign({}, process.env, {
+          TSCONFIG: this.tsconfigPath,
+          TSLINT: this.tslintPath || '',
+          WATCH: this.isWatching ? this.watchPaths.join('|') : '',
+          WORK_DIVISION: Math.max(1, this.workersNumber),
+          MEMORY_LIMIT: this.memoryLimit,
+          CHECK_SYNTACTIC_ERRORS: this.checkSyntacticErrors,
+          VUE: this.vue
+        }),
         stdio: ['inherit', 'inherit', 'inherit', 'ipc']
       }
     );
@@ -506,25 +587,38 @@ class ForkTsCheckerWebpackPlugin {
     }
 
     if (!this.silent && this.logger) {
-      this.logger.info('Starting type checking' + (this.tslint ? ' and linting' : '') + ' service...');
       this.logger.info(
-        'Using ' + this.colors.bold(this.workersNumber === 1 ? '1 worker' : this.workersNumber + ' workers') +
-        ' with ' + this.colors.bold(this.memoryLimit + 'MB') + ' memory limit'
+        'Starting type checking' +
+          (this.tslint ? ' and linting' : '') +
+          ' service...'
+      );
+      this.logger.info(
+        'Using ' +
+          this.colors.bold(
+            this.workersNumber === 1
+              ? '1 worker'
+              : this.workersNumber + ' workers'
+          ) +
+          ' with ' +
+          this.colors.bold(this.memoryLimit + 'MB') +
+          ' memory limit'
       );
 
       if (this.watchPaths.length && this.isWatching) {
         this.logger.info(
           'Watching:' +
-          (this.watchPaths.length > 1 ? '\n' : ' ') +
-          this.watchPaths
-            .map(wpath => this.colors.grey(wpath))
-            .join('\n')
+            (this.watchPaths.length > 1 ? '\n' : ' ') +
+            this.watchPaths.map(wpath => this.colors.grey(wpath)).join('\n')
         );
       }
     }
 
-    this.service.on('message', (message: Message) => this.handleServiceMessage(message));
-    this.service.on('exit', (code: string | number, signal: string) => this.handleServiceExit(code, signal));
+    this.service.on('message', (message: Message) =>
+      this.handleServiceMessage(message)
+    );
+    this.service.on('exit', (code: string | number, signal: string) =>
+      this.handleServiceExit(code, signal)
+    );
   }
 
   killService() {
@@ -553,31 +647,43 @@ class ForkTsCheckerWebpackPlugin {
 
     this.checkDone = true;
     this.elapsed = process.hrtime(this.started);
-    this.diagnostics = message.diagnostics.map(NormalizedMessage.createFromJSON);
+    this.diagnostics = message.diagnostics.map(
+      NormalizedMessage.createFromJSON
+    );
     this.lints = message.lints.map(NormalizedMessage.createFromJSON);
 
     if (this.ignoreDiagnostics.length) {
-      this.diagnostics = this.diagnostics.filter(diagnostic =>
-        this.ignoreDiagnostics.indexOf(parseInt(diagnostic.getCode() as string, 10)) === -1
+      this.diagnostics = this.diagnostics.filter(
+        diagnostic =>
+          this.ignoreDiagnostics.indexOf(
+            parseInt(diagnostic.getCode() as string, 10)
+          ) === -1
       );
     }
 
     if (this.ignoreLints.length) {
-      this.lints = this.lints.filter(lint =>
-        this.ignoreLints.indexOf(lint.getCode() as string) === -1
+      this.lints = this.lints.filter(
+        lint => this.ignoreLints.indexOf(lint.getCode() as string) === -1
       );
     }
 
     if ('hooks' in this.compiler) {
       // webpack 4
-      this.compiler.hooks.forkTsCheckerReceive.call(this.diagnostics, this.lints);
+      this.compiler.hooks.forkTsCheckerReceive.call(
+        this.diagnostics,
+        this.lints
+      );
     } else {
       // webpack 2 / 3
-      this.compiler.applyPlugins('fork-ts-checker-receive', this.diagnostics, this.lints);
+      this.compiler.applyPlugins(
+        'fork-ts-checker-receive',
+        this.diagnostics,
+        this.lints
+      );
     }
 
     if (this.compilationDone) {
-      (this.isWatching && this.async) ? this.doneCallback() : this.emitCallback();
+      this.isWatching && this.async ? this.doneCallback() : this.emitCallback();
     }
   }
 
@@ -597,7 +703,7 @@ class ForkTsCheckerWebpackPlugin {
         this.logger.error(
           this.colors.red(
             'Type checking and linting aborted - probably out of memory. ' +
-            'Check `memoryLimit` option in ForkTsCheckerWebpackPlugin configuration.'
+              'Check `memoryLimit` option in ForkTsCheckerWebpackPlugin configuration.'
           )
         );
       }
@@ -606,7 +712,7 @@ class ForkTsCheckerWebpackPlugin {
 
   createEmitCallback(compilation: any, callback: () => void) {
     return function emitCallback(this: ForkTsCheckerWebpackPlugin) {
-      const elapsed = Math.round(this.elapsed[0] * 1E9 + this.elapsed[1]);
+      const elapsed = Math.round(this.elapsed[0] * 1e9 + this.elapsed[1]);
 
       if ('hooks' in this.compiler) {
         // webpack 4
@@ -628,10 +734,12 @@ class ForkTsCheckerWebpackPlugin {
       this.diagnostics.concat(this.lints).forEach(message => {
         // webpack message format
         const formatted = {
-          rawMessage: (
-            message.getSeverity().toUpperCase() + ' ' + message.getFormattedCode() + ': ' +
-            message.getContent()
-          ),
+          rawMessage:
+            message.getSeverity().toUpperCase() +
+            ' ' +
+            message.getFormattedCode() +
+            ': ' +
+            message.getContent(),
           message: this.formatter(message, this.useColors),
           location: {
             line: message.getLine(),
@@ -653,12 +761,12 @@ class ForkTsCheckerWebpackPlugin {
 
   createNoopEmitCallback() {
     // tslint:disable-next-line:no-empty
-    return function noopEmitCallback() { };
+    return function noopEmitCallback() {};
   }
 
   createDoneCallback() {
     return function doneCallback(this: ForkTsCheckerWebpackPlugin) {
-      const elapsed = Math.round(this.elapsed[0] * 1E9 + this.elapsed[1]);
+      const elapsed = Math.round(this.elapsed[0] * 1e9 + this.elapsed[1]);
 
       if (this.compiler) {
         if ('hooks' in this.compiler) {
@@ -684,7 +792,9 @@ class ForkTsCheckerWebpackPlugin {
           (this.lints || []).concat(this.diagnostics).forEach(message => {
             const formattedMessage = this.formatter(message, this.useColors);
 
-            message.isWarningSeverity() ? this.logger.warn(formattedMessage) : this.logger.error(formattedMessage);
+            message.isWarningSeverity()
+              ? this.logger.warn(formattedMessage)
+              : this.logger.error(formattedMessage);
           });
         }
         if (!this.diagnostics.length) {
@@ -694,15 +804,24 @@ class ForkTsCheckerWebpackPlugin {
           this.logger.info(this.colors.green('No lint errors found'));
         }
         this.logger.info(
-          'Version: typescript ' + this.colors.bold(this.typescriptVersion) +
-          (this.tslint ? ', tslint ' + this.colors.bold(this.tslintVersion) : '')
+          'Version: typescript ' +
+            this.colors.bold(this.typescriptVersion) +
+            (this.tslint
+              ? ', tslint ' + this.colors.bold(this.tslintVersion)
+              : '')
         );
-        this.logger.info('Time: ' + this.colors.bold(Math.round(elapsed / 1E6).toString()) + 'ms');
+        this.logger.info(
+          'Time: ' +
+            this.colors.bold(Math.round(elapsed / 1e6).toString()) +
+            'ms'
+        );
       }
     };
   }
 }
 
-export = ForkTsCheckerWebpackPlugin
+export = ForkTsCheckerWebpackPlugin;
 
-namespace ForkTsCheckerWebpackPlugin {}
+namespace ForkTsCheckerWebpackPlugin {
+
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -46,7 +46,7 @@ function run(cancellationToken: CancellationToken) {
   }
 }
 
-process.on('message', (message) => {
+process.on('message', message => {
   run(CancellationToken.createFromJSON(message));
 });
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,20 +1,18 @@
 {
-    "compilerOptions": {
-        "target": "es5",
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "suppressImplicitAnyIndexErrors": true,
-        "strictNullChecks": false,
-        "lib": [
-            "es5", "es2015.core", "dom"
-        ],
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "declaration": true,
-        "outDir": "../lib",
-        "declarationDir": "../lib/types"
-    }
+  "compilerOptions": {
+    "target": "es5",
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "strictNullChecks": false,
+    "lib": ["es5", "es2015.core", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "../lib",
+    "declarationDir": "../lib/types"
+  }
 }

--- a/src/tslint.json
+++ b/src/tslint.json
@@ -1,5 +1,5 @@
 {
-    "extends": "tslint:latest",
+    "extends": ["tslint:latest", "tslint-config-prettier"],
     "rules": {
       "max-line-length": [false, 140],
       "object-literal-sort-keys": false,
@@ -8,12 +8,8 @@
         false
       ],
       "no-object-literal-type-assertion":false,
-      "no-unused-variable": [true, "check-parameters"],
       "no-var-requires": false,
       "no-string-literal": false,
-      "quotemark": [
-        "single"
-      ],
       "ordered-imports":false,
       "prefer-object-spread": false,
       "ban-types": false,
@@ -30,7 +26,8 @@
         "check-format",
         "allow-leading-underscore",
         "allow-pascal-case"
-      ]
+      ],
+      "no-namespace": false
     }
   }
   

--- a/src/tslint.json
+++ b/src/tslint.json
@@ -21,6 +21,7 @@
       "allow-leading-underscore",
       "allow-pascal-case"
     ],
-    "no-namespace": false
+    "no-namespace": false,
+    "array-type": [true, "array"]
   }
 }

--- a/src/tslint.json
+++ b/src/tslint.json
@@ -1,33 +1,26 @@
 {
-    "extends": ["tslint:latest", "tslint-config-prettier"],
-    "rules": {
-      "max-line-length": [false, 140],
-      "object-literal-sort-keys": false,
-      "interface-name": [true, "never-prefix"],
-      "member-ordering": [
-        false
-      ],
-      "no-object-literal-type-assertion":false,
-      "no-var-requires": false,
-      "no-string-literal": false,
-      "ordered-imports":false,
-      "prefer-object-spread": false,
-      "ban-types": false,
-      "arrow-parens": false,
-      "member-access": [
-          false
-      ],
-      "trailing-comma": [false],
-      "triple-equals": [
-        true
-      ],
-      "variable-name": [true,
-        "ban-keywords",
-        "check-format",
-        "allow-leading-underscore",
-        "allow-pascal-case"
-      ],
-      "no-namespace": false
-    }
+  "extends": ["tslint:latest", "tslint-config-prettier"],
+  "rules": {
+    "object-literal-sort-keys": false,
+    "interface-name": [true, "never-prefix"],
+    "member-ordering": [false],
+    "no-object-literal-type-assertion": false,
+    "no-var-requires": false,
+    "no-string-literal": false,
+    "ordered-imports": false,
+    "prefer-object-spread": false,
+    "ban-types": false,
+    "arrow-parens": false,
+    "member-access": [false],
+    "trailing-comma": [false],
+    "triple-equals": [true],
+    "variable-name": [
+      true,
+      "ban-keywords",
+      "check-format",
+      "allow-leading-underscore",
+      "allow-pascal-case"
+    ],
+    "no-namespace": false
   }
-  
+}

--- a/src/types/vue-template-compiler.d.ts
+++ b/src/types/vue-template-compiler.d.ts
@@ -24,7 +24,7 @@ declare module 'vue-template-compiler' {
 
   interface CompiledResultFunctions {
     render: () => VNode;
-    staticRenderFns: (() => VNode)[];
+    staticRenderFns: Array<() => VNode>;
   }
 
   interface ModuleOptions {
@@ -36,7 +36,10 @@ declare module 'vue-template-compiler' {
     staticKeys?: string[];
   }
 
-  type DirectiveFunction = (node: ASTElement, directiveMeta: ASTDirective) => void;
+  type DirectiveFunction = (
+    node: ASTElement,
+    directiveMeta: ASTDirective
+  ) => void;
 
   /*
   * AST Types
@@ -49,7 +52,7 @@ declare module 'vue-template-compiler' {
    * - 3: CHILDREN - self un-optimizable but have fully optimizable children
    * - 4: PARTIAL - self un-optimizable with some un-optimizable children
    */
-  export type SSROptimizability = 0 | 1 | 2 | 3 | 4
+  export type SSROptimizability = 0 | 1 | 2 | 3 | 4;
 
   export interface ASTModifiers {
     [key: string]: boolean;
@@ -83,7 +86,7 @@ declare module 'vue-template-compiler' {
   export interface ASTElement {
     type: 1;
     tag: string;
-    attrsList: { name: string; value: any }[];
+    attrsList: Array<{ name: string; value: any }>;
     attrsMap: Record<string, any>;
     parent: ASTElement | undefined;
     children: ASTNode[];
@@ -97,8 +100,8 @@ declare module 'vue-template-compiler' {
     hasBindings?: boolean;
 
     text?: string;
-    attrs?: { name: string; value: any }[];
-    props?: { name: string; value: string }[];
+    attrs?: Array<{ name: string; value: any }>;
+    props?: Array<{ name: string; value: string }>;
     plain?: boolean;
     pre?: true;
     ns?: string;
@@ -162,7 +165,7 @@ declare module 'vue-template-compiler' {
     type: 2;
     expression: string;
     text: string;
-    tokens: (string | Record<string, any>)[];
+    tokens: Array<string | Record<string, any>>;
     static?: boolean;
     // 2.4 ssr optimization
     ssrOptimizability?: SSROptimizability;
@@ -218,7 +221,9 @@ declare module 'vue-template-compiler' {
     options?: CompilerOptions
   ): CompiledResult;
 
-  export function ssrCompileToFunctions(template: string): CompiledResultFunctions;
+  export function ssrCompileToFunctions(
+    template: string
+  ): CompiledResultFunctions;
 
   export function parseComponent(
     file: string,

--- a/src/types/vue-template-compiler.d.ts
+++ b/src/types/vue-template-compiler.d.ts
@@ -24,7 +24,7 @@ declare module 'vue-template-compiler' {
 
   interface CompiledResultFunctions {
     render: () => VNode;
-    staticRenderFns: Array<() => VNode>;
+    staticRenderFns: (() => VNode)[];
   }
 
   interface ModuleOptions {
@@ -86,7 +86,7 @@ declare module 'vue-template-compiler' {
   export interface ASTElement {
     type: 1;
     tag: string;
-    attrsList: Array<{ name: string; value: any }>;
+    attrsList: { name: string; value: any }[];
     attrsMap: Record<string, any>;
     parent: ASTElement | undefined;
     children: ASTNode[];
@@ -100,8 +100,8 @@ declare module 'vue-template-compiler' {
     hasBindings?: boolean;
 
     text?: string;
-    attrs?: Array<{ name: string; value: any }>;
-    props?: Array<{ name: string; value: string }>;
+    attrs?: { name: string; value: any }[];
+    props?: { name: string; value: string }[];
     plain?: boolean;
     pre?: true;
     ns?: string;
@@ -165,7 +165,7 @@ declare module 'vue-template-compiler' {
     type: 2;
     expression: string;
     text: string;
-    tokens: Array<string | Record<string, any>>;
+    tokens: (string | Record<string, any>)[];
     static?: boolean;
     // 2.4 ssr optimization
     ssrOptimizability?: SSROptimizability;

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -1,4 +1,3 @@
-
 var describe = require('mocha').describe;
 var it = require('mocha').it;
 var chai = require('chai');
@@ -11,16 +10,18 @@ var expect = chai.expect;
 
 var webpackMajorVersion = require('./webpackVersion')();
 
-describe('[INTEGRATION] index', function () {
+describe('[INTEGRATION] index', function() {
   this.timeout(60000);
   var plugin;
 
   function createCompiler(options, happyPackMode) {
-    plugin = new ForkTsCheckerWebpackPlugin(Object.assign({}, options, { silent: true }));
+    plugin = new ForkTsCheckerWebpackPlugin(
+      Object.assign({}, options, { silent: true })
+    );
 
-    var tsLoaderOptions = happyPackMode 
-        ? { happyPackMode: true, silent: true } 
-        : { transpileOnly: true, silent: true };
+    var tsLoaderOptions = happyPackMode
+      ? { happyPackMode: true, silent: true }
+      : { transpileOnly: true, silent: true };
 
     return webpack({
       ...(webpackMajorVersion >= 4 ? { mode: 'development' } : {}),
@@ -38,9 +39,7 @@ describe('[INTEGRATION] index', function () {
           }
         ]
       },
-      plugins: [
-        plugin
-      ]
+      plugins: [plugin]
     });
   }
 
@@ -53,56 +52,59 @@ describe('[INTEGRATION] index', function () {
     return plugin.service === undefined;
   }
 
-  it('should allow to pass no options', function () {
-    expect(function () {
+  it('should allow to pass no options', function() {
+    expect(function() {
       new ForkTsCheckerWebpackPlugin();
     }).to.not.throw.error;
   });
 
-  it('should detect paths', function () {
+  it('should detect paths', function() {
     var plugin = new ForkTsCheckerWebpackPlugin({ tslint: true });
 
     expect(plugin.tsconfig).to.be.equal('./tsconfig.json');
     expect(plugin.tslint).to.be.equal('./tslint.json');
   });
 
-  it('should set logger to console by default', function () {
-    var plugin = new ForkTsCheckerWebpackPlugin({ });
+  it('should set logger to console by default', function() {
+    var plugin = new ForkTsCheckerWebpackPlugin({});
 
     expect(plugin.logger).to.be.equal(console);
   });
 
-  it('should set watch to empty array by default', function () {
-    var plugin = new ForkTsCheckerWebpackPlugin({ });
+  it('should set watch to empty array by default', function() {
+    var plugin = new ForkTsCheckerWebpackPlugin({});
 
     expect(plugin.watch).to.be.deep.equal([]);
   });
 
-  it('should set watch to one element array for string', function () {
+  it('should set watch to one element array for string', function() {
     var plugin = new ForkTsCheckerWebpackPlugin({ watch: '/test' });
 
     expect(plugin.watch).to.be.deep.equal(['/test']);
   });
 
-  it('should work without configuration', function (callback) {
+  it('should work without configuration', function(callback) {
     var compiler = createCompiler();
 
-    compiler.run(function (err, stats) {
+    compiler.run(function(err, stats) {
       expect(stats.compilation.errors.length).to.be.at.least(1);
       callback();
     });
   });
 
-  it('should block emit on build mode', function (callback) {
+  it('should block emit on build mode', function(callback) {
     var compiler = createCompiler();
 
     if ('hooks' in compiler) {
-      compiler.hooks.forkTsCheckerEmit.tap('should block emit on build mode', function () {
-        expect(true).to.be.true;
-        callback();
-      });
+      compiler.hooks.forkTsCheckerEmit.tap(
+        'should block emit on build mode',
+        function() {
+          expect(true).to.be.true;
+          callback();
+        }
+      );
     } else {
-      compiler.plugin('fork-ts-checker-emit', function () {
+      compiler.plugin('fork-ts-checker-emit', function() {
         expect(true).to.be.true;
         callback();
       });
@@ -111,19 +113,22 @@ describe('[INTEGRATION] index', function () {
     compiler.run(function() {});
   });
 
-  it('should not block emit on watch mode', function (callback) {
+  it('should not block emit on watch mode', function(callback) {
     var compiler = createCompiler();
     var watching = compiler.watch({}, function() {});
 
     if ('hooks' in compiler) {
-      compiler.hooks.forkTsCheckerDone.tap('should not block emit on watch mode', function () {
-        watching.close(function() {
-          expect(true).to.be.true;
-          callback();
-        });
-      });
+      compiler.hooks.forkTsCheckerDone.tap(
+        'should not block emit on watch mode',
+        function() {
+          watching.close(function() {
+            expect(true).to.be.true;
+            callback();
+          });
+        }
+      );
     } else {
-      compiler.plugin('fork-ts-checker-done', function () {
+      compiler.plugin('fork-ts-checker-done', function() {
         watching.close(function() {
           expect(true).to.be.true;
           callback();
@@ -132,19 +137,22 @@ describe('[INTEGRATION] index', function () {
     }
   });
 
-  it('should block emit if async flag is false', function (callback) {
+  it('should block emit if async flag is false', function(callback) {
     var compiler = createCompiler({ async: false });
     var watching = compiler.watch({}, function() {});
 
     if ('hooks' in compiler) {
-      compiler.hooks.forkTsCheckerEmit.tap('should block emit if async flag is false', function () {
-        watching.close(function() {
-          expect(true).to.be.true;
-          callback();
-        });
-      });
+      compiler.hooks.forkTsCheckerEmit.tap(
+        'should block emit if async flag is false',
+        function() {
+          watching.close(function() {
+            expect(true).to.be.true;
+            callback();
+          });
+        }
+      );
     } else {
-      compiler.plugin('fork-ts-checker-emit', function () {
+      compiler.plugin('fork-ts-checker-emit', function() {
         watching.close(function() {
           expect(true).to.be.true;
           callback();
@@ -153,19 +161,22 @@ describe('[INTEGRATION] index', function () {
     }
   });
 
-  it('kills the service when the watch is done', function (done) {
+  it('kills the service when the watch is done', function(done) {
     var compiler = createCompiler();
     var watching = compiler.watch({}, function() {});
 
     if ('hooks' in compiler) {
-      compiler.hooks.forkTsCheckerDone.tap('kills the service when the watch is done', function () {
-        watching.close(function() {
-          expect(killServiceWasCalled()).to.be.true;
-          done();
-        });
-      });
+      compiler.hooks.forkTsCheckerDone.tap(
+        'kills the service when the watch is done',
+        function() {
+          watching.close(function() {
+            expect(killServiceWasCalled()).to.be.true;
+            done();
+          });
+        }
+      );
     } else {
-      compiler.plugin('fork-ts-checker-done', function () {
+      compiler.plugin('fork-ts-checker-done', function() {
         watching.close(function() {
           expect(killServiceWasCalled()).to.be.true;
           done();
@@ -174,7 +185,7 @@ describe('[INTEGRATION] index', function () {
     }
   });
 
-  it('should throw error if config container wrong tsconfig.json path', function () {
+  it('should throw error if config container wrong tsconfig.json path', function() {
     expect(function() {
       createCompiler({
         tsconfig: '/some/path/that/not/exists/tsconfig.json'
@@ -182,7 +193,7 @@ describe('[INTEGRATION] index', function () {
     }).to.throw.error;
   });
 
-  it('should throw error if config container wrong tslint.json path', function () {
+  it('should throw error if config container wrong tslint.json path', function() {
     expect(function() {
       createCompiler({
         tslint: '/some/path/that/not/exists/tslint.json'
@@ -190,7 +201,7 @@ describe('[INTEGRATION] index', function () {
     }).to.throw.error;
   });
 
-  it('should find the same errors on multi-process mode', function (callback) {
+  it('should find the same errors on multi-process mode', function(callback) {
     var compilerA = createCompiler({ workers: 1, tslint: true });
     var compilerB = createCompiler({ workers: 4, tslint: true });
     var errorsA, errorsB, warningsA, warningsB;
@@ -222,59 +233,65 @@ describe('[INTEGRATION] index', function () {
     }
   });
 
-  it('should detect tslint path for true option', function () {
+  it('should detect tslint path for true option', function() {
     expect(function() {
       createCompiler({ tslint: true });
     }).to.not.throw.error;
   });
 
-  it('should allow delaying service-start', function (callback) {
+  it('should allow delaying service-start', function(callback) {
     var compiler = createCompiler();
     var delayed = false;
 
     if ('hooks' in compiler) {
-      compiler.hooks.forkTsCheckerServiceBeforeStart.tapAsync('should allow delaying service-start', function (cb) {
-        setTimeout(function () {
-          delayed = true;
-  
-          cb();
-        }, 0);
-      });
-  
-      compiler.hooks.forkTsCheckerServiceStart.tap('should allow delaying service-start', function () {
-        expect(delayed).to.be.true;
-        callback();
-      });
+      compiler.hooks.forkTsCheckerServiceBeforeStart.tapAsync(
+        'should allow delaying service-start',
+        function(cb) {
+          setTimeout(function() {
+            delayed = true;
+
+            cb();
+          }, 0);
+        }
+      );
+
+      compiler.hooks.forkTsCheckerServiceStart.tap(
+        'should allow delaying service-start',
+        function() {
+          expect(delayed).to.be.true;
+          callback();
+        }
+      );
     } else {
-      compiler.plugin('fork-ts-checker-service-before-start', function (cb) {
-        setTimeout(function () {
+      compiler.plugin('fork-ts-checker-service-before-start', function(cb) {
+        setTimeout(function() {
           delayed = true;
-  
+
           cb();
         }, 0);
       });
-  
-      compiler.plugin('fork-ts-checker-service-start', function () {
+
+      compiler.plugin('fork-ts-checker-service-start', function() {
         expect(delayed).to.be.true;
         callback();
       });
     }
-    
-    compiler.run(function () {});
+
+    compiler.run(function() {});
   });
 
-  it('should not find syntactic errors when checkSyntacticErrors is false', function (callback) {
+  it('should not find syntactic errors when checkSyntacticErrors is false', function(callback) {
     var compiler = createCompiler({}, true);
-    
+
     compiler.run(function(error, stats) {
       expect(stats.compilation.errors.length).to.be.equal(1);
       callback();
     });
   });
 
-  it('should find syntactic errors when checkSyntacticErrors is true', function (callback) {
+  it('should find syntactic errors when checkSyntacticErrors is true', function(callback) {
     var compiler = createCompiler({ checkSyntacticErrors: true }, true);
-    
+
     compiler.run(function(error, stats) {
       expect(stats.compilation.errors.length).to.be.equal(2);
       callback();

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -1,4 +1,3 @@
-
 var describe = require('mocha').describe;
 var it = require('mocha').it;
 var expect = require('chai').expect;
@@ -6,22 +5,26 @@ var path = require('path');
 var webpack = require('webpack');
 var process = require('process');
 var ForkTsCheckerWebpackPlugin = require('../../lib/index');
-var IncrementalChecker = require('../../lib/IncrementalChecker').IncrementalChecker;
+var IncrementalChecker = require('../../lib/IncrementalChecker')
+  .IncrementalChecker;
 
 var webpackMajorVersion = require('./webpackVersion')();
 
-var VueLoaderPlugin = webpackMajorVersion >= 4 ? require('vue-loader/lib/plugin') : undefined;
+var VueLoaderPlugin =
+  webpackMajorVersion >= 4 ? require('vue-loader/lib/plugin') : undefined;
 
-describe('[INTEGRATION] vue', function () {
+describe('[INTEGRATION] vue', function() {
   this.timeout(60000);
-  process.setMaxListeners(0);   
+  process.setMaxListeners(0);
   var plugin;
   var files;
   var compiler;
   var checker;
 
   function createCompiler(options) {
-    plugin = new ForkTsCheckerWebpackPlugin(Object.assign({}, options, { silent: true }));
+    plugin = new ForkTsCheckerWebpackPlugin(
+      Object.assign({}, options, { silent: true })
+    );
 
     compiler = webpack({
       ...(webpackMajorVersion >= 4 ? { mode: 'development' } : {}),
@@ -33,7 +36,7 @@ describe('[INTEGRATION] vue', function () {
       resolve: {
         extensions: ['.ts', '.js', '.vue', '.json'],
         alias: {
-          '@': path.resolve(__dirname, './vue/src'),
+          '@': path.resolve(__dirname, './vue/src')
         }
       },
       module: {
@@ -65,7 +68,10 @@ describe('[INTEGRATION] vue', function () {
 
     files = {
       'example.vue': path.resolve(compiler.context, 'src/example.vue'),
-      'syntacticError.ts': path.resolve(compiler.context, 'src/syntacticError.ts')
+      'syntacticError.ts': path.resolve(
+        compiler.context,
+        'src/syntacticError.ts'
+      )
     };
 
     checker = new IncrementalChecker(
@@ -81,71 +87,75 @@ describe('[INTEGRATION] vue', function () {
     checker.nextIteration();
   }
 
-  it('should create a Vue program config if vue=true', function () {
+  it('should create a Vue program config if vue=true', function() {
     createCompiler({ vue: true });
 
     var fileFound;
-    
-    fileFound = checker.programConfig.fileNames.indexOf(files['example.vue']) >= 0;
+
+    fileFound =
+      checker.programConfig.fileNames.indexOf(files['example.vue']) >= 0;
     expect(fileFound).to.be.true;
-    
-    fileFound = checker.programConfig.fileNames.indexOf(files['syntacticError.ts']) >= 0;
+
+    fileFound =
+      checker.programConfig.fileNames.indexOf(files['syntacticError.ts']) >= 0;
     expect(fileFound).to.be.true;
   });
 
-  it('should not create a Vue program config if vue=false', function () {
+  it('should not create a Vue program config if vue=false', function() {
     createCompiler();
 
-    var fileFound;    
-    
-    fileFound = checker.programConfig.fileNames.indexOf(files['example.vue']) >= 0;
+    var fileFound;
+
+    fileFound =
+      checker.programConfig.fileNames.indexOf(files['example.vue']) >= 0;
     expect(fileFound).to.be.false;
-    
-    fileFound = checker.programConfig.fileNames.indexOf(files['syntacticError.ts']) >= 0;
+
+    fileFound =
+      checker.programConfig.fileNames.indexOf(files['syntacticError.ts']) >= 0;
     expect(fileFound).to.be.true;
   });
 
-  it('should create a Vue program if vue=true', function () {
+  it('should create a Vue program if vue=true', function() {
     createCompiler({ vue: true });
 
     var source;
 
     source = checker.program.getSourceFile(files['example.vue']);
     expect(source).to.not.be.undefined;
-    
+
     source = checker.program.getSourceFile(files['syntacticError.ts']);
-    expect(source).to.not.be.undefined;  
+    expect(source).to.not.be.undefined;
   });
 
-  it('should not create a Vue program if vue=false', function () {
+  it('should not create a Vue program if vue=false', function() {
     createCompiler();
-    
+
     var source;
-    
+
     source = checker.program.getSourceFile(files['example.vue']);
     expect(source).to.be.undefined;
-    
+
     source = checker.program.getSourceFile(files['syntacticError.ts']);
-    expect(source).to.not.be.undefined;  
+    expect(source).to.not.be.undefined;
   });
 
-  it('should get syntactic diagnostics from Vue program', function () {
+  it('should get syntactic diagnostics from Vue program', function() {
     createCompiler({ tslint: true, vue: true });
 
     const diagnostics = checker.program.getSyntacticDiagnostics();
-    expect(diagnostics.length).to.be.equal(1);    
+    expect(diagnostics.length).to.be.equal(1);
   });
 
-  it('should not find syntactic errors when checkSyntacticErrors is false', function (callback) {
+  it('should not find syntactic errors when checkSyntacticErrors is false', function(callback) {
     createCompiler({ tslint: true, vue: true });
-    
+
     compiler.run(function(error, stats) {
       expect(stats.compilation.errors.length).to.be.equal(1);
       callback();
     });
   });
 
-  it('should not report no-consecutive-blank-lines tslint rule', function (callback) {
+  it('should not report no-consecutive-blank-lines tslint rule', function(callback) {
     createCompiler({ tslint: true, vue: true });
 
     compiler.run(function(error, stats) {
@@ -156,22 +166,24 @@ describe('[INTEGRATION] vue', function () {
     });
   });
 
-  it('should find syntactic errors when checkSyntacticErrors is true', function (callback) {
+  it('should find syntactic errors when checkSyntacticErrors is true', function(callback) {
     createCompiler({ tslint: true, vue: true, checkSyntacticErrors: true });
-    
+
     compiler.run(function(error, stats) {
       expect(stats.compilation.errors.length).to.be.equal(2);
       callback();
     });
   });
 
-  it('should resolve src attribute but not report not found error', function (callback) {
+  it('should resolve src attribute but not report not found error', function(callback) {
     createCompiler({ vue: true, tsconfig: 'tsconfig-attrs.json' });
 
     compiler.run(function(error, stats) {
       const errors = stats.compilation.errors;
       expect(errors.length).to.be.equal(1);
-      expect(errors[0].file).to.match(/test\/integration\/vue\/src\/attrs\/test.ts$/);
+      expect(errors[0].file).to.match(
+        /test\/integration\/vue\/src\/attrs\/test.ts$/
+      );
       callback();
     });
   });
@@ -183,9 +195,12 @@ describe('[INTEGRATION] vue', function () {
     'example-jsx.vue',
     'example-nolang.vue'
   ].forEach(fileName => {
-    it('should be able to extract script from ' + fileName, function () {
+    it('should be able to extract script from ' + fileName, function() {
       createCompiler({ vue: true, tsconfig: 'tsconfig-langs.json' });
-      var sourceFilePath = path.resolve(compiler.context, 'src/langs/' + fileName)
+      var sourceFilePath = path.resolve(
+        compiler.context,
+        'src/langs/' + fileName
+      );
       var source = checker.program.getSourceFile(sourceFilePath);
       expect(source).to.not.be.undefined;
       // remove padding lines
@@ -208,7 +223,7 @@ describe('[INTEGRATION] vue', function () {
     return ret;
   }
 
-  describe('should be able to compile *.vue with each lang', function () {
+  describe('should be able to compile *.vue with each lang', function() {
     var errors;
     before(function(callback) {
       createCompiler({ vue: true, tsconfig: 'tsconfig-langs.json' });
@@ -217,24 +232,24 @@ describe('[INTEGRATION] vue', function () {
         callback();
       });
     });
-    it("lang=ts", function() {
+    it('lang=ts', function() {
       expect(errors['example-ts.vue'].length).to.be.equal(0);
-    })
-    it("lang=tsx", function() {
+    });
+    it('lang=tsx', function() {
       expect(errors['example-tsx.vue'].length).to.be.equal(0);
     });
-    it("lang=js", function() {
+    it('lang=js', function() {
       expect(errors['example-js.vue'].length).to.be.equal(0);
     });
-    it("lang=jsx", function() {
+    it('lang=jsx', function() {
       expect(errors['example-jsx.vue'].length).to.be.equal(0);
     });
-    it("no lang", function() {
+    it('no lang', function() {
       expect(errors['example-nolang.vue'].length).to.be.equal(0);
     });
   });
 
-  describe('should be able to detect errors in *.vue', function () {
+  describe('should be able to detect errors in *.vue', function() {
     var errors;
     before(function(callback) {
       // tsconfig-langs-strict.json === tsconfig-langs.json + noUnusedLocals
@@ -244,21 +259,25 @@ describe('[INTEGRATION] vue', function () {
         callback();
       });
     });
-    it("lang=ts", function() {
+    it('lang=ts', function() {
       expect(errors['example-ts.vue'].length).to.be.equal(1);
-      expect(errors['example-ts.vue'][0].rawMessage).to.match(/'a' is declared but/);
-    })
-    it("lang=tsx", function() {
-      expect(errors['example-tsx.vue'].length).to.be.equal(1);
-      expect(errors['example-tsx.vue'][0].rawMessage).to.match(/'a' is declared but/);
+      expect(errors['example-ts.vue'][0].rawMessage).to.match(
+        /'a' is declared but/
+      );
     });
-    it("lang=js", function() {
+    it('lang=tsx', function() {
+      expect(errors['example-tsx.vue'].length).to.be.equal(1);
+      expect(errors['example-tsx.vue'][0].rawMessage).to.match(
+        /'a' is declared but/
+      );
+    });
+    it('lang=js', function() {
       expect(errors['example-js.vue'].length).to.be.equal(0);
     });
-    it("lang=jsx", function() {
+    it('lang=jsx', function() {
       expect(errors['example-jsx.vue'].length).to.be.equal(0);
     });
-    it("no lang", function() {
+    it('no lang', function() {
       expect(errors['example-nolang.vue'].length).to.be.equal(0);
     });
   });
@@ -280,7 +299,8 @@ describe('[INTEGRATION] vue', function () {
     });
     it('should be able to import by path from baseUrl', function() {
       expect(
-        errors.filter(e => e.rawMessage.indexOf('imports/Component2.vue') >= 0).length
+        errors.filter(e => e.rawMessage.indexOf('imports/Component2.vue') >= 0)
+          .length
       ).to.be.equal(0);
     });
     it('should be able to import by compilerOptions.paths setting', function() {

--- a/test/unit/CancellationToken.spec.js
+++ b/test/unit/CancellationToken.spec.js
@@ -7,21 +7,22 @@ var beforeEach = require('mocha').beforeEach;
 var afterEach = require('mocha').afterEach;
 var expect = require('chai').expect;
 var mockFs = require('mock-fs');
-var CancellationToken = require('../../lib/CancellationToken').CancellationToken;
+var CancellationToken = require('../../lib/CancellationToken')
+  .CancellationToken;
 
-describe('[UNIT] CancellationToken', function () {
-  beforeEach(function () {
+describe('[UNIT] CancellationToken', function() {
+  beforeEach(function() {
     var fsTree = {};
     fsTree[os.tmpdir()] = mockFs.directory();
 
     mockFs(fsTree);
   });
 
-  afterEach(function () {
+  afterEach(function() {
     mockFs.restore();
   });
 
-  it('should create valid cancellation token', function () {
+  it('should create valid cancellation token', function() {
     var tokenA = new CancellationToken();
     expect(tokenA.isCancellationRequested()).to.be.false;
 
@@ -35,34 +36,46 @@ describe('[UNIT] CancellationToken', function () {
     expect(tokenD.isCancellationRequested()).to.be.true;
   });
 
-  it('should serialize to JSON', function () {
+  it('should serialize to JSON', function() {
     var tokenA = new CancellationToken();
     var json = JSON.stringify(tokenA);
 
     expect(json).to.be.a('string');
-    expect(function() { JSON.parse(json); }).to.not.throw(Error);
+    expect(function() {
+      JSON.parse(json);
+    }).to.not.throw(Error);
     expect(JSON.parse(json)).to.be.a('object');
 
     var tokenB = CancellationToken.createFromJSON(JSON.parse(json));
-    expect(tokenA.getCancellationFilePath()).to.be.equal(tokenB.getCancellationFilePath());
-    expect(tokenA.isCancellationRequested()).to.be.equal(tokenB.isCancellationRequested());
+    expect(tokenA.getCancellationFilePath()).to.be.equal(
+      tokenB.getCancellationFilePath()
+    );
+    expect(tokenA.isCancellationRequested()).to.be.equal(
+      tokenB.isCancellationRequested()
+    );
   });
 
-  it('should generate path in os.tmpdir() directory', function () {
+  it('should generate path in os.tmpdir() directory', function() {
     var tokenA = new CancellationToken();
 
-    expect(tokenA.getCancellationFilePath().indexOf(os.tmpdir())).to.be.equal(0);
+    expect(tokenA.getCancellationFilePath().indexOf(os.tmpdir())).to.be.equal(
+      0
+    );
   });
 
-  it('should throw ts.OperationCanceledException error on cancelled', function () {
+  it('should throw ts.OperationCanceledException error on cancelled', function() {
     var tokenA = new CancellationToken();
-    expect(function () { tokenA.throwIfCancellationRequested(); }).to.not.throw();
+    expect(function() {
+      tokenA.throwIfCancellationRequested();
+    }).to.not.throw();
 
     var tokenB = new CancellationToken('rgeer#R23r$#T$3t#$t43', true);
-    expect(function () { tokenB.throwIfCancellationRequested(); }).to.throw(ts.OperationCanceledException);
+    expect(function() {
+      tokenB.throwIfCancellationRequested();
+    }).to.throw(ts.OperationCanceledException);
   });
 
-  it('should write file in filesystem on requestCancellation', function () {
+  it('should write file in filesystem on requestCancellation', function() {
     var tokenA = new CancellationToken();
     tokenA.requestCancellation();
 
@@ -70,7 +83,7 @@ describe('[UNIT] CancellationToken', function () {
     expect(fs.existsSync(tokenA.getCancellationFilePath())).to.be.true;
   });
 
-  it('should cleanup file on cleanupCancellation', function () {
+  it('should cleanup file on cleanupCancellation', function() {
     var tokenA = new CancellationToken();
     tokenA.requestCancellation();
     tokenA.cleanupCancellation();
@@ -79,18 +92,24 @@ describe('[UNIT] CancellationToken', function () {
     expect(fs.existsSync(tokenA.getCancellationFilePath())).to.be.false;
 
     // make sure we can call it as many times as we want to
-    expect(function() { tokenA.cleanupCancellation(); }).to.not.throw(Error);
+    expect(function() {
+      tokenA.cleanupCancellation();
+    }).to.not.throw(Error);
     expect(tokenA.isCancellationRequested()).to.be.false;
   });
 
-  it('should not throw error on cleanupCancellation with no file exists', function () {
+  it('should not throw error on cleanupCancellation with no file exists', function() {
     var tokenA = new CancellationToken('some_file_that_doesnt_exists', true);
 
-    expect(function() { tokenA.cleanupCancellation(); }).to.not.throw();
-    expect(function() { tokenA.cleanupCancellation(); }).to.not.throw();
+    expect(function() {
+      tokenA.cleanupCancellation();
+    }).to.not.throw();
+    expect(function() {
+      tokenA.cleanupCancellation();
+    }).to.not.throw();
   });
 
-  it('should throttle check for 10ms', function (done) {
+  it('should throttle check for 10ms', function(done) {
     var tokenA = new CancellationToken();
     var tokenB = CancellationToken.createFromJSON(tokenA.toJSON());
     var start = Date.now();
@@ -107,7 +126,7 @@ describe('[UNIT] CancellationToken', function () {
       expect(tokenB.isCancellationRequested()).to.be.false;
     }
 
-    setTimeout(function () {
+    setTimeout(function() {
       expect(tokenB.isCancellationRequested()).to.be.true;
       done();
     }, 11);

--- a/test/unit/FileRegister.spec.js
+++ b/test/unit/FileRegister.spec.js
@@ -4,17 +4,17 @@ var beforeEach = require('mocha').beforeEach;
 var expect = require('chai').expect;
 var FilesRegister = require('../../lib/FilesRegister').FilesRegister;
 
-describe('[UNIT] FilesRegister', function () {
+describe('[UNIT] FilesRegister', function() {
   var register;
-  beforeEach(function () {
-    register = new FilesRegister(function () {
+  beforeEach(function() {
+    register = new FilesRegister(function() {
       return {
         test: true
       };
     });
   });
 
-  it('should add and remove files', function () {
+  it('should add and remove files', function() {
     register.add('/test');
     register.add('/test2');
     expect(register.has('/test')).to.be.true;
@@ -23,37 +23,52 @@ describe('[UNIT] FilesRegister', function () {
     expect(register.has('/test')).to.be.false;
     expect(register.has('/test2')).to.be.true;
 
-    expect(function() { register.remove('/test'); }).to.not.throw();
+    expect(function() {
+      register.remove('/test');
+    }).to.not.throw();
     register.remove('/test2');
     expect(register.has('/test')).to.be.false;
     expect(register.has('/test2')).to.be.false;
   });
 
-  it('should get file that exists in register', function () {
+  it('should get file that exists in register', function() {
     register.add('/test');
-    expect(function() { register.get('/test'); }).to.not.throw();
-    expect(function() { register.get('/test2'); }).to.throw();
+    expect(function() {
+      register.get('/test');
+    }).to.not.throw();
+    expect(function() {
+      register.get('/test2');
+    }).to.throw();
     expect(register.get('/test')).to.be.a('object');
-    expect(Object.keys(register.get('/test'))).to.be.deep.equal(['mtime', 'data']);
+    expect(Object.keys(register.get('/test'))).to.be.deep.equal([
+      'mtime',
+      'data'
+    ]);
   });
 
-  it('should list all keys in register', function () {
+  it('should list all keys in register', function() {
     register.add('/test');
     register.add('/test/foo');
     register.add('/test/foo/bar');
-    expect(register.keys()).to.be.deep.equal(['/test', '/test/foo', '/test/foo/bar']);
+    expect(register.keys()).to.be.deep.equal([
+      '/test',
+      '/test/foo',
+      '/test/foo/bar'
+    ]);
 
     register.remove('/test');
     expect(register.keys()).to.be.deep.equal(['/test/foo', '/test/foo/bar']);
   });
 
-  it('should get data from file', function () {
+  it('should get data from file', function() {
     register.add('/test');
     expect(register.getData('/test')).to.be.deep.equal({ test: true });
-    expect(function() { register.getData('/test2'); }).to.throw(Error);
+    expect(function() {
+      register.getData('/test2');
+    }).to.throw(Error);
   });
 
-  it('should ensure if file exists', function () {
+  it('should ensure if file exists', function() {
     expect(register.has('/test')).to.be.false;
     register.ensure('/test');
     expect(register.has('/test')).to.be.true;
@@ -63,20 +78,20 @@ describe('[UNIT] FilesRegister', function () {
     expect(reference).to.be.equal(register.get('/test'));
   });
 
-  it('should mutate existing data', function () {
+  it('should mutate existing data', function() {
     register.add('/test');
     var dataReference = register.getData('/test');
     expect(dataReference.test).to.be.true;
-    register.mutateData('/test', function (data) {
+    register.mutateData('/test', function(data) {
       data.test = false;
     });
     expect(dataReference).to.be.equal(register.getData('/test'));
     expect(dataReference.test).to.be.false;
   });
 
-  it('should set mtime and reset data if mtime changes', function () {
+  it('should set mtime and reset data if mtime changes', function() {
     register.add('/test');
-    register.mutateData('/test', function (data) {
+    register.mutateData('/test', function(data) {
       data.test = false;
     });
     expect(register.getData('/test').test).to.be.false;
@@ -85,7 +100,7 @@ describe('[UNIT] FilesRegister', function () {
     register.setMtime('/test', 1000);
     expect(register.getMtime('/test')).to.be.equal(1000);
     expect(register.getData('/test').test).to.be.true;
-    register.mutateData('/test', function (data) {
+    register.mutateData('/test', function(data) {
       data.test = false;
     });
     expect(register.getData('/test').test).to.be.false;

--- a/test/unit/FilesWatcher.spec.js
+++ b/test/unit/FilesWatcher.spec.js
@@ -6,13 +6,13 @@ var sinon = require('sinon');
 var expect = require('chai').expect;
 var mockRequire = require('mock-require');
 
-describe('[UNIT] FilesWatcher', function () {
+describe('[UNIT] FilesWatcher', function() {
   var FilesWatcher;
   var watcher;
   var watchStub;
   var watcherStub;
 
-  beforeEach(function () {
+  beforeEach(function() {
     watcherStub = {
       on: sinon.stub().returnsThis()
     };
@@ -21,24 +21,21 @@ describe('[UNIT] FilesWatcher', function () {
     mockRequire('chokidar', { watch: watchStub });
     FilesWatcher = mockRequire.reRequire('../../lib/FilesWatcher').FilesWatcher;
 
-    watcher = new FilesWatcher(
-      ['/test', '/bar'],
-      ['.ext1', '.ext2']
-    );
+    watcher = new FilesWatcher(['/test', '/bar'], ['.ext1', '.ext2']);
   });
 
-  afterEach(function () {
+  afterEach(function() {
     mockRequire.stopAll();
   });
 
-  it('should check if file is supported', function () {
+  it('should check if file is supported', function() {
     expect(watcher.isFileSupported('/foo.ext1')).to.be.true;
     expect(watcher.isFileSupported('/foo.ext2')).to.be.true;
     expect(watcher.isFileSupported('/foo.txt')).to.be.false;
     expect(watcher.isFileSupported('/foo.ext1.txt')).to.be.false;
   });
 
-  it('should check if is watching file', function () {
+  it('should check if is watching file', function() {
     expect(watcher.isWatchingFile('/test/a.ext1')).to.be.false;
     expect(watcher.isWatchingFile('/test/a.txt')).to.be.false;
     expect(watcher.isWatchingFile('/test')).to.be.false;
@@ -52,18 +49,18 @@ describe('[UNIT] FilesWatcher', function () {
     expect(watcher.isWatchingFile('/foo/a.ext1')).to.be.false;
   });
 
-  it('should check if watcher is watching', function () {
+  it('should check if watcher is watching', function() {
     expect(watcher.isWatching()).to.be.false;
     watcher.watch();
     expect(watcher.isWatching()).to.be.true;
-    expect(function () { watcher.watch(); }).to.throw(Error);
+    expect(function() {
+      watcher.watch();
+    }).to.throw(Error);
   });
 
-  it('should add and remove listeners', function () {
-    var listenerA = function () {
-    };
-    var listenerB = function () {
-    };
+  it('should add and remove listeners', function() {
+    var listenerA = function() {};
+    var listenerB = function() {};
 
     expect(watcher.listeners).to.be.a('object');
     watcher.on('event', listenerA);
@@ -74,19 +71,23 @@ describe('[UNIT] FilesWatcher', function () {
     watcher.off('event', listenerA);
     expect(watcher.listeners['event']).to.be.deep.equal([listenerB]);
 
-    expect(function() { watcher.off('event', listenerA); }).to.not.throw();
+    expect(function() {
+      watcher.off('event', listenerA);
+    }).to.not.throw();
     expect(watcher.listeners['event']).to.be.deep.equal([listenerB]);
 
     watcher.off('event', listenerB);
     expect(watcher.listeners['event']).to.be.deep.equal([]);
 
     expect(watcher.listeners['foo']).to.be.undefined;
-    expect(function() { watcher.off('foo', listenerA); }).to.not.throw();
+    expect(function() {
+      watcher.off('foo', listenerA);
+    }).to.not.throw();
 
     expect(watcher.listeners['foo']).to.be.undefined;
   });
 
-  it('should watch filesystem using chokidar', function () {
+  it('should watch filesystem using chokidar', function() {
     expect(watchStub.called).to.be.false;
 
     var changeListenerA = sinon.spy();
@@ -105,8 +106,12 @@ describe('[UNIT] FilesWatcher', function () {
     expect(triggerChange).to.be.a('function');
     expect(triggerUnlink).to.be.a('function');
 
-    expect(function() { triggerChange('/test/test.ext1', {}); }).to.not.throw();
-    expect(function() { triggerUnlink('/test/test.ext1', {}); }).to.not.throw();
+    expect(function() {
+      triggerChange('/test/test.ext1', {});
+    }).to.not.throw();
+    expect(function() {
+      triggerUnlink('/test/test.ext1', {});
+    }).to.not.throw();
 
     watcher.on('change', changeListenerA);
     watcher.on('change', changeListenerB);
@@ -125,7 +130,6 @@ describe('[UNIT] FilesWatcher', function () {
     triggerChange('/test/test.ext1', {});
     expect(changeListenerB.called).to.be.true;
     expect(changeListenerB.called).to.be.true;
-
 
     // manually trigger unlink listeners
     triggerUnlink('/test/test.txt');

--- a/test/unit/IncrementalChecker.spec.js
+++ b/test/unit/IncrementalChecker.spec.js
@@ -4,20 +4,21 @@ var expect = require('chai').expect;
 var path = require('path');
 var minimatch = require('minimatch');
 
-var IncrementalChecker = require('../../lib/IncrementalChecker').IncrementalChecker;
+var IncrementalChecker = require('../../lib/IncrementalChecker')
+  .IncrementalChecker;
 
-describe('[UNIT] IncrementalChecker', function () {
+describe('[UNIT] IncrementalChecker', function() {
   describe('isFileExcluded', function() {
     it('should properly filter definition files and listed exclusions', function() {
       var linterConfig = {
         linterOptions: {
-          exclude: [
-            'src/formatter/**/*.ts'
-          ]
+          exclude: ['src/formatter/**/*.ts']
         }
       };
 
-      var exclusions = linterConfig.linterOptions.exclude.map(function(pattern) {
+      var exclusions = linterConfig.linterOptions.exclude.map(function(
+        pattern
+      ) {
         return new minimatch.Minimatch(path.resolve(pattern));
       });
 
@@ -25,7 +26,7 @@ describe('[UNIT] IncrementalChecker', function () {
         'src/formatter/codeframeFormatter.ts',
         'src/formatter/defaultFormatter.ts',
         'src/service.ts',
-        'node_modules/tslint/lib/configuration.d.ts',
+        'node_modules/tslint/lib/configuration.d.ts'
       ].map(function(p) {
         return path.resolve(p);
       });

--- a/test/unit/NormalizedMessage.spec.js
+++ b/test/unit/NormalizedMessage.spec.js
@@ -2,13 +2,14 @@ var describe = require('mocha').describe;
 var it = require('mocha').it;
 var beforeEach = require('mocha').beforeEach;
 var expect = require('chai').expect;
-var NormalizedMessage = require('../../lib/NormalizedMessage').NormalizedMessage;
+var NormalizedMessage = require('../../lib/NormalizedMessage')
+  .NormalizedMessage;
 
-describe('[UNIT] NormalizedMessage', function () {
+describe('[UNIT] NormalizedMessage', function() {
   var diagnosticMessage;
   var lintMessage;
 
-  beforeEach(function () {
+  beforeEach(function() {
     diagnosticMessage = new NormalizedMessage({
       type: 'diagnostic',
       code: 123,
@@ -30,7 +31,7 @@ describe('[UNIT] NormalizedMessage', function () {
     });
   });
 
-  it('should create new message', function () {
+  it('should create new message', function() {
     expect(diagnosticMessage.getType()).to.be.equal('diagnostic');
     expect(diagnosticMessage.getCode()).to.be.equal(123);
     expect(diagnosticMessage.getSeverity()).to.be.equal('error');
@@ -40,7 +41,7 @@ describe('[UNIT] NormalizedMessage', function () {
     expect(diagnosticMessage.getCharacter()).to.be.equal(12);
   });
 
-  it('should serialize and create from json', function () {
+  it('should serialize and create from json', function() {
     var json = diagnosticMessage.toJSON();
 
     expect(json).to.be.object;
@@ -50,33 +51,41 @@ describe('[UNIT] NormalizedMessage', function () {
     expect(jsonMessage).to.be.instanceof(NormalizedMessage);
     expect(jsonMessage.getType()).to.be.equal(diagnosticMessage.getType());
     expect(jsonMessage.getCode()).to.be.equal(diagnosticMessage.getCode());
-    expect(jsonMessage.getSeverity()).to.be.equal(diagnosticMessage.getSeverity());
-    expect(jsonMessage.getContent()).to.be.equal(diagnosticMessage.getContent());
+    expect(jsonMessage.getSeverity()).to.be.equal(
+      diagnosticMessage.getSeverity()
+    );
+    expect(jsonMessage.getContent()).to.be.equal(
+      diagnosticMessage.getContent()
+    );
     expect(jsonMessage.getFile()).to.be.equal(diagnosticMessage.getFile());
     expect(jsonMessage.getLine()).to.be.equal(diagnosticMessage.getLine());
-    expect(jsonMessage.getCharacter()).to.be.equal(diagnosticMessage.getCharacter());
+    expect(jsonMessage.getCharacter()).to.be.equal(
+      diagnosticMessage.getCharacter()
+    );
   });
 
-  it('should check type', function () {
+  it('should check type', function() {
     expect(diagnosticMessage.isDiagnosticType()).to.be.true;
     expect(diagnosticMessage.isLintType()).to.be.false;
     expect(lintMessage.isDiagnosticType()).to.be.false;
     expect(lintMessage.isLintType()).to.be.true;
   });
 
-  it('should return formatted code', function () {
-    expect(diagnosticMessage.getFormattedCode()).to.be.equal('TS' + diagnosticMessage.getCode());
+  it('should return formatted code', function() {
+    expect(diagnosticMessage.getFormattedCode()).to.be.equal(
+      'TS' + diagnosticMessage.getCode()
+    );
     expect(lintMessage.getFormattedCode()).to.be.equal(lintMessage.getCode());
   });
 
-  it('should check severity', function () {
+  it('should check severity', function() {
     expect(diagnosticMessage.isErrorSeverity()).to.be.true;
     expect(diagnosticMessage.isWarningSeverity()).to.be.false;
     expect(lintMessage.isErrorSeverity()).to.be.false;
     expect(lintMessage.isWarningSeverity()).to.be.true;
   });
 
-  it('should compare numbers in asc', function () {
+  it('should compare numbers in asc', function() {
     expect(NormalizedMessage.compareNumbers(123, 126)).to.be.lessThan(0);
     expect(NormalizedMessage.compareNumbers(-123, 126)).to.be.lessThan(0);
     expect(NormalizedMessage.compareNumbers(-126, -123)).to.be.lessThan(0);
@@ -88,49 +97,87 @@ describe('[UNIT] NormalizedMessage', function () {
     expect(NormalizedMessage.compareNumbers(-15, -15)).to.be.equal(0);
   });
 
-  it('should compare strings in asc', function () {
-    expect(NormalizedMessage.compareOptionalStrings('abc', 'xyz')).to.be.lessThan(0);
-    expect(NormalizedMessage.compareOptionalStrings(undefined, 'xyz')).to.be.lessThan(0);
-    expect(NormalizedMessage.compareOptionalStrings(null, 'xyz')).to.be.lessThan(0);
-    expect(NormalizedMessage.compareOptionalStrings('xyz', 'abc')).to.be.greaterThan(0);
-    expect(NormalizedMessage.compareOptionalStrings('xyz', undefined)).to.be.greaterThan(0);
-    expect(NormalizedMessage.compareOptionalStrings('xyz', null)).to.be.greaterThan(0);
-    expect(NormalizedMessage.compareOptionalStrings('xyz', 'xyz')).to.be.equal(0);
-    expect(NormalizedMessage.compareOptionalStrings(undefined, undefined)).to.be.equal(0);
+  it('should compare strings in asc', function() {
+    expect(
+      NormalizedMessage.compareOptionalStrings('abc', 'xyz')
+    ).to.be.lessThan(0);
+    expect(
+      NormalizedMessage.compareOptionalStrings(undefined, 'xyz')
+    ).to.be.lessThan(0);
+    expect(
+      NormalizedMessage.compareOptionalStrings(null, 'xyz')
+    ).to.be.lessThan(0);
+    expect(
+      NormalizedMessage.compareOptionalStrings('xyz', 'abc')
+    ).to.be.greaterThan(0);
+    expect(
+      NormalizedMessage.compareOptionalStrings('xyz', undefined)
+    ).to.be.greaterThan(0);
+    expect(
+      NormalizedMessage.compareOptionalStrings('xyz', null)
+    ).to.be.greaterThan(0);
+    expect(NormalizedMessage.compareOptionalStrings('xyz', 'xyz')).to.be.equal(
+      0
+    );
+    expect(
+      NormalizedMessage.compareOptionalStrings(undefined, undefined)
+    ).to.be.equal(0);
     expect(NormalizedMessage.compareOptionalStrings(null, null)).to.be.equal(0);
   });
 
-  it('should compare severities in asc', function () {
-    expect(NormalizedMessage.compareSeverities('warning', 'error')).to.be.lessThan(0);
-    expect(NormalizedMessage.compareSeverities('unknown', 'warning')).to.be.lessThan(0);
-    expect(NormalizedMessage.compareSeverities('error', 'warning')).to.be.greaterThan(0);
-    expect(NormalizedMessage.compareSeverities('warning', 'unknown')).to.be.greaterThan(0);
-    expect(NormalizedMessage.compareSeverities('error', 'error')).to.be.equal(0);
-    expect(NormalizedMessage.compareSeverities('warning', 'warning')).to.be.equal(0);
-    expect(NormalizedMessage.compareSeverities('unknown', 'unknown')).to.be.equal(0);
-    expect(NormalizedMessage.compareSeverities('unknown', 'another_unknown')).to.be.equal(0);
+  it('should compare severities in asc', function() {
+    expect(
+      NormalizedMessage.compareSeverities('warning', 'error')
+    ).to.be.lessThan(0);
+    expect(
+      NormalizedMessage.compareSeverities('unknown', 'warning')
+    ).to.be.lessThan(0);
+    expect(
+      NormalizedMessage.compareSeverities('error', 'warning')
+    ).to.be.greaterThan(0);
+    expect(
+      NormalizedMessage.compareSeverities('warning', 'unknown')
+    ).to.be.greaterThan(0);
+    expect(NormalizedMessage.compareSeverities('error', 'error')).to.be.equal(
+      0
+    );
+    expect(
+      NormalizedMessage.compareSeverities('warning', 'warning')
+    ).to.be.equal(0);
+    expect(
+      NormalizedMessage.compareSeverities('unknown', 'unknown')
+    ).to.be.equal(0);
+    expect(
+      NormalizedMessage.compareSeverities('unknown', 'another_unknown')
+    ).to.be.equal(0);
   });
 
-  it('should compare types in asc', function () {
-    expect(NormalizedMessage.compareTypes('lint', 'diagnostic')).to.be.lessThan(0);
+  it('should compare types in asc', function() {
+    expect(NormalizedMessage.compareTypes('lint', 'diagnostic')).to.be.lessThan(
+      0
+    );
     expect(NormalizedMessage.compareTypes('unknown', 'lint')).to.be.lessThan(0);
-    expect(NormalizedMessage.compareTypes('diagnostic', 'lint')).to.be.greaterThan(0);
-    expect(NormalizedMessage.compareTypes('lint', 'unknown')).to.be.greaterThan(0);
-    expect(NormalizedMessage.compareTypes('diagnostic', 'diagnostic')).to.be.equal(0);
+    expect(
+      NormalizedMessage.compareTypes('diagnostic', 'lint')
+    ).to.be.greaterThan(0);
+    expect(NormalizedMessage.compareTypes('lint', 'unknown')).to.be.greaterThan(
+      0
+    );
+    expect(
+      NormalizedMessage.compareTypes('diagnostic', 'diagnostic')
+    ).to.be.equal(0);
     expect(NormalizedMessage.compareTypes('lint', 'lint')).to.be.equal(0);
     expect(NormalizedMessage.compareTypes('unknown', 'unknown')).to.be.equal(0);
-    expect(NormalizedMessage.compareTypes('unknown', 'another_unknown')).to.be.equal(0);
+    expect(
+      NormalizedMessage.compareTypes('unknown', 'another_unknown')
+    ).to.be.equal(0);
   });
 
-  it('should compare messages', function () {
+  it('should compare messages', function() {
     var messageA = diagnosticMessage;
-    function buildMessage (diff) {
+    function buildMessage(diff) {
       return NormalizedMessage.createFromJSON(
-        Object.assign(
-          {},
-          messageA.toJSON(),
-          diff
-        )
+        Object.assign({}, messageA.toJSON(), diff)
       );
     }
 
@@ -138,16 +185,30 @@ describe('[UNIT] NormalizedMessage', function () {
     expect(NormalizedMessage.compare(undefined, messageA)).to.be.lessThan(0);
     expect(NormalizedMessage.compare(messageA, {})).to.be.greaterThan(0);
     expect(NormalizedMessage.compare({}, messageA)).to.be.lessThan(0);
-    expect(NormalizedMessage.compare(messageA, buildMessage({ type: 'lint' }))).to.be.greaterThan(0);
-    expect(NormalizedMessage.compare(messageA, buildMessage({ file: '/goo/bar.ts' }))).to.be.lessThan(0);
-    expect(NormalizedMessage.compare(messageA, buildMessage({ severity: 'notice' }))).to.be.greaterThan(0);
-    expect(NormalizedMessage.compare(messageA, buildMessage({ line: 400 }))).to.be.greaterThan(0);
-    expect(NormalizedMessage.compare(messageA, buildMessage({ character: 200 }))).to.be.lessThan(0);
-    expect(NormalizedMessage.compare(messageA, buildMessage({ code: 100 }))).to.be.greaterThan(0);
-    expect(NormalizedMessage.compare(messageA, buildMessage({ content: 'bar' }))).to.be.greaterThan(0);
+    expect(
+      NormalizedMessage.compare(messageA, buildMessage({ type: 'lint' }))
+    ).to.be.greaterThan(0);
+    expect(
+      NormalizedMessage.compare(messageA, buildMessage({ file: '/goo/bar.ts' }))
+    ).to.be.lessThan(0);
+    expect(
+      NormalizedMessage.compare(messageA, buildMessage({ severity: 'notice' }))
+    ).to.be.greaterThan(0);
+    expect(
+      NormalizedMessage.compare(messageA, buildMessage({ line: 400 }))
+    ).to.be.greaterThan(0);
+    expect(
+      NormalizedMessage.compare(messageA, buildMessage({ character: 200 }))
+    ).to.be.lessThan(0);
+    expect(
+      NormalizedMessage.compare(messageA, buildMessage({ code: 100 }))
+    ).to.be.greaterThan(0);
+    expect(
+      NormalizedMessage.compare(messageA, buildMessage({ content: 'bar' }))
+    ).to.be.greaterThan(0);
   });
 
-  it('should check if messages are equal', function () {
+  it('should check if messages are equal', function() {
     var messageA = diagnosticMessage;
     var messageB = NormalizedMessage.createFromJSON(diagnosticMessage.toJSON());
     var messageC = lintMessage;
@@ -161,13 +222,21 @@ describe('[UNIT] NormalizedMessage', function () {
     expect(NormalizedMessage.equals(messageC, messageD)).to.be.true;
   });
 
-  it('should deduplicate list of messages', function () {
+  it('should deduplicate list of messages', function() {
     var messageA = diagnosticMessage;
     var messageB = NormalizedMessage.createFromJSON(diagnosticMessage.toJSON());
     var messageC = lintMessage;
     var messageD = NormalizedMessage.createFromJSON(lintMessage.toJSON());
 
-    var messages = [messageA, messageC, messageD, messageD, messageB, messageC, messageA];
+    var messages = [
+      messageA,
+      messageC,
+      messageD,
+      messageD,
+      messageB,
+      messageC,
+      messageA
+    ];
     var unique = NormalizedMessage.deduplicate(messages);
 
     expect(unique).to.be.a('array');

--- a/test/unit/VueProgram.spec.js
+++ b/test/unit/VueProgram.spec.js
@@ -4,7 +4,7 @@ var it = require('mocha').it;
 var expect = require('chai').expect;
 var VueProgram = require('../../lib/VueProgram').VueProgram;
 
-describe('[UNIT] VueProgram', function () {
+describe('[UNIT] VueProgram', function() {
   it('should determine if file is a Vue file', function() {
     expect(VueProgram.isVue('./test.vue')).to.be.true;
     expect(VueProgram.isVue('../test.vue')).to.be.true;
@@ -22,19 +22,18 @@ describe('[UNIT] VueProgram', function () {
     var options = {
       baseUrl: '/baseurl',
       paths: {
-        '@/*': [
-          'src/*'
-        ]
+        '@/*': ['src/*']
       }
-    }
-    var moduleNames = [
-      './test.vue',
-      '../test.vue',
-      '../../test.vue'
-    ];
+    };
+    var moduleNames = ['./test.vue', '../test.vue', '../../test.vue'];
 
     var resolvedModuleNames = moduleNames.map(function(moduleName) {
-      return VueProgram.resolveNonTsModuleName(moduleName, containingFile, basedir, options);
+      return VueProgram.resolveNonTsModuleName(
+        moduleName,
+        containingFile,
+        basedir,
+        options
+      );
     });
 
     expect(resolvedModuleNames[0]).to.be.equal('/con/tain/ing/test.vue');
@@ -48,21 +47,41 @@ describe('[UNIT] VueProgram', function () {
     var options = {};
     var moduleName = '@/test.vue';
 
-    var resolvedModuleName = VueProgram.resolveNonTsModuleName(moduleName, containingFile, basedir, options);
+    var resolvedModuleName = VueProgram.resolveNonTsModuleName(
+      moduleName,
+      containingFile,
+      basedir,
+      options
+    );
     expect(resolvedModuleName).to.be.equal('/base/dir/src/test.vue');
 
     options.baseUrl = '/baseurl1';
-    resolvedModuleName = VueProgram.resolveNonTsModuleName(moduleName, containingFile, basedir, options);
+    resolvedModuleName = VueProgram.resolveNonTsModuleName(
+      moduleName,
+      containingFile,
+      basedir,
+      options
+    );
     expect(resolvedModuleName).to.be.equal('/baseurl1/src/test.vue');
 
-    options.baseUrl = '/baseurl2';    
+    options.baseUrl = '/baseurl2';
     options.paths = { '@/*': ['src1/*'] };
-    resolvedModuleName = VueProgram.resolveNonTsModuleName(moduleName, containingFile, basedir, options);
+    resolvedModuleName = VueProgram.resolveNonTsModuleName(
+      moduleName,
+      containingFile,
+      basedir,
+      options
+    );
     expect(resolvedModuleName).to.be.equal('/baseurl2/src1/test.vue');
 
-    options.baseUrl = '/baseurl3';    
+    options.baseUrl = '/baseurl3';
     options.paths = { '@/*': ['src1/src2/*'] };
-    resolvedModuleName = VueProgram.resolveNonTsModuleName(moduleName, containingFile, basedir, options);
+    resolvedModuleName = VueProgram.resolveNonTsModuleName(
+      moduleName,
+      containingFile,
+      basedir,
+      options
+    );
     expect(resolvedModuleName).to.be.equal('/baseurl3/src1/src2/test.vue');
   });
 
@@ -77,12 +96,11 @@ describe('[UNIT] VueProgram', function () {
     var result = VueProgram.resolveScriptBlock(content);
 
     expect(result.scriptKind).to.be.equal(ts.ScriptKind.TS);
-    expect(result.content).to.be.equal([
-      '',
-      'import Vue from "vue";',
-      'export default Vue.extend({});',
-      ''
-    ].join('\n'));
+    expect(result.content).to.be.equal(
+      ['', 'import Vue from "vue";', 'export default Vue.extend({});', ''].join(
+        '\n'
+      )
+    );
   });
 
   it('should pad lines', function() {
@@ -99,15 +117,17 @@ describe('[UNIT] VueProgram', function () {
 
     var result = VueProgram.resolveScriptBlock(content);
 
-    expect(result.content).to.be.equal([
-      '//',
-      '//',
-      '//',
-      '//',
-      '',
-      'import Vue from "vue";',
-      'export default Vue.extend({});',
-      ''
-    ].join('\n'));
+    expect(result.content).to.be.equal(
+      [
+        '//',
+        '//',
+        '//',
+        '//',
+        '',
+        'import Vue from "vue";',
+        'export default Vue.extend({});',
+        ''
+      ].join('\n')
+    );
   });
 });

--- a/test/unit/WorkResult.spec.js
+++ b/test/unit/WorkResult.spec.js
@@ -5,14 +5,14 @@ var expect = require('chai').expect;
 var sinon = require('sinon');
 var WorkResult = require('../../lib/WorkResult').WorkResult;
 
-describe('[UNIT] WorkResult', function () {
+describe('[UNIT] WorkResult', function() {
   var result;
 
-  beforeEach(function () {
+  beforeEach(function() {
     result = new WorkResult([1, 2, 3]);
   });
 
-  it('should allow result only from work domain', function () {
+  it('should allow result only from work domain', function() {
     expect(result.supports(1)).to.be.true;
     expect(result.supports(2)).to.be.true;
     expect(result.supports(3)).to.be.true;
@@ -21,14 +21,22 @@ describe('[UNIT] WorkResult', function () {
     expect(result.supports('something else')).to.be.false;
   });
 
-  it('should throw error if we want set or get result out of work domain', function () {
-    expect(function () { result.set(1, 'abc'); }).to.not.throw();
-    expect(function () { result.set(4, 'abc'); }).to.throw();
-    expect(function () { result.get(1); }).to.not.throw();
-    expect(function () { result.get(4); }).to.throw();
+  it('should throw error if we want set or get result out of work domain', function() {
+    expect(function() {
+      result.set(1, 'abc');
+    }).to.not.throw();
+    expect(function() {
+      result.set(4, 'abc');
+    }).to.throw();
+    expect(function() {
+      result.get(1);
+    }).to.not.throw();
+    expect(function() {
+      result.get(4);
+    }).to.throw();
   });
 
-  it('should set and get result', function () {
+  it('should set and get result', function() {
     result.set(1, 'test');
     expect(result.has(1)).to.be.true;
     expect(result.has(2)).to.be.false;
@@ -36,7 +44,7 @@ describe('[UNIT] WorkResult', function () {
     expect(result.get(2)).to.be.undefined;
   });
 
-  it('should check if we have all result', function () {
+  it('should check if we have all result', function() {
     expect(result.hasAll()).to.be.false;
     result.set(1, 'abc');
     expect(result.hasAll()).to.be.false;
@@ -50,8 +58,10 @@ describe('[UNIT] WorkResult', function () {
     expect(result.hasAll()).to.be.true;
   });
 
-  it('should clear work result', function () {
-    expect(function () { result.clear(); }).to.not.throw();
+  it('should clear work result', function() {
+    expect(function() {
+      result.clear();
+    }).to.not.throw();
     result.set(1, 'test');
     result.clear();
     expect(result.get(1)).to.be.undefined;
@@ -62,9 +72,9 @@ describe('[UNIT] WorkResult', function () {
     expect(result.hasAll()).to.be.false;
   });
 
-  it('should reduce work result', function () {
+  it('should reduce work result', function() {
     result.set(2, 'c');
-    var reducer = sinon.spy(function (reduced, current) {
+    var reducer = sinon.spy(function(reduced, current) {
       return reduced.concat(current);
     });
 

--- a/test/unit/WorkSet.spec.js
+++ b/test/unit/WorkSet.spec.js
@@ -3,44 +3,47 @@ var it = require('mocha').it;
 var expect = require('chai').expect;
 var WorkSet = require('../../lib/WorkSet').WorkSet;
 
-describe('[UNIT] WorkSet', function () {
-  function testForDomainAndDivision (domain, divisions) {
-    divisions.forEach(function (division) {
+describe('[UNIT] WorkSet', function() {
+  function testForDomainAndDivision(domain, divisions) {
+    divisions.forEach(function(division) {
       var toProcess = [];
 
       for (var i = 0; i < division; ++i) {
         var set = new WorkSet(domain, i, division);
-        set.forEach(function (work) {
+        set.forEach(function(work) {
           toProcess.push(work);
         });
       }
 
-      expect(toProcess).to.be.deep.equal(domain, 'work processed with division ' + division + ' is not equal work domain');
+      expect(toProcess).to.be.deep.equal(
+        domain,
+        'work processed with division ' + division + ' is not equal work domain'
+      );
     });
   }
 
-  it('should split work and cover odd work domain', function () {
+  it('should split work and cover odd work domain', function() {
     var domain = [0, 10, 20, 30, 40, 50, 60, 70, 80];
     var divisions = [1, 2, 3, 4, domain.length, 1000];
 
     testForDomainAndDivision(domain, divisions);
   });
 
-  it('should split work and cover even work domain', function () {
+  it('should split work and cover even work domain', function() {
     var domain = [0, 100, 200, 300, 400, 500, 600, 700, 800, 900];
     var divisions = [1, 2, 3, 4, domain.length, 1000];
 
     testForDomainAndDivision(domain, divisions);
   });
 
-  it('should split work and cover empty work domain', function () {
+  it('should split work and cover empty work domain', function() {
     var domain = [];
     var divisions = [1, 2, 3, 4, 1000];
 
     testForDomainAndDivision(domain, divisions);
   });
 
-  it('should split work and cover single work domain', function () {
+  it('should split work and cover single work domain', function() {
     var domain = [5];
     var divisions = [1, 2, 3, 4, 1000];
 

--- a/test/unit/codeframeFormatter.spec.js
+++ b/test/unit/codeframeFormatter.spec.js
@@ -1,4 +1,3 @@
-
 var describe = require('mocha').describe;
 var it = require('mocha').it;
 var os = require('os');
@@ -6,19 +5,20 @@ var beforeEach = require('mocha').beforeEach;
 var afterEach = require('mocha').afterEach;
 var expect = require('chai').expect;
 var mockFs = require('mock-fs');
-var NormalizedMessage = require('../../lib/NormalizedMessage').NormalizedMessage;
-var createCodeframeFormatter = require('../../lib/formatter/codeframeFormatter').createCodeframeFormatter;
+var NormalizedMessage = require('../../lib/NormalizedMessage')
+  .NormalizedMessage;
+var createCodeframeFormatter = require('../../lib/formatter/codeframeFormatter')
+  .createCodeframeFormatter;
 
-describe('[UNIT] formatter/codeframeFormatter', function () {
-
-  beforeEach(function () {
+describe('[UNIT] formatter/codeframeFormatter', function() {
+  beforeEach(function() {
     mockFs({
       some: {
         'file.ts': [
           'class SomeClass {',
           '  private someProperty: boolean;',
           '  constructor() {',
-          '    console.log(\'anything special\');',
+          "    console.log('anything special');",
           '  }',
           '}'
         ].join('\n')
@@ -26,11 +26,11 @@ describe('[UNIT] formatter/codeframeFormatter', function () {
     });
   });
 
-  afterEach(function () {
+  afterEach(function() {
     mockFs.restore();
   });
 
-  it('should format normalized diagnostic message', function () {
+  it('should format normalized diagnostic message', function() {
     var message = new NormalizedMessage({
       type: NormalizedMessage.TYPE_DIAGNOSTIC,
       code: 123,
@@ -47,15 +47,19 @@ describe('[UNIT] formatter/codeframeFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'ERROR in some/file.ts' + os.EOL +
-      '1:7 Some diagnostic content' + os.EOL +
-      '  > 1 | class SomeClass {' + os.EOL +
-      '      |       ^' + os.EOL +
-      '    2 |   private someProperty: boolean;'
+      'ERROR in some/file.ts' +
+        os.EOL +
+        '1:7 Some diagnostic content' +
+        os.EOL +
+        '  > 1 | class SomeClass {' +
+        os.EOL +
+        '      |       ^' +
+        os.EOL +
+        '    2 |   private someProperty: boolean;'
     );
   });
 
-  it('should format normalized lint message', function () {
+  it('should format normalized lint message', function() {
     var message = new NormalizedMessage({
       type: NormalizedMessage.TYPE_LINT,
       code: 'some-lint-rule',
@@ -72,16 +76,21 @@ describe('[UNIT] formatter/codeframeFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'WARNING in some/file.ts' + os.EOL +
-      '2:11 Some lint content' + os.EOL +
-      '    1 | class SomeClass {' + os.EOL +
-      '  > 2 |   private someProperty: boolean;' + os.EOL +
-      '      |           ^' + os.EOL +
-      '    3 |   constructor() {'
+      'WARNING in some/file.ts' +
+        os.EOL +
+        '2:11 Some lint content' +
+        os.EOL +
+        '    1 | class SomeClass {' +
+        os.EOL +
+        '  > 2 |   private someProperty: boolean;' +
+        os.EOL +
+        '      |           ^' +
+        os.EOL +
+        '    3 |   constructor() {'
     );
   });
 
-  it('should format normalized message without file', function () {
+  it('should format normalized message without file', function() {
     var message = new NormalizedMessage({
       type: NormalizedMessage.TYPE_LINT,
       code: 'some-lint-rule',
@@ -98,8 +107,7 @@ describe('[UNIT] formatter/codeframeFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'WARNING in some/unknown-file.ts' + os.EOL +
-      '2:11 Some lint content'
+      'WARNING in some/unknown-file.ts' + os.EOL + '2:11 Some lint content'
     );
   });
 });

--- a/test/unit/defaultFormatter.spec.js
+++ b/test/unit/defaultFormatter.spec.js
@@ -1,14 +1,14 @@
-
 var describe = require('mocha').describe;
 var it = require('mocha').it;
 var os = require('os');
 var expect = require('chai').expect;
-var NormalizedMessage = require('../../lib/NormalizedMessage').NormalizedMessage;
-var createDefaultFormatter = require('../../lib/formatter/defaultFormatter').createDefaultFormatter;
+var NormalizedMessage = require('../../lib/NormalizedMessage')
+  .NormalizedMessage;
+var createDefaultFormatter = require('../../lib/formatter/defaultFormatter')
+  .createDefaultFormatter;
 
-describe('[UNIT] formatter/defaultFormatter', function () {
-
-  it('should format normalized diagnostic message', function () {
+describe('[UNIT] formatter/defaultFormatter', function() {
+  it('should format normalized diagnostic message', function() {
     var message = new NormalizedMessage({
       type: NormalizedMessage.TYPE_DIAGNOSTIC,
       code: 123,
@@ -22,12 +22,11 @@ describe('[UNIT] formatter/defaultFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'ERROR in /some/file.ts(1,5):' + os.EOL +
-      'TS123: Some diagnostic content'
+      'ERROR in /some/file.ts(1,5):' + os.EOL + 'TS123: Some diagnostic content'
     );
   });
 
-  it('should format normalized lint message', function () {
+  it('should format normalized lint message', function() {
     var message = new NormalizedMessage({
       type: NormalizedMessage.TYPE_LINT,
       code: 'some-lint-rule',
@@ -41,8 +40,9 @@ describe('[UNIT] formatter/defaultFormatter', function () {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).to.be.equal(
-      'WARNING in /some/file.ts(2,6):' + os.EOL +
-      'some-lint-rule: Some lint content'
+      'WARNING in /some/file.ts(2,6):' +
+        os.EOL +
+        'some-lint-rule: Some lint content'
     );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,26 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
+  dependencies:
+    any-observable "^0.3.0"
+
 "@types/babel-code-frame@^6.20.1":
   version "6.20.1"
   resolved "https://registry.yarnpkg.com/@types/babel-code-frame/-/babel-code-frame-6.20.1.tgz#e79a40ea81435034df7b46b5e32e8ed638aea4dd"
@@ -246,38 +266,23 @@ acorn-dynamic-import@^3.0.0:
   dependencies:
     acorn "^5.0.0"
 
-acorn-jsx@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+acorn-jsx@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
   dependencies:
-    acorn "^3.0.4"
-
-acorn@^3.0.4:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+    acorn "^5.0.3"
 
 acorn@^5.0.0, acorn@^5.6.2:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
-acorn@^5.4.0:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
-
-ajv-keywords@^1.0.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+acorn@^5.0.3, acorn@^5.6.0:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
 
 ajv-keywords@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
-
-ajv@^4.7.0:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
 
 ajv@^6.1.0:
   version "6.5.2"
@@ -287,6 +292,15 @@ ajv@^6.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.1"
+
+ajv@^6.5.3:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.4.tgz#247d5274110db653706b550fcc2b797ca28cfc59"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -304,9 +318,13 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.1.0:
+ansi-escapes@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+
+ansi-escapes@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -326,11 +344,15 @@ ansi-styles@^3.1.0:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^3.2.1:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
+
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -431,7 +453,7 @@ autoprefixer@^6.3.1:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -601,7 +623,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.1.1:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -689,7 +711,7 @@ chai@^3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -699,6 +721,14 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
@@ -707,13 +737,9 @@ chalk@^2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
 
 chokidar@^2.0.2, chokidar@^2.0.4:
   version "2.0.4"
@@ -744,6 +770,10 @@ chrome-trace-event@^1.0.0:
   dependencies:
     tslib "^1.9.0"
 
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -770,11 +800,24 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cli-cursor@^1.0.1:
+cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
     restore-cursor "^1.0.1"
+
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -791,10 +834,6 @@ cliui@^2.1.0:
 clone@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.3.tgz#298d7e2231660f40c003c2ed3140decf3f53085f"
-
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
 coa@~1.0.1:
   version "1.0.4"
@@ -859,6 +898,10 @@ commander@^2.12.1, commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
+commander@^2.14.1, commander@^2.9.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -876,14 +919,6 @@ concat-stream@^1.5.0:
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
     buffer-from "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
-concat-stream@^1.5.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
-  dependencies:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
@@ -927,6 +962,14 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^5.0.2, cosmiconfig@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
@@ -954,6 +997,24 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -1054,11 +1115,9 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
-d@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
-  dependencies:
-    es5-ext "^0.10.9"
+date-fns@^1.27.2:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -1074,7 +1133,7 @@ debug@2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
+debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1086,6 +1145,12 @@ debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.0.0, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1093,6 +1158,10 @@ decamelize@^1.0.0, decamelize@^1.1.2:
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
 
 deep-eql@^0.1.3:
   version "0.1.3"
@@ -1174,7 +1243,7 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-doctrine@^2.0.0:
+doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
@@ -1202,6 +1271,10 @@ duplexify@^3.4.2, duplexify@^3.6.0:
 electron-to-chromium@^1.2.7:
   version "1.3.32"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.32.tgz#11d0684c0840e003c4be8928f8ac5f35dbc2b4e6"
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -1253,57 +1326,11 @@ errno@~0.1.7:
   dependencies:
     prr "~1.0.1"
 
-es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.38"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.38.tgz#fa7d40d65bbc9bb8a67e1d3f9cc656a00530eed3"
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.1"
-
-es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-map@^0.1.3:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-set "~0.1.5"
-    es6-symbol "~3.1.1"
-    event-emitter "~0.3.5"
-
-es6-set@~0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-symbol "3.1.1"
-    event-emitter "~0.3.5"
-
-es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-es6-weak-map@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.14"
-    es6-iterator "^2.0.1"
-    es6-symbol "^3.1.1"
+    is-arrayish "^0.2.1"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1320,15 +1347,6 @@ escodegen@1.8.x:
   optionalDependencies:
     source-map "~0.2.0"
 
-escope@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
-  dependencies:
-    es6-map "^0.1.3"
-    es6-weak-map "^2.0.1"
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
 eslint-scope@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
@@ -1336,52 +1354,63 @@ eslint-scope@^4.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^3.19.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.7.0.tgz#55c326d6fb2ad45fcbd0ce17c3846f025d1d819c"
   dependencies:
-    babel-code-frame "^6.16.0"
-    chalk "^1.1.3"
-    concat-stream "^1.5.2"
-    debug "^2.1.1"
-    doctrine "^2.0.0"
-    escope "^3.6.0"
-    espree "^3.4.0"
-    esquery "^1.0.0"
-    estraverse "^4.2.0"
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.5.3"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
-    glob "^7.0.3"
-    globals "^9.14.0"
-    ignore "^3.2.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
     imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    is-my-json-valid "^2.10.0"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.5.1"
-    json-stable-stringify "^1.0.0"
+    inquirer "^6.1.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.12.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.0.0"
-    mkdirp "^0.5.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.1"
-    pluralize "^1.2.1"
-    progress "^1.1.8"
-    require-uncached "^1.0.2"
-    shelljs "^0.7.5"
-    strip-bom "^3.0.0"
-    strip-json-comments "~2.0.1"
-    table "^3.7.8"
-    text-table "~0.2.0"
-    user-home "^2.0.0"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    require-uncached "^1.0.3"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.0.2"
+    text-table "^0.2.0"
 
-espree@^3.4.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.3.tgz#931e0af64e7fbbed26b050a29daad1fc64799fa6"
+espree@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-4.0.0.tgz#253998f20a0f82db5d866385799d912a83a36634"
   dependencies:
-    acorn "^5.4.0"
-    acorn-jsx "^3.0.0"
+    acorn "^5.6.0"
+    acorn-jsx "^4.1.1"
 
 esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
@@ -1391,9 +1420,9 @@ esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
-esquery@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+esquery@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
     estraverse "^4.0.0"
 
@@ -1408,20 +1437,13 @@ estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-
-event-emitter@~0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
 
 events@^1.0.0:
   version "1.1.1"
@@ -1433,6 +1455,18 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+execa@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -1463,6 +1497,14 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
+external-editor@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^2.0.2, extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -1492,12 +1534,18 @@ fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
-figures@^1.3.5:
+figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 file-entry-cache@^2.0.0:
   version "2.0.0"
@@ -1523,11 +1571,21 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+
 find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  dependencies:
+    locate-path "^3.0.0"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -1602,6 +1660,10 @@ function-bind@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -1615,15 +1677,17 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-generate-function@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
+get-own-enumerable-property-symbols@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
 
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  dependencies:
-    is-property "^1.0.0"
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -1657,7 +1721,7 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1668,9 +1732,9 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.14.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+globals@^11.7.0:
+  version "11.8.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -1790,6 +1854,10 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hosted-git-info@^2.1.4:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
+
 html-comment-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
@@ -1797,6 +1865,27 @@ html-comment-regex@^1.1.0:
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+
+husky@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.1.2.tgz#574c2bb16958db8a8120b63306efaff110525c23"
+  dependencies:
+    cosmiconfig "^5.0.6"
+    execa "^0.9.0"
+    find-up "^3.0.0"
+    get-stdin "^6.0.0"
+    is-ci "^1.2.1"
+    pkg-dir "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^4.0.1"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
+iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@^0.4.4:
   version "0.4.23"
@@ -1828,13 +1917,17 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.2.0:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -1863,27 +1956,23 @@ ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-inquirer@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+inquirer@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
   dependencies:
-    ansi-escapes "^1.1.0"
-    ansi-regex "^2.0.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    figures "^1.3.5"
-    lodash "^4.3.0"
-    readline2 "^1.0.1"
-    run-async "^0.1.0"
-    rx-lite "^3.1.2"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
-
-interpret@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -1901,6 +1990,10 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -1910,6 +2003,18 @@ is-binary-path@^1.0.0:
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
+
+is-ci@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  dependencies:
+    ci-info "^1.5.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -1938,6 +2043,10 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-accessor-descriptor "^1.0.0"
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -1975,24 +2084,21 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
-is-my-json-valid@^2.10.0:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz#3da98914a70a22f0a8563ef1511a246c6fc55471"
-  dependencies:
-    generate-function "^2.0.0"
-    generate-object-property "^1.1.0"
-    jsonpointer "^4.0.0"
-    xtend "^4.0.0"
-
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
 
-is-obj@^1.0.0:
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  dependencies:
+    symbol-observable "^1.1.0"
 
 is-odd@^1.0.0:
   version "1.0.0"
@@ -2026,13 +2132,21 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-property@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
-is-resolvable@^1.0.0:
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+
+is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-svg@^2.0.0:
   version "2.1.0"
@@ -2085,6 +2199,19 @@ istanbul@^0.4.5:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
+jest-get-type@^22.1.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
+
+jest-validate@^23.5.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.6.0.tgz#36761f99d1ed33fcd425b4e4c5595d62b6597474"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    leven "^2.1.0"
+    pretty-format "^23.6.0"
+
 js-base64@^2.1.9:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
@@ -2093,9 +2220,20 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.x, js-yaml@^3.5.1, js-yaml@^3.7.0:
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
+js-yaml@3.x, js-yaml@^3.7.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.12.0, js-yaml@^3.9.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -2111,7 +2249,7 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-parse-better-errors@^1.0.2:
+json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
 
@@ -2119,11 +2257,9 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
 
-json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  dependencies:
-    jsonify "~0.0.0"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json3@3.3.2:
   version "3.3.2"
@@ -2132,14 +2268,6 @@ json3@3.3.2:
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -2171,12 +2299,83 @@ lazy-cache@^2.0.2:
   dependencies:
     set-getter "^0.1.0"
 
+leven@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lint-staged@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.3.0.tgz#90ff33e5ca61ed3dbac35b6f6502dbefdc0db58d"
+  dependencies:
+    chalk "^2.3.1"
+    commander "^2.14.1"
+    cosmiconfig "^5.0.2"
+    debug "^3.1.0"
+    dedent "^0.7.0"
+    execa "^0.9.0"
+    find-parent-dir "^0.3.0"
+    is-glob "^4.0.0"
+    is-windows "^1.0.2"
+    jest-validate "^23.5.0"
+    listr "^0.14.1"
+    lodash "^4.17.5"
+    log-symbols "^2.2.0"
+    micromatch "^3.1.8"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    path-is-inside "^1.0.2"
+    pify "^3.0.0"
+    please-upgrade-node "^3.0.2"
+    staged-git-files "1.1.1"
+    string-argv "^0.0.2"
+    stringify-object "^3.2.2"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz#344d980da2ca2e8b145ba305908f32ae3f4cc8a7"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#8206f4cf6d52ddc5827e5fd14989e0e965933a35"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.14.1:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.2.tgz#cbe44b021100a15376addfc2d79349ee430bfe14"
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.4.0"
+    listr-verbose-renderer "^0.4.0"
+    p-map "^1.1.1"
+    rxjs "^6.1.0"
 
 loader-runner@^2.3.0:
   version "2.3.0"
@@ -2195,6 +2394,13 @@ locate-path@^2.0.0:
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
   dependencies:
     p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  dependencies:
+    p-locate "^3.0.0"
     path-exists "^3.0.0"
 
 lodash._baseassign@^3.0.0:
@@ -2276,9 +2482,28 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.3.0:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+lodash@^4.17.10, lodash@^4.17.5:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  dependencies:
+    chalk "^2.0.1"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
 
 lolex@^1.6.0:
   version "1.6.0"
@@ -2296,7 +2521,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-lru-cache@^4.1.1, lru-cache@^4.1.2:
+lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
@@ -2393,6 +2618,10 @@ miller-rabin@^4.0.0:
   dependencies:
     bn.js "^4.0.0"
     brorand "^1.0.1"
+
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -2503,9 +2732,13 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-mute-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.9.2:
   version "2.10.0"
@@ -2563,6 +2796,10 @@ neo-async@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+
 node-libs-browser@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
@@ -2619,6 +2856,15 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+normalize-package-data@^2.3.2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
 normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -2648,6 +2894,26 @@ npm-packlist@^1.1.6:
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
+
+npm-path@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
+  dependencies:
+    which "^1.2.10"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -2698,7 +2964,13 @@ once@1.x, once@^1.3.0, once@^1.3.1, once@^1.4.0:
 
 onetime@^1.0.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+  resolved "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -2726,7 +2998,7 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-tmpdir@^1.0.0:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -2737,11 +3009,21 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
 p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
   dependencies:
     p-try "^1.0.0"
+
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  dependencies:
+    p-try "^2.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -2749,9 +3031,23 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  dependencies:
+    p-limit "^2.0.0"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 pako@~1.0.5:
   version "1.0.6"
@@ -2775,6 +3071,13 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -2795,9 +3098,13 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0, path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -2843,9 +3150,21 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pluralize@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  dependencies:
+    find-up "^3.0.0"
+
+please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  dependencies:
+    semver-compare "^1.0.0"
+
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -3125,6 +3444,17 @@ prettier@^1.13.0:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.4.tgz#31bbae6990f13b1093187c731766a14036fa72e6"
 
+prettier@^1.14.3:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+
+pretty-format@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
@@ -3137,9 +3467,9 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
-progress@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -3231,6 +3561,14 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.4, readable-stream@^2.1.5, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -3264,20 +3602,6 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-readline2@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    mute-stream "0.0.5"
-
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  dependencies:
-    resolve "^1.1.6"
-
 reduce-css-calc@^1.2.6:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
@@ -3309,6 +3633,10 @@ regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+
 regexpu-core@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-1.0.0.tgz#86a763f58ee4d7c2f6b102e4764050de7ed90c6b"
@@ -3339,7 +3667,7 @@ repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
-require-uncached@^1.0.2:
+require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   dependencies:
@@ -3358,7 +3686,7 @@ resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.3.2, resolve@^1.5.0:
+resolve@^1.3.2, resolve@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
@@ -3370,6 +3698,13 @@ restore-cursor@^1.0.1:
   dependencies:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
+
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -3394,11 +3729,15 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-run-async@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
-    once "^1.3.0"
+    is-promise "^2.1.0"
+
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -3406,9 +3745,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+rxjs@^6.1.0:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
   version "5.1.2"
@@ -3442,6 +3783,14 @@ schema-utils@^0.4.4, schema-utils@^0.4.5:
   dependencies:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.5.1:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
 semver@^5.0.1, semver@^5.3.0:
   version "5.5.0"
@@ -3494,15 +3843,17 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shelljs@^0.7.5:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
   dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
+    shebang-regex "^1.0.0"
 
-signal-exit@^3.0.0:
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
@@ -3519,9 +3870,19 @@ sinon@^2.3.1:
     text-encoding "0.6.4"
     type-detect "^4.0.0"
 
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -3594,6 +3955,28 @@ source-map@~0.2.0:
   dependencies:
     amdefine ">=0.0.4"
 
+spdx-correct@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.2.tgz#19bb409e91b47b1ad54159243f7312a858db3c2e"
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz#e2a303236cac54b04031fa7a5a79c7e701df852f"
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -3613,6 +3996,10 @@ ssri@^5.2.4:
 stack-trace@~0.0.7:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+
+staged-git-files@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.1.tgz#37c2218ef0d6d26178b1310719309a16a59f8f7b"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -3653,6 +4040,10 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
+string-argv@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
+
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -3661,7 +4052,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0:
+string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -3680,6 +4071,14 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-object@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.2.tgz#9853052e5a88fb605a44cd27445aa257ad7ffbcd"
+  dependencies:
+    get-own-enumerable-property-symbols "^2.0.1"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -3692,11 +4091,11 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -3746,16 +4145,18 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-table@^3.7.8:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+
+table@^5.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.1.0.tgz#69a54644f6f01ad1628f8178715b408dc6bf11f7"
   dependencies:
-    ajv "^4.7.0"
-    ajv-keywords "^1.0.0"
-    chalk "^1.1.1"
-    lodash "^4.0.0"
-    slice-ansi "0.0.4"
-    string-width "^2.0.0"
+    ajv "^6.5.3"
+    lodash "^4.17.10"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
 
 tapable@^1.0.0:
   version "1.0.0"
@@ -3777,7 +4178,7 @@ text-encoding@0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
-text-table@~0.2.0:
+text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -3797,6 +4198,12 @@ timers-browserify@^2.0.4:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
   dependencies:
     setimmediate "^1.0.4"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -3850,9 +4257,13 @@ tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
-tslint@^5.0.0:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+tslint-config-prettier@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.15.0.tgz#76b9714399004ab6831fdcf76d89b73691c812cf"
+
+tslint@^5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -3865,11 +4276,11 @@ tslint@^5.0.0:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.8.0"
-    tsutils "^2.12.1"
+    tsutils "^2.27.2"
 
-tsutils@^2.12.1:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.21.0.tgz#43466a2283a0abce64e2209bc732ad72f8a04fab"
+tsutils@^2.27.2:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   dependencies:
     tslib "^1.8.1"
 
@@ -3982,7 +4393,7 @@ upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
-uri-js@^4.2.1:
+uri-js@^4.2.1, uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
   dependencies:
@@ -4007,12 +4418,6 @@ use@^2.0.0:
     isobject "^3.0.0"
     lazy-cache "^2.0.2"
 
-user-home@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
-  dependencies:
-    os-homedir "^1.0.0"
-
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -4028,6 +4433,13 @@ util@^0.10.3:
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
   dependencies:
     inherits "2.0.3"
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
 
 vendors@^1.0.0:
   version "1.0.1"
@@ -4131,6 +4543,12 @@ whet.extend@~0.9.9:
 which@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.10, which@^1.2.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
## Description
This PR enforces linting with `prettier`, `eslint` and `tslint` for the project by leveraging pre-commit looks with `husky` and `lint-staged`

- Upgraded `tslint`, `eslint` packages
- Added `prettier`, `tslint-config-prettier` (to disable conflicting rules), `husky`, and `lint-staged` packages
- Ran `prettier` for files matching `src/**/*.{ts,json}` and `src/**/*.js` files once
- Hand off `eslint` and `tslint` styling rules, like spacing, and semicolons, to `prettier` with a pre-commit hook **(needs review)** 
- Run `yarn lint` in CI

I've tested the pre-commit hooks, and they seem to be working fine.
