### PR TITLE
Semantic release improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,7 @@ jobs:
         script:
           - yarn exec semantic-release
         on:
-          all_branches: true
+          branches:
+            only:
+              - beta
+              - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## ⚠️ Next versions are available only on the [GitHub Releases](https://github.com/Realytics/fork-ts-checker-webpack-plugin/releases) page ⚠️
+
 # [1.3.0-beta.1](https://github.com/Realytics/fork-ts-checker-webpack-plugin/compare/v1.2.0...v1.3.0-beta.1@beta) (2019-04-30)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,40 +3,52 @@
 # [1.3.0-beta.1](https://github.com/Realytics/fork-ts-checker-webpack-plugin/compare/v1.2.0...v1.3.0-beta.1@beta) (2019-04-30)
 
 ### Bug Fixes
-* **tests:** fix linter tests that were doing nothing ([d078278](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/d078278))
-* **tests:** linter tests - useTypescriptIncrementalApi usage ([e0020d6](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/e0020d6))
-* **tests:** rework vue integration tests ([5ad2568](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/5ad2568))
+
+- **tests:** fix linter tests that were doing nothing ([d078278](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/d078278))
+- **tests:** linter tests - useTypescriptIncrementalApi usage ([e0020d6](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/e0020d6))
+- **tests:** rework vue integration tests ([5ad2568](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/5ad2568))
+
 ### Features
-* **apiincrementalchecker:** improve generation of diagnostics ([ae80e5f](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/ae80e5f)), closes [#257](https://github.com/Realytics/fork-ts-checker-webpack-plugin/issues/257)
+
+- **apiincrementalchecker:** improve generation of diagnostics ([ae80e5f](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/ae80e5f)), closes [#257](https://github.com/Realytics/fork-ts-checker-webpack-plugin/issues/257)
 
 # [1.2.0](https://github.com/Realytics/fork-ts-checker-webpack-plugin/compare/v1.1.1...v1.2.0) (2019-04-22)
 
 ### Bug Fixes
-* 🐛 semantic-release update `CHANGELOG.md` on the git repo ([8ad58af](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/8ad58af))
+
+- semantic-release update `CHANGELOG.md` on the git repo ([8ad58af](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/8ad58af))
+
 ### Features
-* ✨ add semantic-release integration ([5fe0653](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/5fe0653))
+
+- add semantic-release integration ([5fe0653](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/5fe0653))
 
 # [1.2.0-beta.4](https://github.com/Realytics/fork-ts-checker-webpack-plugin/compare/v1.2.0-beta.3@beta...v1.2.0-beta.4@beta) (2019-04-23)
 
 ### Bug Fixes
-* **tests:** fix linter tests that were doing nothing ([d078278](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/d078278))
-* **tests:** linter tests - useTypescriptIncrementalApi usage ([e0020d6](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/e0020d6))
+
+- **tests:** fix linter tests that were doing nothing ([d078278](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/d078278))
+- **tests:** linter tests - useTypescriptIncrementalApi usage ([e0020d6](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/e0020d6))
+
 ### Features
-* **apiincrementalchecker:** improve generation of diagnostics ([ae80e5f](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/ae80e5f)), closes [#257](https://github.com/Realytics/fork-ts-checker-webpack-plugin/issues/257)
+
+- **apiincrementalchecker:** improve generation of diagnostics ([ae80e5f](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/ae80e5f)), closes [#257](https://github.com/Realytics/fork-ts-checker-webpack-plugin/issues/257)
 
 # [1.2.0-beta.3](https://github.com/Realytics/fork-ts-checker-webpack-plugin/compare/v1.2.0-beta.2@beta...v1.2.0-beta.3@beta) (2019-04-22)
 
 ### Bug Fixes
-* **tests:** rework vue integration tests ([5ad2568](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/5ad2568))
+
+- **tests:** rework vue integration tests ([5ad2568](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/5ad2568))
 
 # [1.2.0-beta.2](https://github.com/Realytics/fork-ts-checker-webpack-plugin/compare/v1.2.0-beta.1@beta...v1.2.0-beta.2@beta) (2019-04-22)
 
 ### Bug Fixes
+
 - semantic-release update `CHANGELOG.md` on the git repo ([8ad58af](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/8ad58af))
 
 # [1.2.0-beta.1](https://github.com/Realytics/fork-ts-checker-webpack-plugin/compare/v1.1.0...v1.2.0-beta.1@beta) (2019-04-22)
 
 ### Features
+
 - add semantic-release integration ([5fe0653](https://github.com/Realytics/fork-ts-checker-webpack-plugin/commit/5fe0653))
 
 ## v1.1.1

--- a/changelog.config.js
+++ b/changelog.config.js
@@ -6,37 +6,30 @@ module.exports = {
   types: {
     feat: {
       description: 'A new feature',
-      emoji: '✨ ',
       value: 'feat'
     },
     fix: {
       description: 'A bug fix',
-      emoji: '🐛',
       value: 'fix'
     },
     refactor: {
       description: 'A code change that neither adds a feature or fixes a bug',
-      emoji: '💡',
       value: 'refactor'
     },
     perf: {
       description: 'A code change that improves performance',
-      emoji: '⚡️',
       value: 'perf'
     },
     test: {
       description: 'Adding missing tests',
-      emoji: '✅ ',
       value: 'test'
     },
     chore: {
       description: 'Build process, CI or auxiliary tool changes',
-      emoji: '🔧',
       value: 'chore'
     },
     docs: {
       description: 'Documentation only changes',
-      emoji: '📖',
       value: 'docs'
     }
   }

--- a/package.json
+++ b/package.json
@@ -93,8 +93,6 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      "@semantic-release/changelog",
-      "@semantic-release/git",
       "@semantic-release/npm",
       "@semantic-release/github"
     ]
@@ -111,8 +109,6 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^7.5.0",
-    "@semantic-release/changelog": "^3.0.2",
-    "@semantic-release/git": "^7.1.0-beta.3",
     "@types/babel-code-frame": "^6.20.1",
     "@types/chokidar": "^1.7.5",
     "@types/micromatch": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,16 +228,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@semantic-release/changelog@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@semantic-release/changelog/-/changelog-3.0.2.tgz#b09a8e0d072ef54d2bc7a5c82f6112dc3c8ae85d"
-  integrity sha512-pDUaBNAuPAqQ+ArHwvR160RG2LbfyIVz9EJXgxH0V547rlx/hCs0Sp7L4Rtzi5Z+d6CHcv9g2ynxplE1xAzp2g==
-  dependencies:
-    "@semantic-release/error" "^2.1.0"
-    aggregate-error "^2.0.0"
-    fs-extra "^7.0.0"
-    lodash "^4.17.4"
-
 "@semantic-release/commit-analyzer@^7.0.0-beta.1":
   version "7.0.0-beta-.2"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-7.0.0-beta-.2.tgz#5f30919eabee8f876c5f80d270274dca34933f76"
@@ -251,26 +241,10 @@
     lodash "^4.17.4"
     micromatch "^3.1.10"
 
-"@semantic-release/error@^2.1.0", "@semantic-release/error@^2.2.0":
+"@semantic-release/error@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
   integrity sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==
-
-"@semantic-release/git@^7.1.0-beta.3":
-  version "7.1.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-7.1.0-beta.3.tgz#eeef3dbdedad6c363aa8a3bba5210a72af26a3a2"
-  integrity sha512-8IX4izJAWJVUqsugNC+JTIw3ZVdO3oEzE0K+1UAvYPlVMXxDEvpEMDOvZ8VYhYHUU4HOyoGc+CSoBmb09wrzdQ==
-  dependencies:
-    "@semantic-release/error" "^2.1.0"
-    aggregate-error "^2.0.0"
-    debug "^4.0.0"
-    dir-glob "^2.0.0"
-    execa "^1.0.0"
-    fs-extra "^7.0.0"
-    globby "^9.0.0"
-    lodash "^4.17.4"
-    micromatch "^3.1.4"
-    p-reduce "^1.0.0"
 
 "@semantic-release/github@^5.3.0-beta.6":
   version "5.3.1"


### PR DESCRIPTION
To avoid issues that we had in the #275, we drop `CHANGELOG.md` generation support. We can regenerate it  in any time using existing commit messages or by copying it from the [GitHub Releases](https://github.com/Realytics/fork-ts-checker-webpack-plugin/releases) page.