### PR TITLE
gracefully handle error thrown from the service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.4
+
+* [gracefully handle error thrown from the service](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/249)
+
 ## v1.0.3
 
 * [use worker-rpc library for inter-process communication](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/231)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/NormalizedMessage.ts
+++ b/src/NormalizedMessage.ts
@@ -1,4 +1,4 @@
-export type ErrorType = 'diagnostic' | 'lint' | 'internal';
+export type ErrorType = 'diagnostic' | 'lint';
 export type Severity = 'error' | 'warning';
 
 interface NormalizedMessageJson {
@@ -15,11 +15,12 @@ interface NormalizedMessageJson {
 export class NormalizedMessage {
   public static readonly TYPE_DIAGNOSTIC: ErrorType = 'diagnostic';
   public static readonly TYPE_LINT: ErrorType = 'lint';
-  public static readonly TYPE_INTERNAL: ErrorType = 'internal';
 
   // severity types
   public static readonly SEVERITY_ERROR: Severity = 'error';
   public static readonly SEVERITY_WARNING: Severity = 'warning';
+
+  public static readonly ERROR_CODE_INTERNAL = 'INTERNAL_ERROR';
 
   public readonly type: ErrorType;
   public readonly code: string | number;
@@ -168,10 +169,6 @@ export class NormalizedMessage {
 
   public isLintType() {
     return NormalizedMessage.TYPE_LINT === this.type;
-  }
-
-  public isInternalType() {
-    return NormalizedMessage.TYPE_INTERNAL === this.type;
   }
 
   public getFormattedCode() {

--- a/src/NormalizedMessage.ts
+++ b/src/NormalizedMessage.ts
@@ -1,4 +1,4 @@
-export type ErrorType = 'diagnostic' | 'lint';
+export type ErrorType = 'diagnostic' | 'lint' | 'internal';
 export type Severity = 'error' | 'warning';
 
 interface NormalizedMessageJson {
@@ -9,11 +9,13 @@ interface NormalizedMessageJson {
   file?: string;
   line?: number;
   character?: number;
+  stack?: string;
 }
 
 export class NormalizedMessage {
   public static readonly TYPE_DIAGNOSTIC: ErrorType = 'diagnostic';
   public static readonly TYPE_LINT: ErrorType = 'lint';
+  public static readonly TYPE_INTERNAL: ErrorType = 'internal';
 
   // severity types
   public static readonly SEVERITY_ERROR: Severity = 'error';
@@ -26,6 +28,7 @@ export class NormalizedMessage {
   public readonly file?: string;
   public readonly line?: number;
   public readonly character?: number;
+  public readonly stack?: string;
 
   constructor(data: NormalizedMessageJson) {
     this.type = data.type;
@@ -35,6 +38,7 @@ export class NormalizedMessage {
     this.file = data.file;
     this.line = data.line;
     this.character = data.character;
+    this.stack = data.stack;
   }
 
   public static createFromJSON(json: NormalizedMessageJson) {
@@ -72,6 +76,10 @@ export class NormalizedMessage {
       NormalizedMessage.compareOptionalStrings(
         messageA.content,
         messageB.content
+      ) ||
+      NormalizedMessage.compareOptionalStrings(
+        messageA.stack,
+        messageB.stack
       ) ||
       0 /* EqualTo */
     );
@@ -149,7 +157,8 @@ export class NormalizedMessage {
       content: this.content,
       file: this.file,
       line: this.line,
-      character: this.character
+      character: this.character,
+      stack: this.stack
     } as NormalizedMessageJson;
   }
 
@@ -159,6 +168,10 @@ export class NormalizedMessage {
 
   public isLintType() {
     return NormalizedMessage.TYPE_LINT === this.type;
+  }
+
+  public isInternalType() {
+    return NormalizedMessage.TYPE_INTERNAL === this.type;
   }
 
   public getFormattedCode() {

--- a/src/NormalizedMessageFactories.ts
+++ b/src/NormalizedMessageFactories.ts
@@ -58,3 +58,18 @@ export const makeCreateNormalizedMessageFromRuleFailure = () => {
   };
   return createNormalizedMessageFromRuleFailure;
 };
+
+export const makeCreateNormalizedMessageFromInternalError = () => {
+  const createNormalizedMessageFromInternalError = (error: any) => {
+    return new NormalizedMessage({
+      type: NormalizedMessage.TYPE_DIAGNOSTIC,
+      severity: NormalizedMessage.SEVERITY_ERROR,
+      code: NormalizedMessage.ERROR_CODE_INTERNAL,
+      content:
+        typeof error.message === 'string' ? error.message : error.toString(),
+      stack: typeof error.stack === 'string' ? error.stack : undefined,
+      file: '[internal]'
+    });
+  };
+  return createNormalizedMessageFromInternalError;
+};

--- a/src/formatter/codeframeFormatter.ts
+++ b/src/formatter/codeframeFormatter.ts
@@ -22,7 +22,7 @@ export function createCodeframeFormatter(options: any) {
       : colors.bold.red;
     const positionColor = colors.dim;
 
-    if (message.isInternalType()) {
+    if (message.code === NormalizedMessage.ERROR_CODE_INTERNAL) {
       return (
         messageColor(`INTERNAL ${message.severity.toUpperCase()}: `) +
         message.content +

--- a/src/formatter/codeframeFormatter.ts
+++ b/src/formatter/codeframeFormatter.ts
@@ -22,6 +22,16 @@ export function createCodeframeFormatter(options: any) {
       : colors.bold.red;
     const positionColor = colors.dim;
 
+    if (message.isInternalType()) {
+      return (
+        messageColor(`INTERNAL ${message.severity.toUpperCase()}: `) +
+        message.content +
+        (message.stack
+          ? os.EOL + 'stack trace:' + os.EOL + colors.gray(message.stack)
+          : '')
+      );
+    }
+
     const file = message.file;
     const source =
       file && FsHelper.existsSync(file) && fs.readFileSync(file, 'utf-8');

--- a/src/formatter/defaultFormatter.ts
+++ b/src/formatter/defaultFormatter.ts
@@ -19,6 +19,16 @@ export function createDefaultFormatter() {
     const fileAndNumberColor = colors.bold.cyan;
     const codeColor = colors.grey;
 
+    if (message.isInternalType()) {
+      return (
+        messageColor(`INTERNAL ${message.severity.toUpperCase()}: `) +
+        message.content +
+        (message.stack
+          ? os.EOL + 'stack trace:' + os.EOL + colors.gray(message.stack)
+          : '')
+      );
+    }
+
     return [
       messageColor(`${message.severity.toUpperCase()} in `) +
         fileAndNumberColor(

--- a/src/formatter/defaultFormatter.ts
+++ b/src/formatter/defaultFormatter.ts
@@ -19,7 +19,7 @@ export function createDefaultFormatter() {
     const fileAndNumberColor = colors.bold.cyan;
     const codeColor = colors.grey;
 
-    if (message.isInternalType()) {
+    if (message.code === NormalizedMessage.ERROR_CODE_INTERNAL) {
       return (
         messageColor(`INTERNAL ${message.severity.toUpperCase()}: `) +
         message.content +

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,9 @@ class ForkTsCheckerWebpackPlugin {
   private measureTime: boolean;
   private performance: any;
   private startAt: number = 0;
+
+  private nodeArgs: string[] = [];
+
   constructor(options?: Partial<Options>) {
     options = options || ({} as Options);
     this.options = { ...options };
@@ -573,10 +576,10 @@ class ForkTsCheckerWebpackPlugin {
       ),
       [],
       {
-        execArgv:
-          this.workersNumber > 1
-            ? []
-            : ['--max-old-space-size=' + this.memoryLimit],
+        execArgv: (this.workersNumber > 1
+          ? []
+          : ['--max-old-space-size=' + this.memoryLimit]
+        ).concat(this.nodeArgs),
         env: {
           ...process.env,
           TYPESCRIPT_PATH: this.typescriptPath,

--- a/src/service.ts
+++ b/src/service.ts
@@ -8,7 +8,8 @@ import { IncrementalCheckerInterface } from './IncrementalCheckerInterface';
 import { ApiIncrementalChecker } from './ApiIncrementalChecker';
 import {
   makeCreateNormalizedMessageFromDiagnostic,
-  makeCreateNormalizedMessageFromRuleFailure
+  makeCreateNormalizedMessageFromRuleFailure,
+  makeCreateNormalizedMessageFromInternalError
 } from './NormalizedMessageFactories';
 import { RpcProvider } from 'worker-rpc';
 import { RunPayload, RunResult, RUN } from './RpcTypes';
@@ -30,6 +31,7 @@ export const createNormalizedMessageFromDiagnostic = makeCreateNormalizedMessage
   typescript
 );
 export const createNormalizedMessageFromRuleFailure = makeCreateNormalizedMessageFromRuleFailure();
+export const createNormalizedMessageFromInternalError = makeCreateNormalizedMessageFromInternalError();
 
 const checker: IncrementalCheckerInterface =
   process.env.USE_INCREMENTAL_API === 'true'
@@ -76,26 +78,7 @@ async function run(cancellationToken: CancellationToken) {
       return undefined;
     }
 
-    diagnostics.push(
-      new NormalizedMessage(
-        error instanceof Error
-          ? {
-              type: NormalizedMessage.TYPE_INTERNAL,
-              severity: NormalizedMessage.SEVERITY_ERROR,
-              code: '',
-              content: error.message,
-              stack: error.stack,
-              file: '[internal]'
-            }
-          : {
-              type: NormalizedMessage.TYPE_INTERNAL,
-              severity: NormalizedMessage.SEVERITY_ERROR,
-              code: '',
-              content: error.toString(),
-              file: '[internal]'
-            }
-      )
-    );
+    diagnostics.push(createNormalizedMessageFromInternalError(error));
   }
 
   if (cancellationToken.isCancellationRequested()) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -64,9 +64,9 @@ async function run(cancellationToken: CancellationToken) {
   let diagnostics: NormalizedMessage[] = [];
   let lints: NormalizedMessage[] = [];
 
-  checker.nextIteration();
-
   try {
+    checker.nextIteration();
+
     diagnostics = await checker.getDiagnostics(cancellationToken);
     if (checker.hasLinter()) {
       lints = checker.getLints(cancellationToken);
@@ -76,7 +76,26 @@ async function run(cancellationToken: CancellationToken) {
       return undefined;
     }
 
-    throw error;
+    diagnostics.push(
+      new NormalizedMessage(
+        error instanceof Error
+          ? {
+              type: NormalizedMessage.TYPE_INTERNAL,
+              severity: NormalizedMessage.SEVERITY_ERROR,
+              code: '',
+              content: error.message,
+              stack: error.stack,
+              file: '[internal]'
+            }
+          : {
+              type: NormalizedMessage.TYPE_INTERNAL,
+              severity: NormalizedMessage.SEVERITY_ERROR,
+              code: '',
+              content: error.toString(),
+              file: '[internal]'
+            }
+      )
+    );
   }
 
   if (cancellationToken.isCancellationRequested()) {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -381,6 +381,7 @@ function makeCommonTests(useTypescriptIncrementalApi) {
 
 describe('[INTEGRATION] specific tests for useTypescriptIncrementalApi: false', function() {
   this.timeout(60000);
+  var plugin;
 
   function createCompiler(
     options,
@@ -390,6 +391,7 @@ describe('[INTEGRATION] specific tests for useTypescriptIncrementalApi: false', 
     options = options || {};
     options.useTypescriptIncrementalApi = false;
     var compiler = helpers.createCompiler(options, happyPackMode, entryPoint);
+    plugin = compiler.plugin;
     return compiler.webpack;
   }
 
@@ -455,6 +457,20 @@ describe('[INTEGRATION] specific tests for useTypescriptIncrementalApi: false', 
     compiler.run(function(error, stats) {
       expect(stats.compilation.errors.length).to.equal(1);
       expect(stats.compilation.errors[0].file.endsWith('index.ts')).to.be.true;
+      callback();
+    });
+  });
+
+  it('should handle errors within the IncrementalChecker gracefully as diagnostic', callback => {
+    var compiler = createCompiler();
+    plugin.nodeArgs = [
+      `--require`,
+      `${path.resolve(__dirname, './mocks/IncrementalCheckerWithError.js')}`
+    ];
+
+    compiler.run(function(error, stats) {
+      expect(stats.compilation.errors.length).to.equal(1);
+      expect(stats.compilation.errors[0].message).to.include("I'm an error!");
       callback();
     });
   });

--- a/test/integration/mocks/IncrementalCheckerWithError.js
+++ b/test/integration/mocks/IncrementalCheckerWithError.js
@@ -1,0 +1,9 @@
+const mock = require('mock-require');
+
+mock('../../../lib/IncrementalChecker', {
+  IncrementalChecker: class {
+    nextIteration() {
+      throw new Error("I'm an error!");
+    }
+  }
+});


### PR DESCRIPTION
This needs some clarification - I'll add some in-code-comments.

PS: no need for panic, the current 1.0.3 should not break anything for anyone. 
This only addresses the case where Errors are thrown within the service (which should not happen in the first place) and in that case the 1.0.3 behaviour should only be logging an "uncaught promise" warning and nothing grave should happen.
I just had hoped to get this into the release, because it was clearly missing :/