### PR TITLE
add support for type-checking .mdx files

### DIFF
--- a/src/MdxProgram.ts
+++ b/src/MdxProgram.ts
@@ -1,0 +1,162 @@
+import * as fs from 'fs';
+import * as path from 'path';
+// tslint:disable-next-line:no-implicit-dependencies
+import * as ts from 'typescript'; // import for types alone
+import { FilesRegister } from './FilesRegister';
+import { FilesWatcher } from './FilesWatcher';
+
+interface ResolvedScript {
+  scriptKind: ts.ScriptKind;
+  content: string;
+}
+
+interface MdxOptions {
+  footnotes: boolean;
+  mdPlugins: unknown[];
+  hastPlugins: unknown[];
+  compilers: unknown[];
+  blocks: unknown[];
+}
+
+export class MdxProgram {
+  public static extraExtensions = ['mdx', 'md'];
+
+  public static loadProgramConfig(
+    typescript: typeof ts,
+    configFile: string,
+    compilerOptions: object
+  ) {
+    const parseConfigHost: ts.ParseConfigHost = {
+      fileExists: typescript.sys.fileExists,
+      readFile: typescript.sys.readFile,
+      useCaseSensitiveFileNames: typescript.sys.useCaseSensitiveFileNames,
+      readDirectory: (rootDir, extensions, excludes, includes, depth) => {
+        return typescript.sys.readDirectory(
+          rootDir,
+          extensions.concat(MdxProgram.extraExtensions),
+          excludes,
+          includes,
+          depth
+        );
+      }
+    };
+
+    const tsconfig = typescript.readConfigFile(
+      configFile,
+      typescript.sys.readFile
+    ).config;
+
+    tsconfig.compilerOptions = tsconfig.compilerOptions || {};
+    tsconfig.compilerOptions = {
+      ...tsconfig.compilerOptions,
+      ...compilerOptions
+    };
+
+    const parsed = typescript.parseJsonConfigFileContent(
+      tsconfig,
+      parseConfigHost,
+      path.dirname(configFile)
+    );
+
+    parsed.options.allowNonTsExtensions = true;
+
+    return parsed;
+  }
+
+  public static isMdx(filePath: string) {
+    return MdxProgram.extraExtensions.includes(path.extname(filePath).slice(1));
+  }
+
+  public static createProgram(
+    typescript: typeof ts,
+    programConfig: ts.ParsedCommandLine,
+    files: FilesRegister,
+    watcher: FilesWatcher,
+    oldProgram: ts.Program
+  ) {
+    const host = typescript.createCompilerHost(programConfig.options);
+    const realGetSourceFile = host.getSourceFile;
+
+    host.getSourceFile = (filePath, languageVersion, onError) => {
+      // first check if watcher is watching file - if not - check it's mtime
+      if (!watcher.isWatchingFile(filePath)) {
+        try {
+          const stats = fs.statSync(filePath);
+
+          files.setMtime(filePath, stats.mtime.valueOf());
+        } catch (e) {
+          // probably file does not exists
+          files.remove(filePath);
+        }
+      }
+
+      // get source file only if there is no source in files register
+      if (!files.has(filePath) || !files.getData(filePath).source) {
+        files.mutateData(filePath, data => {
+          data.source = realGetSourceFile(filePath, languageVersion, onError);
+        });
+      }
+
+      let source = files.getData(filePath).source;
+
+      // get typescript react component from mdx file
+      if (source && MdxProgram.isMdx(filePath)) {
+        const resolved = MdxProgram.resolveScriptBlock(typescript, source.text);
+        source = typescript.createSourceFile(
+          filePath,
+          resolved.content,
+          languageVersion,
+          true,
+          resolved.scriptKind
+        );
+      }
+
+      return source;
+    };
+
+    return typescript.createProgram(
+      programConfig.fileNames,
+      programConfig.options,
+      host,
+      oldProgram // re-use old program
+    );
+  }
+
+  public static resolveScriptBlock(
+    typescript: typeof ts,
+    content: string
+  ): ResolvedScript {
+    // We need to import @mdx-js/mdx lazily because it cannot be included it
+    // as direct dependency because it is an optional dependency of fork-ts-checker-webpack-plugin.
+    let compiler: { sync(mdx: string, options?: Partial<MdxOptions>): string };
+    try {
+      // tslint:disable-next-line
+      compiler = require('@mdx-js/mdx');
+    } catch (err) {
+      throw new Error(
+        'When you use `mdx` option, make sure to install `@mdx-js/mdx`.'
+      );
+    }
+
+    const src = compiler.sync(content);
+    const scriptKind = typescript.ScriptKind.TSX;
+
+    const finalContent = `
+/* tslint:disable */
+import * as React from 'react';
+declare class MDXTag extends React.Component<{ name: string; components: any; parentName?: string; props?: any }> {
+  public render(): JSX.Element;
+}
+${src}`.replace(
+      /export default class MDXContent extends React.Component \{/,
+      `export default class MDXContent extends React.Component<{components: any}> {
+        private layout: any;
+        public static isMDXComponent: boolean = true;`
+    );
+
+    return {
+      scriptKind,
+      content: finalContent
+    };
+  }
+}

--- a/src/ProgramType.ts
+++ b/src/ProgramType.ts
@@ -1,0 +1,5 @@
+export enum ProgramType {
+  typescript = 'TypeScript',
+  vue = 'vue',
+  mdx = 'mdx'
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -10,6 +10,7 @@ import {
   makeCreateNormalizedMessageFromDiagnostic,
   makeCreateNormalizedMessageFromRuleFailure
 } from './NormalizedMessageFactories';
+import { ProgramType } from './ProgramType';
 
 const typescript: typeof ts = require(process.env.TYPESCRIPT_PATH!);
 
@@ -45,7 +46,7 @@ const checker: IncrementalCheckerInterface =
         parseInt(process.env.WORK_NUMBER!, 10) || 0,
         parseInt(process.env.WORK_DIVISION!, 10) || 1,
         process.env.CHECK_SYNTACTIC_ERRORS === 'true',
-        process.env.VUE === 'true'
+        (process.env.TYPE || ProgramType.typescript) as ProgramType
       );
 
 async function run(cancellationToken: CancellationToken) {

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -71,7 +71,7 @@ exports.createVueCompiler = function(options) {
     ForkTsCheckerWebpackPlugin.ONE_CPU,
     1,
     plugin.checkSyntacticErrors,
-    plugin.vue
+    plugin.type
   );
 
   checker.nextIteration();


### PR DESCRIPTION
This allows for typechecking .mdx files for use with systems like `docz`. (see #224 and https://github.com/pedronauck/docz/issues/664 )

To use it with docz, add the following to the `doczrc.js`:

```javascript
import ForkTsCheckerPlugin from 'fork-ts-checker-webpack-plugin';

export default {
    modifyBundlerConfig: config => {
        config.plugins.push(
            new ForkTsCheckerPlugin({
                mdx: true,
                compilerOptions: {
                    noImplicitAny: false
                }
            })
        );

        return config;
    }
};
```

Note: as far as I am aware, this will not work for `.mdx` files if they are imported from another file as I did not transfer the `resolveNonTsModuleName` method from `VueProgram.ts`.
Apparently, it is also possible to use `.mdx` files to create components that are imported from normal TypeScript files. 

This is something that would not be done in the context of `docz` which I am using - in docz, an mdx file is always a top level file. I don't know if anyone out there really uses it that way, so I did not implement it.
