### PR TITLE
Merge in compilerOptions prior to calling parseJsonConfigFileContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.4.13
+
+* [Merge in `compilerOptions` prior to calling `parseJsonConfigFileContent`](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/176) (#176)
+
 ## v0.4.12
 
 * [Add `compilerOptions` option](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/173) (#173)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/src/IncrementalChecker.ts
+++ b/src/IncrementalChecker.ts
@@ -72,16 +72,19 @@ export class IncrementalChecker {
   }
 
   static loadProgramConfig(configFile: string, compilerOptions: object) {
+    const tsconfig = ts.readConfigFile(configFile, ts.sys.readFile).config;
+
+    tsconfig.compilerOptions = tsconfig.compilerOptions || {};
+    tsconfig.compilerOptions = {
+      ...tsconfig.compilerOptions,
+      ...compilerOptions
+    };
+
     const parsed = ts.parseJsonConfigFileContent(
-      // Regardless of the setting in the tsconfig.json we want isolatedModules to be false
-      Object.assign(ts.readConfigFile(configFile, ts.sys.readFile).config, {
-        isolatedModules: false
-      }),
+      tsconfig,
       ts.sys,
       path.dirname(configFile)
     );
-
-    parsed.options = { ...parsed.options, ...compilerOptions };
 
     return parsed;
   }

--- a/src/VueProgram.ts
+++ b/src/VueProgram.ts
@@ -30,17 +30,21 @@ export class VueProgram {
       }
     };
 
+    const tsconfig = ts.readConfigFile(configFile, ts.sys.readFile).config;
+
+    tsconfig.compilerOptions = tsconfig.compilerOptions || {};
+    tsconfig.compilerOptions = {
+      ...tsconfig.compilerOptions,
+      ...compilerOptions
+    };
+
     const parsed = ts.parseJsonConfigFileContent(
-      // Regardless of the setting in the tsconfig.json we want isolatedModules to be false
-      Object.assign(ts.readConfigFile(configFile, ts.sys.readFile).config, {
-        isolatedModules: false
-      }),
+      tsconfig,
       parseConfigHost,
       path.dirname(configFile)
     );
 
     parsed.options.allowNonTsExtensions = true;
-    parsed.options = { ...parsed.options, ...compilerOptions };
 
     return parsed;
   }

--- a/test/unit/IncrementalChecker.spec.js
+++ b/test/unit/IncrementalChecker.spec.js
@@ -8,20 +8,28 @@ var sinon = require('sinon');
 
 describe('[UNIT] IncrementalChecker', function() {
   var IncrementalChecker;
+  var parseJsonConfigFileContentStub;
 
   beforeEach(function() {
-    var parseJsonConfigFileContentStub = sinon.stub().returns({
-      options: {
-        foo: true
-      }
+    parseJsonConfigFileContentStub = sinon.spy(function(tsconfig) {
+      return {
+        options: tsconfig.compilerOptions
+      };
     });
-    var readConfigFileStub = sinon.stub().returns({
-      config: {}
-    });
+
+    var readConfigFile = function() {
+      return {
+        config: {
+          compilerOptions: {
+            foo: true
+          }
+        }
+      };
+    };
 
     mockRequire('typescript', {
       parseJsonConfigFileContent: parseJsonConfigFileContentStub,
-      readConfigFile: readConfigFileStub,
+      readConfigFile,
       sys: {}
     });
 
@@ -68,14 +76,17 @@ describe('[UNIT] IncrementalChecker', function() {
   });
 
   describe('loadProgramConfig', function() {
-    it('merges compilerOptions into returned options', function() {
-      var result = IncrementalChecker.loadProgramConfig('tsconfig.foo.json', {
+    it('merges compilerOptions into config file options', function() {
+      IncrementalChecker.loadProgramConfig('tsconfig.foo.json', {
         bar: false
       });
 
-      expect(result.options).to.deep.equal({
-        foo: true,
-        bar: false
+      expect(parseJsonConfigFileContentStub.calledOnce).to.equal(true);
+      expect(parseJsonConfigFileContentStub.args[0][0]).to.deep.equal({
+        compilerOptions: {
+          foo: true,
+          bar: false
+        }
       });
     });
   });


### PR DESCRIPTION
This PR fixes a deficiency in https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/173#issuecomment-432840339, as we were merging the `compilerOptions` in too late in the pipeline, which meant that if someone wanted to override a configuration option that was a string value example (such as `module` or `target`), they would have to use the typescript enum integer value instead (`module: 1` instead of `module: "es5"`).

Here is an example where I'm overriding in the webpack config of create-react-app. My `tsconfig.json` specifies `"moduleResolution": "node"`, but i override it to `"classic"` here:
![image](https://user-images.githubusercontent.com/6355370/47540340-93683780-d889-11e8-89ab-3650a9ebe36b.png)

/cc @Timer