### PR TITLE
refactor(object-spread): use spread instead of assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0-alpha.1
+
+* [Use object-spread instead of `Object.assign`](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/194) (#194)
+
 ## v1.0.0-alpha.0
 
 * [Add support for webpack 5](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/166)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -14,7 +14,7 @@ for (let num = 0; num < division; num++) {
   workers.push(
     childProcess.fork(path.resolve(__dirname, './service.js'), [], {
       execArgv: ['--max-old-space-size=' + process.env.MEMORY_LIMIT],
-      env: Object.assign({}, process.env, { WORK_NUMBER: num }),
+      env: { ...process.env, WORK_NUMBER: num },
       stdio: ['inherit', 'inherit', 'inherit', 'ipc']
     })
   );

--- a/src/formatter/codeframeFormatter.ts
+++ b/src/formatter/codeframeFormatter.ts
@@ -32,7 +32,10 @@ export function createCodeframeFormatter(options: any) {
         source,
         message.line!, // Assertion: `codeFrame` allows passing undefined, typings are incorrect
         message.character!,
-        Object.assign({}, options || {}, { highlightCode: useColors })
+        {
+          ...(options || {}),
+          highlightCode: useColors
+        }
       )
         .split('\n')
         .map(str => '  ' + str)

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ class ForkTsCheckerWebpackPlugin {
 
   constructor(options?: Partial<Options>) {
     options = options || ({} as Options);
-    this.options = Object.assign({}, options);
+    this.options = { ...options };
 
     this.tsconfig = options.tsconfig || './tsconfig.json';
     this.compilerOptions =
@@ -489,7 +489,8 @@ class ForkTsCheckerWebpackPlugin {
           this.workersNumber > 1
             ? []
             : ['--max-old-space-size=' + this.memoryLimit],
-        env: Object.assign({}, process.env, {
+        env: {
+          ...process.env,
           TSCONFIG: this.tsconfigPath,
           COMPILER_OPTIONS: JSON.stringify(this.compilerOptions),
           TSLINT: this.tslintPath || '',
@@ -499,7 +500,7 @@ class ForkTsCheckerWebpackPlugin {
           MEMORY_LIMIT: this.memoryLimit,
           CHECK_SYNTACTIC_ERRORS: this.checkSyntacticErrors,
           VUE: this.vue
-        }),
+        },
         stdio: ['inherit', 'inherit', 'inherit', 'ipc']
       }
     );

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -35,33 +35,30 @@ describe('[INTEGRATION] index', function() {
     happyPackMode,
     entryPoint = './src/index.ts'
   ) {
-    plugin = new ForkTsCheckerWebpackPlugin(
-      Object.assign({}, options, { silent: true })
-    );
+    plugin = new ForkTsCheckerWebpackPlugin({ ...options, silent: true });
 
     var tsLoaderOptions = happyPackMode
       ? { happyPackMode: true, silent: true }
       : { transpileOnly: true, silent: true };
 
-    return webpack(
-      Object.assign(webpackMajorVersion >= 4 ? { mode: 'development' } : {}, {
-        context: path.resolve(__dirname, './project'),
-        entry: entryPoint,
-        output: {
-          path: path.resolve(__dirname, '../../tmp')
-        },
-        module: {
-          rules: [
-            {
-              test: /\.tsx?$/,
-              loader: 'ts-loader',
-              options: tsLoaderOptions
-            }
-          ]
-        },
-        plugins: [plugin]
-      })
-    );
+    return webpack({
+      ...(webpackMajorVersion >= 4 ? { mode: 'development' } : {}),
+      context: path.resolve(__dirname, './project'),
+      entry: entryPoint,
+      output: {
+        path: path.resolve(__dirname, '../../tmp')
+      },
+      module: {
+        rules: [
+          {
+            test: /\.tsx?$/,
+            loader: 'ts-loader',
+            options: tsLoaderOptions
+          }
+        ]
+      },
+      plugins: [plugin]
+    });
   }
 
   /**

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -22,49 +22,45 @@ describe('[INTEGRATION] vue', function() {
   var checker;
 
   function createCompiler(options) {
-    plugin = new ForkTsCheckerWebpackPlugin(
-      Object.assign({}, options, { silent: true })
-    );
+    plugin = new ForkTsCheckerWebpackPlugin({ ...options, silent: true });
 
-    compiler = webpack(
-      Object.assign(
-        webpackMajorVersion >= 4 ? { mode: 'development' } : {},
-        {
-        context: path.resolve(__dirname, './vue'),
-        entry: './src/index.ts',
-        output: {
-          path: path.resolve(__dirname, '../../tmp')
-        },
-        resolve: {
-          extensions: ['.ts', '.js', '.vue', '.json'],
-          alias: {
-            '@': path.resolve(__dirname, './vue/src')
-          }
-        },
-        module: {
-          rules: [
-            {
-              test: /\.vue$/,
-              loader: 'vue-loader'
-            },
-            {
-              test: /\.ts$/,
-              loader: 'ts-loader',
-              options: {
-                appendTsSuffixTo: [/\.vue$/],
-                transpileOnly: true,
-                silent: true
-              }
-            },
-            {
-              test: /\.css$/,
-              loader: 'css-loader'
+    compiler = webpack({
+      ...(webpackMajorVersion >= 4 ? { mode: 'development' } : {}),
+      context: path.resolve(__dirname, './vue'),
+      entry: './src/index.ts',
+      output: {
+        path: path.resolve(__dirname, '../../tmp')
+      },
+      resolve: {
+        extensions: ['.ts', '.js', '.vue', '.json'],
+        alias: {
+          '@': path.resolve(__dirname, './vue/src')
+        }
+      },
+      module: {
+        rules: [
+          {
+            test: /\.vue$/,
+            loader: 'vue-loader'
+          },
+          {
+            test: /\.ts$/,
+            loader: 'ts-loader',
+            options: {
+              appendTsSuffixTo: [/\.vue$/],
+              transpileOnly: true,
+              silent: true
             }
-          ]
-        },
-        plugins: webpackMajorVersion >= 4 ? [new VueLoaderPlugin(), plugin] : [plugin],
-      }
-    ));
+          },
+          {
+            test: /\.css$/,
+            loader: 'css-loader'
+          }
+        ]
+      },
+      plugins:
+        webpackMajorVersion >= 4 ? [new VueLoaderPlugin(), plugin] : [plugin]
+    });
 
     files = {
       'example.vue': path.resolve(compiler.context, 'src/example.vue'),

--- a/test/unit/NormalizedMessage.spec.js
+++ b/test/unit/NormalizedMessage.spec.js
@@ -51,17 +51,11 @@ describe('[UNIT] NormalizedMessage', function() {
     expect(jsonMessage).to.be.instanceof(NormalizedMessage);
     expect(jsonMessage.type).to.be.equal(diagnosticMessage.type);
     expect(jsonMessage.code).to.be.equal(diagnosticMessage.code);
-    expect(jsonMessage.severity).to.be.equal(
-      diagnosticMessage.severity
-    );
-    expect(jsonMessage.content).to.be.equal(
-      diagnosticMessage.content
-    );
+    expect(jsonMessage.severity).to.be.equal(diagnosticMessage.severity);
+    expect(jsonMessage.content).to.be.equal(diagnosticMessage.content);
     expect(jsonMessage.file).to.be.equal(diagnosticMessage.file);
     expect(jsonMessage.line).to.be.equal(diagnosticMessage.line);
-    expect(jsonMessage.character).to.be.equal(
-      diagnosticMessage.character
-    );
+    expect(jsonMessage.character).to.be.equal(diagnosticMessage.character);
   });
 
   it('should check type', function() {
@@ -176,9 +170,10 @@ describe('[UNIT] NormalizedMessage', function() {
   it('should compare messages', function() {
     var messageA = diagnosticMessage;
     function buildMessage(diff) {
-      return NormalizedMessage.createFromJSON(
-        Object.assign({}, messageA.toJSON(), diff)
-      );
+      return NormalizedMessage.createFromJSON({
+        ...messageA.toJSON(),
+        ...diff
+      });
     }
 
     expect(NormalizedMessage.compare(messageA, undefined)).to.be.greaterThan(0);


### PR DESCRIPTION
Just following up from #166 and #169:

Since we've already dropped support for Node 6 in #166, object spread properties can now be safely used. (As briefly discussed [here](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/166#pullrequestreview-164500790))

In `.eslintrc.json`, `"experimentalObjectRestSpread": true` and `"ecmaVersion": 6` should be kept, since Node 8 supports 99% of ES2015 features, and object-spread is just a ES2018 feature, but is [fully supported in Node 8](https://node.green/#ES2018-features-object-rest-spread-properties) and above. (Also mentioned in #169, [here](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/169#pullrequestreview-165328521))

---

Note: This PR does not introduce any functionality changes