### PR TITLE
WIP: Fix incremental api for vue files (#219)

### DIFF
--- a/src/ApiIncrementalChecker.ts
+++ b/src/ApiIncrementalChecker.ts
@@ -41,7 +41,8 @@ export class ApiIncrementalChecker implements IncrementalCheckerInterface {
     private context: string,
     private linterConfigFile: string | boolean,
     private linterAutoFix: boolean,
-    checkSyntacticErrors: boolean
+    checkSyntacticErrors: boolean,
+    private vue: boolean = false
   ) {
     this.hasFixedConfig = typeof this.linterConfigFile === 'string';
 
@@ -51,7 +52,8 @@ export class ApiIncrementalChecker implements IncrementalCheckerInterface {
       typescript,
       programConfigFile,
       compilerOptions,
-      checkSyntacticErrors
+      checkSyntacticErrors,
+      this.vue
     );
   }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -30,7 +30,8 @@ const checker: IncrementalCheckerInterface =
         process.env.CONTEXT!,
         process.env.TSLINT === 'true' ? true : process.env.TSLINT! || false,
         process.env.TSLINTAUTOFIX === 'true',
-        process.env.CHECK_SYNTACTIC_ERRORS === 'true'
+        process.env.CHECK_SYNTACTIC_ERRORS === 'true',
+        process.env.VUE === 'true'
       )
     : new IncrementalChecker(
         typescript,

--- a/test/integration/vue.spec.js
+++ b/test/integration/vue.spec.js
@@ -6,258 +6,274 @@ var process = require('process');
 var unixify = require('unixify');
 var helpers = require('./helpers');
 
-describe('[INTEGRATION] vue', function() {
-  this.timeout(60000);
-  process.setMaxListeners(0);
-  var files;
-  var compiler;
-  var checker;
+describe(
+  '[INTEGRATION] vue tests - useTypescriptIncrementalApi: true',
+  makeCommonTests(true)
+);
+describe(
+  '[INTEGRATION] vue tests - useTypescriptIncrementalApi: false',
+  makeCommonTests(false)
+);
 
-  function createCompiler(options) {
-    var vueCompiler = helpers.createVueCompiler(options);
-    files = vueCompiler.files;
-    compiler = vueCompiler.compiler;
-    checker = vueCompiler.checker;
-  }
+function makeCommonTests(useTypescriptIncrementalApi) {
+  return function() {
+    this.timeout(60000);
+    process.setMaxListeners(0);
+    var files;
+    var compiler;
+    var checker;
 
-  it('should create a Vue program config if vue=true', function() {
-    createCompiler({ vue: true });
-
-    var fileFound;
-    var fileWeWant = unixify(files['example.vue']);
-    fileFound = checker.programConfig.fileNames.some(
-      filename => unixify(filename) === fileWeWant
-    );
-    expect(fileFound).to.be.true;
-
-    fileWeWant = unixify(files['syntacticError.ts']);
-    fileFound = checker.programConfig.fileNames.some(
-      filename => unixify(filename) === fileWeWant
-    );
-    expect(fileFound).to.be.true;
-  });
-
-  it('should not create a Vue program config if vue=false', function() {
-    createCompiler();
-
-    var fileFound;
-    var fileWeWant = unixify(files['example.vue']);
-
-    fileFound = checker.programConfig.fileNames.some(
-      filename => unixify(filename) === fileWeWant
-    );
-    expect(fileFound).to.be.false;
-
-    fileWeWant = unixify(files['syntacticError.ts']);
-    fileFound = checker.programConfig.fileNames.some(
-      filename => unixify(filename) === fileWeWant
-    );
-    expect(fileFound).to.be.true;
-  });
-
-  it('should create a Vue program if vue=true', function() {
-    createCompiler({ vue: true });
-
-    var source;
-
-    source = checker.program.getSourceFile(files['example.vue']);
-    expect(source).to.not.be.undefined;
-
-    source = checker.program.getSourceFile(files['syntacticError.ts']);
-    expect(source).to.not.be.undefined;
-  });
-
-  it('should not create a Vue program if vue=false', function() {
-    createCompiler();
-
-    var source;
-
-    source = checker.program.getSourceFile(files['example.vue']);
-    expect(source).to.be.undefined;
-
-    source = checker.program.getSourceFile(files['syntacticError.ts']);
-    expect(source).to.not.be.undefined;
-  });
-
-  it('should get syntactic diagnostics from Vue program', function() {
-    createCompiler({ tslint: true, vue: true });
-
-    const diagnostics = checker.program.getSyntacticDiagnostics();
-    expect(diagnostics.length).to.be.equal(1);
-  });
-
-  it('should not find syntactic errors when checkSyntacticErrors is false', function(callback) {
-    createCompiler({ tslint: true, vue: true });
-
-    compiler.run(function(error, stats) {
-      expect(stats.compilation.errors.length).to.be.equal(1);
-      callback();
-    });
-  });
-
-  it('should not report no-consecutive-blank-lines tslint rule', function(callback) {
-    createCompiler({ tslint: true, vue: true });
-
-    compiler.run(function(error, stats) {
-      stats.compilation.warnings.forEach(function(warning) {
-        expect(warning.rawMessage).to.not.match(/no-consecutive-blank-lines/);
-      });
-      callback();
-    });
-  });
-
-  it('should find syntactic errors when checkSyntacticErrors is true', function(callback) {
-    createCompiler({ tslint: true, vue: true, checkSyntacticErrors: true });
-
-    compiler.run(function(error, stats) {
-      expect(stats.compilation.errors.length).to.be.equal(2);
-      callback();
-    });
-  });
-
-  it('should resolve src attribute but not report not found error', function(callback) {
-    createCompiler({ vue: true, tsconfig: 'tsconfig-attrs.json' });
-
-    compiler.run(function(error, stats) {
-      const errors = stats.compilation.errors;
-      expect(errors.length).to.be.equal(1);
-      expect(errors[0].file).to.match(
-        /test\/integration\/vue\/src\/attrs\/test.ts$/
-      );
-      callback();
-    });
-  });
-
-  [
-    'example-ts.vue',
-    'example-tsx.vue',
-    'example-js.vue',
-    'example-jsx.vue',
-    'example-nolang.vue'
-  ].forEach(fileName => {
-    it('should be able to extract script from ' + fileName, function() {
-      createCompiler({ vue: true, tsconfig: 'tsconfig-langs.json' });
-      var sourceFilePath = path.resolve(
-        compiler.context,
-        'src/langs/' + fileName
-      );
-      var source = checker.program.getSourceFile(sourceFilePath);
-      expect(source).to.not.be.undefined;
-      // remove padding lines
-      var text = source.text.replace(/^\s*\/\/.*$\r*\n/gm, '').trim();
-      expect(text.startsWith('/* OK */')).to.be.true;
-    });
-  });
-
-  function groupByFileName(errors) {
-    var ret = {
-      'example-ts.vue': [],
-      'example-tsx.vue': [],
-      'example-js.vue': [],
-      'example-jsx.vue': [],
-      'example-nolang.vue': []
-    };
-    for (var error of errors) {
-      ret[path.basename(error.file)].push(error);
+    function createCompiler(options) {
+      options = options || {};
+      options.useTypescriptIncrementalApi = useTypescriptIncrementalApi;
+      var vueCompiler = helpers.createVueCompiler(options);
+      files = vueCompiler.files;
+      compiler = vueCompiler.compiler;
+      checker = vueCompiler.checker;
     }
-    return ret;
-  }
 
-  describe('should be able to compile *.vue with each lang', function() {
-    var errors;
-    before(function(callback) {
-      createCompiler({ vue: true, tsconfig: 'tsconfig-langs.json' });
-      compiler.run(function(error, stats) {
-        errors = groupByFileName(stats.compilation.errors);
-        callback();
-      });
-    });
-    it('lang=ts', function() {
-      expect(errors['example-ts.vue'].length).to.be.equal(0);
-    });
-    it('lang=tsx', function() {
-      expect(errors['example-tsx.vue'].length).to.be.equal(0);
-    });
-    it('lang=js', function() {
-      expect(errors['example-js.vue'].length).to.be.equal(0);
-    });
-    it('lang=jsx', function() {
-      expect(errors['example-jsx.vue'].length).to.be.equal(0);
-    });
-    it('no lang', function() {
-      expect(errors['example-nolang.vue'].length).to.be.equal(0);
-    });
-  });
+    it('should create a Vue program config if vue=true', function() {
+      createCompiler({ vue: true });
 
-  describe('should be able to detect errors in *.vue', function() {
-    var errors;
-    before(function(callback) {
-      // tsconfig-langs-strict.json === tsconfig-langs.json + noUnusedLocals
-      createCompiler({ vue: true, tsconfig: 'tsconfig-langs-strict.json' });
-      compiler.run(function(error, stats) {
-        errors = groupByFileName(stats.compilation.errors);
-        callback();
-      });
-    });
-    it('lang=ts', function() {
-      expect(errors['example-ts.vue'].length).to.be.equal(1);
-      expect(errors['example-ts.vue'][0].rawMessage).to.match(
-        /'a' is declared but/
+      var fileFound;
+      var fileWeWant = unixify(files['example.vue']);
+      fileFound = checker.programConfig.fileNames.some(
+        filename => unixify(filename) === fileWeWant
       );
-    });
-    it('lang=tsx', function() {
-      expect(errors['example-tsx.vue'].length).to.be.equal(1);
-      expect(errors['example-tsx.vue'][0].rawMessage).to.match(
-        /'a' is declared but/
-      );
-    });
-    it('lang=js', function() {
-      expect(errors['example-js.vue'].length).to.be.equal(0);
-    });
-    it('lang=jsx', function() {
-      expect(errors['example-jsx.vue'].length).to.be.equal(0);
-    });
-    it('no lang', function() {
-      expect(errors['example-nolang.vue'].length).to.be.equal(0);
-    });
-  });
+      expect(fileFound).to.be.true;
 
-  describe('should resolve *.vue in the same way as TypeScript', function() {
-    var errors;
-    before(function(callback) {
-      createCompiler({ vue: true, tsconfig: 'tsconfig-imports.json' });
+      fileWeWant = unixify(files['syntacticError.ts']);
+      fileFound = checker.programConfig.fileNames.some(
+        filename => unixify(filename) === fileWeWant
+      );
+      expect(fileFound).to.be.true;
+    });
+
+    it('should not create a Vue program config if vue=false', function() {
+      createCompiler();
+
+      var fileFound;
+      var fileWeWant = unixify(files['example.vue']);
+
+      fileFound = checker.programConfig.fileNames.some(
+        filename => unixify(filename) === fileWeWant
+      );
+      expect(fileFound).to.be.false;
+
+      fileWeWant = unixify(files['syntacticError.ts']);
+      fileFound = checker.programConfig.fileNames.some(
+        filename => unixify(filename) === fileWeWant
+      );
+      expect(fileFound).to.be.true;
+    });
+
+    it('should create a Vue program if vue=true', function() {
+      createCompiler({ vue: true });
+
+      var source;
+
+      source = checker.program.getSourceFile(files['example.vue']);
+      expect(source).to.not.be.undefined;
+
+      source = checker.program.getSourceFile(files['syntacticError.ts']);
+      expect(source).to.not.be.undefined;
+    });
+
+    it('should not create a Vue program if vue=false', function() {
+      createCompiler();
+
+      var source;
+
+      source = checker.program.getSourceFile(files['example.vue']);
+      expect(source).to.be.undefined;
+
+      source = checker.program.getSourceFile(files['syntacticError.ts']);
+      expect(source).to.not.be.undefined;
+    });
+
+    it('should get syntactic diagnostics from Vue program', function() {
+      createCompiler({ tslint: true, vue: true });
+
+      const diagnostics = checker.program.getSyntacticDiagnostics();
+      expect(diagnostics.length).to.be.equal(1);
+    });
+
+    it('should not find syntactic errors when checkSyntacticErrors is false', function(callback) {
+      createCompiler({ tslint: true, vue: true });
+
       compiler.run(function(error, stats) {
-        errors = stats.compilation.errors;
+        expect(stats.compilation.errors.length).to.be.equal(1);
         callback();
       });
     });
 
-    it('should be able to import by relative path', function() {
-      expect(
-        errors.filter(e => e.rawMessage.indexOf('./Component1.vue') >= 0).length
-      ).to.be.equal(0);
+    it('should not report no-consecutive-blank-lines tslint rule', function(callback) {
+      createCompiler({ tslint: true, vue: true });
+
+      compiler.run(function(error, stats) {
+        stats.compilation.warnings.forEach(function(warning) {
+          expect(warning.rawMessage).to.not.match(/no-consecutive-blank-lines/);
+        });
+        callback();
+      });
     });
-    it('should be able to import by path from baseUrl', function() {
-      expect(
-        errors.filter(e => e.rawMessage.indexOf('imports/Component2.vue') >= 0)
-          .length
-      ).to.be.equal(0);
+
+    it('should find syntactic errors when checkSyntacticErrors is true', function(callback) {
+      createCompiler({ tslint: true, vue: true, checkSyntacticErrors: true });
+
+      compiler.run(function(error, stats) {
+        expect(stats.compilation.errors.length).to.be.equal(2);
+        callback();
+      });
     });
-    it('should be able to import by compilerOptions.paths setting', function() {
-      expect(
-        errors.filter(e => e.rawMessage.indexOf('@/Component3.vue') >= 0).length
-      ).to.be.equal(0);
+
+    it('should resolve src attribute but not report not found error', function(callback) {
+      createCompiler({ vue: true, tsconfig: 'tsconfig-attrs.json' });
+
+      compiler.run(function(error, stats) {
+        const errors = stats.compilation.errors;
+        expect(errors.length).to.be.equal(1);
+        expect(errors[0].file).to.match(
+          /test\/integration\/vue\/src\/attrs\/test.ts$/
+        );
+        callback();
+      });
     });
-    it('should be able to import by compilerOptions.paths setting (by array)', function() {
-      expect(
-        errors.filter(e => e.rawMessage.indexOf('foo/Foo1.vue') >= 0).length
-      ).to.be.equal(0);
-      expect(
-        errors.filter(e => e.rawMessage.indexOf('foo/Foo2.vue') >= 0).length
-      ).to.be.equal(0);
+
+    [
+      'example-ts.vue',
+      'example-tsx.vue',
+      'example-js.vue',
+      'example-jsx.vue',
+      'example-nolang.vue'
+    ].forEach(fileName => {
+      it('should be able to extract script from ' + fileName, function() {
+        createCompiler({ vue: true, tsconfig: 'tsconfig-langs.json' });
+        var sourceFilePath = path.resolve(
+          compiler.context,
+          'src/langs/' + fileName
+        );
+        var source = checker.program.getSourceFile(sourceFilePath);
+        expect(source).to.not.be.undefined;
+        // remove padding lines
+        var text = source.text.replace(/^\s*\/\/.*$\r*\n/gm, '').trim();
+        expect(text.startsWith('/* OK */')).to.be.true;
+      });
     });
-    it('should not report any compilation errors', function() {
-      expect(errors.length).to.be.equal(0);
+
+    function groupByFileName(errors) {
+      var ret = {
+        'example-ts.vue': [],
+        'example-tsx.vue': [],
+        'example-js.vue': [],
+        'example-jsx.vue': [],
+        'example-nolang.vue': []
+      };
+      for (var error of errors) {
+        ret[path.basename(error.file)].push(error);
+      }
+      return ret;
+    }
+
+    describe('should be able to compile *.vue with each lang', function() {
+      var errors;
+      before(function(callback) {
+        createCompiler({ vue: true, tsconfig: 'tsconfig-langs.json' });
+        compiler.run(function(error, stats) {
+          errors = groupByFileName(stats.compilation.errors);
+          callback();
+        });
+      });
+      it('lang=ts', function() {
+        expect(errors['example-ts.vue'].length).to.be.equal(0);
+      });
+      it('lang=tsx', function() {
+        expect(errors['example-tsx.vue'].length).to.be.equal(0);
+      });
+      it('lang=js', function() {
+        expect(errors['example-js.vue'].length).to.be.equal(0);
+      });
+      it('lang=jsx', function() {
+        expect(errors['example-jsx.vue'].length).to.be.equal(0);
+      });
+      it('no lang', function() {
+        expect(errors['example-nolang.vue'].length).to.be.equal(0);
+      });
     });
-  });
-});
+
+    describe('should be able to detect errors in *.vue', function() {
+      var errors;
+      before(function(callback) {
+        // tsconfig-langs-strict.json === tsconfig-langs.json + noUnusedLocals
+        createCompiler({ vue: true, tsconfig: 'tsconfig-langs-strict.json' });
+        compiler.run(function(error, stats) {
+          errors = groupByFileName(stats.compilation.errors);
+          callback();
+        });
+      });
+      it('lang=ts', function() {
+        expect(errors['example-ts.vue'].length).to.be.equal(1);
+        expect(errors['example-ts.vue'][0].rawMessage).to.match(
+          /'a' is declared but/
+        );
+      });
+      it('lang=tsx', function() {
+        expect(errors['example-tsx.vue'].length).to.be.equal(1);
+        expect(errors['example-tsx.vue'][0].rawMessage).to.match(
+          /'a' is declared but/
+        );
+      });
+      it('lang=js', function() {
+        expect(errors['example-js.vue'].length).to.be.equal(0);
+      });
+      it('lang=jsx', function() {
+        expect(errors['example-jsx.vue'].length).to.be.equal(0);
+      });
+      it('no lang', function() {
+        expect(errors['example-nolang.vue'].length).to.be.equal(0);
+      });
+    });
+
+    describe('should resolve *.vue in the same way as TypeScript', function() {
+      var errors;
+      before(function(callback) {
+        createCompiler({ vue: true, tsconfig: 'tsconfig-imports.json' });
+        compiler.run(function(error, stats) {
+          errors = stats.compilation.errors;
+          callback();
+        });
+      });
+
+      it('should be able to import by relative path', function() {
+        expect(
+          errors.filter(e => e.rawMessage.indexOf('./Component1.vue') >= 0)
+            .length
+        ).to.be.equal(0);
+      });
+      it('should be able to import by path from baseUrl', function() {
+        expect(
+          errors.filter(
+            e => e.rawMessage.indexOf('imports/Component2.vue') >= 0
+          ).length
+        ).to.be.equal(0);
+      });
+      it('should be able to import by compilerOptions.paths setting', function() {
+        expect(
+          errors.filter(e => e.rawMessage.indexOf('@/Component3.vue') >= 0)
+            .length
+        ).to.be.equal(0);
+      });
+      it('should be able to import by compilerOptions.paths setting (by array)', function() {
+        expect(
+          errors.filter(e => e.rawMessage.indexOf('foo/Foo1.vue') >= 0).length
+        ).to.be.equal(0);
+        expect(
+          errors.filter(e => e.rawMessage.indexOf('foo/Foo2.vue') >= 0).length
+        ).to.be.equal(0);
+      });
+      it('should not report any compilation errors', function() {
+        expect(errors.length).to.be.equal(0);
+      });
+    });
+  };
+}


### PR DESCRIPTION
This is a first try to fix #219 
As I'm new to the typescript compiler I'm not sure if it's the right way to do it.
Please let me know 😁

It adds ".ts" extension to all vue files by using the hooks.
It also hooks into getSourceFile of the program to return .vue.ts files as .vue so the linter is using the correct filename.

It is pretty similar to VueProgram which is not used in the Incremental API case (CompilerHost).
I also pushed the vue config down to the CompilerHost so any additional vue related code is only executed if vue is enabled.

This works as long as tsconfig does have "noEmitOnError" set to true.
Otherwise type errors don't seem to be reported correctly at all.
This seems to be like another issue so I'm going to open a new issue for that.