### PR TITLE
Add compilerOptions option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.4.12
+
+* [Add `compilerOptions` option](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/173) (#173)
+
 ## v0.4.11
 
 * [Fix os.cpus is not a function](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/172) (#172)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ It helps to distinguish lints from typescript's diagnostics.
 * **tsconfig** `string`:
 Path to *tsconfig.json* file. Default: `path.resolve(compiler.options.context, './tsconfig.json')`.
 
-* **compilerOptions** `string`:
+* **compilerOptions** `object`:
 Allows overriding TypeScript options. Should be specified in the same format as you would do for the `compilerOptions` property in tsconfig.json. Default: `{}`.
 
 * **tslint** `string | true`: 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ It helps to distinguish lints from typescript's diagnostics.
 * **tsconfig** `string`:
 Path to *tsconfig.json* file. Default: `path.resolve(compiler.options.context, './tsconfig.json')`.
 
+* **compilerOptions** `string`:
+Allows overriding TypeScript options. Should be specified in the same format as you would do for the `compilerOptions` property in tsconfig.json. Default: `{}`.
+
 * **tslint** `string | true`: 
 Path to *tslint.json* file or `true`. If `true`, uses `path.resolve(compiler.options.context, './tslint.json')`. Default: `undefined`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/src/VueProgram.ts
+++ b/src/VueProgram.ts
@@ -12,7 +12,7 @@ interface ResolvedScript {
 }
 
 export class VueProgram {
-  static loadProgramConfig(configFile: string) {
+  static loadProgramConfig(configFile: string, compilerOptions: object) {
     const extraExtensions = ['vue'];
 
     const parseConfigHost: ts.ParseConfigHost = {
@@ -40,6 +40,7 @@ export class VueProgram {
     );
 
     parsed.options.allowNonTsExtensions = true;
+    parsed.options = { ...parsed.options, ...compilerOptions };
 
     return parsed;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ interface Logger {
 
 interface Options {
   tsconfig: string;
+  compilerOptions: object;
   tslint: string | true;
   watch: string | string[];
   async: boolean;
@@ -71,6 +72,7 @@ class ForkTsCheckerWebpackPlugin {
 
   options: Partial<Options>;
   tsconfig: string;
+  compilerOptions: object;
   tslint: string | true;
   watch: string[];
   ignoreDiagnostics: number[];
@@ -114,6 +116,10 @@ class ForkTsCheckerWebpackPlugin {
     this.options = Object.assign({}, options);
 
     this.tsconfig = options.tsconfig || './tsconfig.json';
+    this.compilerOptions =
+      typeof options.compilerOptions === 'object'
+        ? options.compilerOptions
+        : {};
     this.tslint = options.tslint
       ? options.tslint === true
         ? './tslint.json'
@@ -554,6 +560,7 @@ class ForkTsCheckerWebpackPlugin {
             : ['--max-old-space-size=' + this.memoryLimit],
         env: Object.assign({}, process.env, {
           TSCONFIG: this.tsconfigPath,
+          COMPILER_OPTIONS: JSON.stringify(this.compilerOptions),
           TSLINT: this.tslintPath || '',
           WATCH: this.isWatching ? this.watchPaths.join('|') : '',
           WORK_DIVISION: Math.max(1, this.workersNumber),

--- a/src/service.ts
+++ b/src/service.ts
@@ -6,6 +6,7 @@ import { NormalizedMessage } from './NormalizedMessage';
 
 const checker = new IncrementalChecker(
   process.env.TSCONFIG,
+  JSON.parse(process.env.COMPILER_OPTIONS),
   process.env.TSLINT === '' ? false : process.env.TSLINT,
   process.env.WATCH === '' ? [] : process.env.WATCH.split('|'),
   parseInt(process.env.WORK_NUMBER, 10),

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -76,6 +76,7 @@ describe('[INTEGRATION] vue', function() {
 
     checker = new IncrementalChecker(
       plugin.tsconfigPath,
+      {},
       plugin.tslintPath || false,
       [compiler.context],
       ForkTsCheckerWebpackPlugin.ONE_CPU,


### PR DESCRIPTION
Adds `compilerOptions` option, using [ts-loader](https://github.com/TypeStrong/ts-loader#compileroptions-object-default) as inspiration. This allows overriding `compilerOptions` of your `tsconfig.json` explicitly when initializing the plugin.

Here it is in action using [create-react-app](https://github.com/facebook/create-react-app) with the newly added TypeScript support:

![image](https://user-images.githubusercontent.com/6355370/47336380-57906080-d644-11e8-9017-1189c4578af7.png)

Here is the discussion over at CRA for the background on this feature: https://github.com/facebook/create-react-app/pull/5514

**TODO:**
- [x] Unit/Integration tests?
- [ ] Validate Vue works as expected

/cc @Timer, @brunolemos