### PR TITLE
ignoreLintWarnings shouldn't mark rule as error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.2-alpha.0
+## v1.0.2
 
 * [Fix ignoreLintWarning mark warnings as errors](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/243) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.2-alpha.0
+
+* [Fix ignoreLintWarning mark warnings as errors](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/243) 
+
 ## v1.0.1
 
 * [Apply rounding to compilation time](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/235)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2-alpha.0",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "1.0.2-alpha.0",
+  "version": "1.0.2",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -800,8 +800,10 @@ class ForkTsCheckerWebpackPlugin {
           file: message.file
         };
 
-        if (message.isWarningSeverity() && !this.ignoreLintWarnings) {
-          compilation.warnings.push(formatted);
+        if (message.isWarningSeverity()) {
+          if (!this.ignoreLintWarnings) {
+            compilation.warnings.push(formatted);
+          }
         } else {
           compilation.errors.push(formatted);
         }

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -93,6 +93,21 @@ function makeCommonTests(useTypescriptIncrementalApi) {
       );
     });
 
+    it('should not mark warnings as errors when ignoreLintWarnings passed as option', function(callback) {
+      const fileName = 'lintingError2';
+      helpers.testLintAutoFixTest(
+        callback,
+        fileName,
+        {
+          tslint: true,
+          ignoreLintWarnings: true
+        },
+        (err, stats) => {
+          expect(stats.compilation.errors.length).to.be.eq(0);
+        }
+      );
+    });
+
     it('should find semantic errors', function(callback) {
       var compiler = createCompiler({
         tsconfig: 'tsconfig-semantic-error-only.json'


### PR DESCRIPTION
Nested condition to fix the case when warning is marked as error when enabling `ignoreLintWarnings` 