### PR TITLE
Round compilation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.1
+
+* [Apply rounding to compilation time](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/235)
+
 ## v1.0.0
 
 * [Going 1.0](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/218)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -659,7 +659,8 @@ class ForkTsCheckerWebpackPlugin {
   private handleServiceMessage(message: Message): void {
     if (this.measureTime) {
       const delta = this.performance.now() - this.startAt;
-      this.logger.info(`compilation took: ${delta} ms.`);
+      const deltaRounded = Math.round(delta * 100) / 100;
+      this.logger.info(`Compilation took: ${deltaRounded} ms.`);
     }
     if (this.cancellationToken) {
       this.cancellationToken.cleanupCancellation();


### PR DESCRIPTION
Before: "compilation took: 549.9791609942913 ms."
After: "Compilation took: 549.98 ms."