### PR TITLE
add concept for pluggable program factories

### DIFF
--- a/src/BasicProgramFactory.ts
+++ b/src/BasicProgramFactory.ts
@@ -1,0 +1,103 @@
+// tslint:disable-next-line:no-implicit-dependencies
+import * as ts from 'typescript'; // Imported for types alone; actual requires take place in methods below
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { PluggableProgramFactoryInterface } from './PluggableProgramFactory';
+import { FilesRegister } from './FilesRegister';
+import { FilesWatcher } from './FilesWatcher';
+
+/**
+ * @deprecated do not call directly from other files - exported just for unit testing
+ */
+export function loadProgramConfig(
+  typescript: typeof ts,
+  configFile: string,
+  compilerOptions: object
+) {
+  const tsconfig = typescript.readConfigFile(
+    configFile,
+    typescript.sys.readFile
+  ).config;
+
+  tsconfig.compilerOptions = tsconfig.compilerOptions || {};
+  tsconfig.compilerOptions = {
+    ...tsconfig.compilerOptions,
+    ...compilerOptions
+  };
+
+  const parsed = typescript.parseJsonConfigFileContent(
+    tsconfig,
+    typescript.sys,
+    path.dirname(configFile)
+  );
+
+  return parsed;
+}
+
+function createProgram(
+  typescript: typeof ts,
+  programConfig: ts.ParsedCommandLine,
+  files: FilesRegister,
+  watcher: FilesWatcher,
+  oldProgram: ts.Program
+) {
+  const host = typescript.createCompilerHost(programConfig.options);
+  const realGetSourceFile = host.getSourceFile;
+
+  host.getSourceFile = (filePath, languageVersion, onError) => {
+    // first check if watcher is watching file - if not - check it's mtime
+    if (!watcher.isWatchingFile(filePath)) {
+      try {
+        const stats = fs.statSync(filePath);
+
+        files.setMtime(filePath, stats.mtime.valueOf());
+      } catch (e) {
+        // probably file does not exists
+        files.remove(filePath);
+      }
+    }
+
+    // get source file only if there is no source in files register
+    if (!files.has(filePath) || !files.getData(filePath).source) {
+      files.mutateData(filePath, data => {
+        data.source = realGetSourceFile(filePath, languageVersion, onError);
+      });
+    }
+
+    return files.getData(filePath).source;
+  };
+
+  return typescript.createProgram(
+    programConfig.fileNames,
+    programConfig.options,
+    host,
+    oldProgram // re-use old program
+  );
+}
+
+const BasicProgramFactory: PluggableProgramFactoryInterface = {
+  watchExtensions: ['.ts', '.tsx'],
+
+  loadProgram(config) {
+    const programConfig =
+      config.programConfig ||
+      loadProgramConfig(
+        config.typescript,
+        config.configFile,
+        config.compilerOptions
+      );
+
+    const program = createProgram(
+      config.typescript,
+      programConfig,
+      config.files,
+      config.watcher!,
+      config.oldProgram!
+    );
+
+    return { programConfig, program };
+  }
+};
+
+export default BasicProgramFactory;

--- a/src/PluggableProgramFactory.ts
+++ b/src/PluggableProgramFactory.ts
@@ -1,0 +1,45 @@
+// tslint:disable-next-line:no-implicit-dependencies
+import * as ts from 'typescript'; // Imported for types alone; actual requires take place in methods below
+import { FilesRegister } from './FilesRegister';
+import { FilesWatcher } from './FilesWatcher';
+
+export interface CreateProgramConfig {
+  typescript: typeof ts;
+  configFile: string;
+  programConfig?: ts.ParsedCommandLine;
+  compilerOptions: object;
+  files: FilesRegister;
+  watcher?: FilesWatcher;
+  oldProgram?: ts.Program;
+}
+
+export interface CreateProgramResult {
+  programConfig: ts.ParsedCommandLine;
+  program: ts.Program;
+}
+
+export interface PluggableProgramFactoryInterface {
+  loadProgram(config: CreateProgramConfig): CreateProgramResult;
+  watchExtensions: string[];
+}
+
+export function loadPluggableProgramFactory(
+  pluggableProgramFactoryImport: string = __dirname + '/BasicProgramFactory'
+) {
+  let factory = require(pluggableProgramFactoryImport);
+  factory = factory.default || factory;
+
+  if (!Array.isArray(factory.watchExtensions)) {
+    throw new Error(
+      'pluggableProgramFactoryImport does not implement watchExtensions as an Array'
+    );
+  }
+
+  if (typeof factory.loadProgram !== 'function') {
+    throw new Error(
+      'pluggableProgramFactoryImport does not implement loadProgram as a function'
+    );
+  }
+
+  return factory as PluggableProgramFactoryInterface;
+}

--- a/src/VueProgramFactory.ts
+++ b/src/VueProgramFactory.ts
@@ -1,0 +1,31 @@
+import * as path from 'path';
+
+import { PluggableProgramFactoryInterface } from './PluggableProgramFactory';
+import { VueProgram } from './VueProgram';
+
+const VueProgramFactory: PluggableProgramFactoryInterface = {
+  watchExtensions: ['.ts', '.tsx', '.vue'],
+
+  loadProgram(config) {
+    const programConfig =
+      config.programConfig ||
+      VueProgram.loadProgramConfig(
+        config.typescript,
+        config.configFile,
+        config.compilerOptions
+      );
+
+    const program = VueProgram.createProgram(
+      config.typescript,
+      programConfig,
+      path.dirname(config.configFile),
+      config.files,
+      config.watcher!,
+      config.oldProgram!
+    );
+
+    return { programConfig, program };
+  }
+};
+
+export default VueProgramFactory;

--- a/src/service.ts
+++ b/src/service.ts
@@ -10,6 +10,7 @@ import {
   makeCreateNormalizedMessageFromDiagnostic,
   makeCreateNormalizedMessageFromRuleFailure
 } from './NormalizedMessageFactories';
+import { loadPluggableProgramFactory } from './PluggableProgramFactory';
 
 const typescript: typeof ts = require(process.env.TYPESCRIPT_PATH!);
 
@@ -45,7 +46,7 @@ const checker: IncrementalCheckerInterface =
         parseInt(process.env.WORK_NUMBER!, 10) || 0,
         parseInt(process.env.WORK_DIVISION!, 10) || 1,
         process.env.CHECK_SYNTACTIC_ERRORS === 'true',
-        process.env.VUE === 'true'
+        loadPluggableProgramFactory(process.env.PLUGGABLE_PROGRAM_FACTORY)
       );
 
 async function run(cancellationToken: CancellationToken) {

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -5,6 +5,8 @@ var ForkTsCheckerWebpackPlugin = require('../../lib/index');
 var IncrementalChecker = require('../../lib/IncrementalChecker')
   .IncrementalChecker;
 var NormalizedMessageFactories = require('../../lib/NormalizedMessageFactories');
+var loadPluggableProgramFactory = require('../../lib/PluggableProgramFactory')
+  .loadPluggableProgramFactory;
 
 var webpackMajorVersion = require('./webpackVersion')();
 var VueLoaderPlugin =
@@ -71,7 +73,7 @@ exports.createVueCompiler = function(options) {
     ForkTsCheckerWebpackPlugin.ONE_CPU,
     1,
     plugin.checkSyntacticErrors,
-    plugin.vue
+    loadPluggableProgramFactory(plugin.pluggableProgramFactory)
   );
 
   checker.nextIteration();

--- a/test/unit/BasicProgramFactory.spec.js
+++ b/test/unit/BasicProgramFactory.spec.js
@@ -1,0 +1,62 @@
+var describe = require('mocha').describe;
+var it = require('mocha').it;
+var expect = require('chai').expect;
+var mockRequire = require('mock-require');
+var sinon = require('sinon');
+
+describe('[UNIT] IncrementalChecker', function() {
+  var BasicProgramFactory;
+  var parseJsonConfigFileContentStub;
+
+  beforeEach(function() {
+    parseJsonConfigFileContentStub = sinon.spy(function(tsconfig) {
+      return {
+        options: tsconfig.compilerOptions
+      };
+    });
+
+    var readConfigFile = function() {
+      return {
+        config: {
+          compilerOptions: {
+            foo: true
+          }
+        }
+      };
+    };
+
+    mockRequire('typescript', {
+      parseJsonConfigFileContent: parseJsonConfigFileContentStub,
+      readConfigFile,
+      sys: {}
+    });
+
+    BasicProgramFactory = mockRequire.reRequire(
+      '../../lib/BasicProgramFactory'
+    );
+  });
+
+  afterEach(function() {
+    mockRequire.stopAll();
+  });
+
+  describe('loadProgramConfig', function() {
+    it('merges compilerOptions into config file options', function() {
+      BasicProgramFactory.loadProgramConfig(
+        require('typescript'),
+        'tsconfig.foo.json',
+        {
+          bar: false
+        }
+      );
+
+      expect(parseJsonConfigFileContentStub.calledOnce).to.equal(true);
+      expect(parseJsonConfigFileContentStub.args[0][0]).to.deep.equal({
+        compilerOptions: {
+          foo: true,
+          bar: false
+        }
+      });
+    });
+  });
+});

--- a/test/unit/IncrementalChecker.spec.js
+++ b/test/unit/IncrementalChecker.spec.js
@@ -74,24 +74,4 @@ describe('[UNIT] IncrementalChecker', function() {
       expect(pathsAreExcluded[3]).to.be.true;
     });
   });
-
-  describe('loadProgramConfig', function() {
-    it('merges compilerOptions into config file options', function() {
-      IncrementalChecker.loadProgramConfig(
-        require('typescript'),
-        'tsconfig.foo.json',
-        {
-          bar: false
-        }
-      );
-
-      expect(parseJsonConfigFileContentStub.calledOnce).to.equal(true);
-      expect(parseJsonConfigFileContentStub.args[0][0]).to.deep.equal({
-        compilerOptions: {
-          foo: true,
-          bar: false
-        }
-      });
-    });
-  });
 });


### PR DESCRIPTION
Okay, so I've been playing around a bit.

I've added a usage example here:
https://github.com/phryneas/fork-ts-checker-webpack-plugin-docz-test/blob/master/doczrc.js

and the code for @phryneas/fork-ts-checker-plugin-mdx is here:
https://github.com/phryneas/fork-ts-checker-plugin-mdx

As a next step, I would recommend moving the vue code to a separate package as well and maybe remove the `vue` configuration option. 

But that would be a breaking change - the upcoming version increment 1.0.0 could be a good chance for that as it would be a major version step?