### PR TITLE
Add `all_branches: true` to the deploy config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,5 @@ jobs:
         skip_cleanup: true
         script:
           - yarn exec semantic-release
+        on:
+          all_branches: true

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "test:watch": "mocha -R spec --watch ./test/unit",
     "watch": "tsc --version && tsc --project \"./src\" --watch",
     "precommit": "lint-staged && yarn build",
-    "commit": "./node_modules/.bin/git-cz",
-    "semantic-release": "semantic-release"
+    "commit": "./node_modules/.bin/git-cz"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
semantic-release is responsible for checking whether package should be
deployed on the current branch or not. By setting `all_branches: true`
in the deploy job, we move this responsibility away from Travis CI.