### PR TITLE
Working as expected on first line diagnostic.start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.5.2
+
+* [Fix erroneous error on diagnostics at 0 line; remove deprecated fs.existsSync](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/190) (#190)
+
 ## v0.5.1
 
 * [Make the checker compile with TypeScript 3.2](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/189)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/CancellationToken.ts
+++ b/src/CancellationToken.ts
@@ -4,6 +4,8 @@ import * as os from 'os';
 import * as path from 'path';
 import * as ts from 'typescript';
 
+import { FsHelper } from './FsHelper';
+
 interface CancellationTokenData {
   isCancelled: boolean;
   cancellationFileName: string;
@@ -46,7 +48,7 @@ export class CancellationToken {
     if (duration > 10) {
       // check no more than once every 10ms
       this.lastCancellationCheckTime = time;
-      this.isCancelled = fs.existsSync(this.getCancellationFilePath());
+      this.isCancelled = FsHelper.existsSync(this.getCancellationFilePath());
     }
 
     return this.isCancelled;
@@ -64,7 +66,10 @@ export class CancellationToken {
   }
 
   public cleanupCancellation() {
-    if (this.isCancelled && fs.existsSync(this.getCancellationFilePath())) {
+    if (
+      this.isCancelled &&
+      FsHelper.existsSync(this.getCancellationFilePath())
+    ) {
       fs.unlinkSync(this.getCancellationFilePath());
       this.isCancelled = false;
     }

--- a/src/FsHelper.ts
+++ b/src/FsHelper.ts
@@ -1,0 +1,16 @@
+import * as fs from 'fs';
+
+export class FsHelper {
+  public static existsSync(filePath: fs.PathLike) {
+    try {
+      fs.statSync(filePath);
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        return false;
+      } else {
+        throw err;
+      }
+    }
+    return true;
+  }
+}

--- a/src/IncrementalChecker.ts
+++ b/src/IncrementalChecker.ts
@@ -9,6 +9,7 @@ import { NormalizedMessage } from './NormalizedMessage';
 import { CancellationToken } from './CancellationToken';
 import * as minimatch from 'minimatch';
 import { VueProgram } from './VueProgram';
+import { FsHelper } from './FsHelper';
 
 // Need some augmentation here - linterOptions.exclude is not (yet) part of the official
 // types for tslint.
@@ -284,7 +285,7 @@ export class IncrementalChecker {
         linter.lint(fileName, undefined!, this.linterConfig);
       } catch (e) {
         if (
-          fs.existsSync(fileName) &&
+          FsHelper.existsSync(fileName) &&
           // check the error type due to file system lag
           !(e instanceof Error) &&
           !(e.constructor.name === 'FatalError') &&

--- a/src/NormalizedMessage.ts
+++ b/src/NormalizedMessage.ts
@@ -51,7 +51,7 @@ export class NormalizedMessage {
     let character: number | undefined;
     if (diagnostic.file) {
       file = diagnostic.file.fileName;
-      if (typeof diagnostic.start === 'undefined') {
+      if (diagnostic.start === undefined) {
         throw new Error('Expected diagnostics to have start');
       }
       const position = diagnostic.file.getLineAndCharacterOfPosition(

--- a/src/NormalizedMessage.ts
+++ b/src/NormalizedMessage.ts
@@ -51,7 +51,7 @@ export class NormalizedMessage {
     let character: number | undefined;
     if (diagnostic.file) {
       file = diagnostic.file.fileName;
-      if (!diagnostic.start) {
+      if (typeof diagnostic.start === 'undefined') {
         throw new Error('Expected diagnostics to have start');
       }
       const position = diagnostic.file.getLineAndCharacterOfPosition(
@@ -92,7 +92,10 @@ export class NormalizedMessage {
     return new NormalizedMessage(json);
   }
 
-  public static compare(messageA: NormalizedMessage, messageB: NormalizedMessage) {
+  public static compare(
+    messageA: NormalizedMessage,
+    messageB: NormalizedMessage
+  ) {
     if (!(messageA instanceof NormalizedMessage)) {
       return -1;
     }
@@ -102,18 +105,12 @@ export class NormalizedMessage {
 
     return (
       NormalizedMessage.compareTypes(messageA.type, messageB.type) ||
-      NormalizedMessage.compareOptionalStrings(
-        messageA.file,
-        messageB.file
-      ) ||
+      NormalizedMessage.compareOptionalStrings(messageA.file, messageB.file) ||
       NormalizedMessage.compareSeverities(
         messageA.severity,
         messageB.severity
       ) ||
-      NormalizedMessage.compareNumbers(
-        messageA.line,
-        messageB.line
-      ) ||
+      NormalizedMessage.compareNumbers(messageA.line, messageB.line) ||
       NormalizedMessage.compareNumbers(
         messageA.character,
         messageB.character
@@ -131,7 +128,10 @@ export class NormalizedMessage {
     );
   }
 
-  public static equals(messageA: NormalizedMessage, messageB: NormalizedMessage) {
+  public static equals(
+    messageA: NormalizedMessage,
+    messageB: NormalizedMessage
+  ) {
     return this.compare(messageA, messageB) === 0;
   }
 

--- a/src/formatter/codeframeFormatter.ts
+++ b/src/formatter/codeframeFormatter.ts
@@ -3,6 +3,7 @@ import codeFrame = require('babel-code-frame');
 import chalk from 'chalk';
 import * as fs from 'fs';
 import { NormalizedMessage } from '../NormalizedMessage';
+import { FsHelper } from '../FsHelper';
 
 /**
  * Create new code frame formatter.
@@ -23,9 +24,7 @@ export function createCodeframeFormatter(options: any) {
 
     const file = message.file;
     const source =
-    file &&
-      fs.existsSync(file) &&
-      fs.readFileSync(file, 'utf-8');
+      file && FsHelper.existsSync(file) && fs.readFileSync(file, 'utf-8');
     let frame = '';
 
     if (source) {
@@ -41,9 +40,7 @@ export function createCodeframeFormatter(options: any) {
     }
 
     return (
-      messageColor(
-        message.severity.toUpperCase() + ' in ' + message.file
-      ) +
+      messageColor(message.severity.toUpperCase() + ' in ' + message.file) +
       os.EOL +
       positionColor(message.line + ':' + message.character) +
       ' ' +

--- a/test/unit/CancellationToken.spec.js
+++ b/test/unit/CancellationToken.spec.js
@@ -2,13 +2,13 @@ var describe = require('mocha').describe;
 var it = require('mocha').it;
 var os = require('os');
 var ts = require('typescript');
-var fs = require('fs');
 var beforeEach = require('mocha').beforeEach;
 var afterEach = require('mocha').afterEach;
 var expect = require('chai').expect;
 var mockFs = require('mock-fs');
 var CancellationToken = require('../../lib/CancellationToken')
   .CancellationToken;
+var FsHelper = require('../../lib/FsHelper').FsHelper;
 
 describe('[UNIT] CancellationToken', function() {
   beforeEach(function() {
@@ -72,7 +72,9 @@ describe('[UNIT] CancellationToken', function() {
     var tokenB = new CancellationToken('rgeer#R23r$#T$3t#$t43', true);
     expect(function() {
       tokenB.throwIfCancellationRequested();
-    }).to.throw().instanceOf(ts.OperationCanceledException);
+    })
+      .to.throw()
+      .instanceOf(ts.OperationCanceledException);
   });
 
   it('should write file in filesystem on requestCancellation', function() {
@@ -80,7 +82,7 @@ describe('[UNIT] CancellationToken', function() {
     tokenA.requestCancellation();
 
     expect(tokenA.isCancellationRequested()).to.be.true;
-    expect(fs.existsSync(tokenA.getCancellationFilePath())).to.be.true;
+    expect(FsHelper.existsSync(tokenA.getCancellationFilePath())).to.be.true;
   });
 
   it('should cleanup file on cleanupCancellation', function() {
@@ -89,7 +91,7 @@ describe('[UNIT] CancellationToken', function() {
     tokenA.cleanupCancellation();
 
     expect(tokenA.isCancellationRequested()).to.be.false;
-    expect(fs.existsSync(tokenA.getCancellationFilePath())).to.be.false;
+    expect(FsHelper.existsSync(tokenA.getCancellationFilePath())).to.be.false;
 
     // make sure we can call it as many times as we want to
     expect(function() {


### PR DESCRIPTION
If Typescript diagnostic starts on line 0, fork-ts-checker-webpack-plugin as of 0.5.1 fails and throws an error, which it shouldn't. This humble and small PR fixes it :) I'll update package.json and changelog.md if needed.