### PR TITLE
Enables custom resolver only if they're used in incremental mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.1
+
+* [Fix a regression w/ plugins like tsconfig-paths-webpack-plugin](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/260)
+
 ## v1.1.0
 
 * [Add new custom resolution options](https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/250)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-webpack-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Runs typescript type checker and linter on separate process.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -23,7 +23,8 @@ exports.createVueCompiler = function(options) {
     resolve: {
       extensions: ['.ts', '.js', '.vue', '.json'],
       alias: {
-        '@': path.resolve(__dirname, './vue/src')
+        '@': path.resolve(__dirname, './vue/src'),
+        surprise: './src/index.ts'
       }
     },
     module: {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -35,6 +35,8 @@ function makeCommonTests(useTypescriptIncrementalApi) {
       return compiler.webpack;
     }
 
+    const skipIfIncremental = useTypescriptIncrementalApi ? it.skip : it;
+
     /**
      * Implicitly check whether killService was called by checking that
      * the service property was set to undefined.
@@ -122,6 +124,21 @@ function makeCommonTests(useTypescriptIncrementalApi) {
     it('should support custom resolution', function(callback) {
       var compiler = createCompiler({
         tsconfig: 'tsconfig-weird-resolutions.json',
+        resolveModuleNameModule: `${__dirname}/project/weirdResolver.js`,
+        resolveTypeReferenceDirectiveModule: `${__dirname}/project/weirdResolver.js`
+      });
+
+      compiler.run(function(err, stats) {
+        expect(stats.compilation.errors.length).to.be.eq(0);
+        callback();
+      });
+    });
+
+    skipIfIncremental('should support custom resolution w/ "paths"', function(
+      callback
+    ) {
+      var compiler = createCompiler({
+        tsconfig: 'tsconfig-weird-resolutions-with-paths.json',
         resolveModuleNameModule: `${__dirname}/project/weirdResolver.js`,
         resolveTypeReferenceDirectiveModule: `${__dirname}/project/weirdResolver.js`
       });

--- a/test/integration/project/src/pathResolutions.ts
+++ b/test/integration/project/src/pathResolutions.ts
@@ -1,0 +1,1 @@
+import 'surprise';

--- a/test/integration/project/tsconfig-weird-resolutions-with-paths.json
+++ b/test/integration/project/tsconfig-weird-resolutions-with-paths.json
@@ -1,8 +1,11 @@
 {
   "compilerOptions": {
       "lib": ["es2016"],
+      "paths": {
+          "surprise": "./index.ts"
+      }
   },
-  "exclude": [
+  "include": [
       "src/pathResolutions.ts",
       "src/weirdResolutions.ts"
   ]


### PR DESCRIPTION
This diff only adds the custom `resolveModuleNames` wrapper if the custom resolution is really used. It theoretically shouldn't be needed (we should be able to implement the default resolution), but there's a problem in TS with the watch system.

Since it's only about the native TS watch system, I've only made the change in `CompilerHost` (not in `IncrementalWatcher`).

Tests are a bit more funky since it requires a plugin. Thoughts?