### PR TITLE
fix: add @types dependencies for tapable + webpack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,4 @@ jobs:
         script:
           - yarn exec semantic-release
         on:
-          branches:
-            only:
-              - beta
-              - master
+          all_branches: true

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     ]
   },
   "dependencies": {
+    "@types/tapable": "^1.0.4",
+    "@types/webpack": "^4.4.19",
     "babel-code-frame": "^6.22.0",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",
@@ -115,7 +117,6 @@
     "@types/minimatch": "^3.0.1",
     "@types/node": "^8.10.38",
     "@types/semver": "^5.5.0",
-    "@types/webpack": "^4.4.19",
     "chai": "^4.2.0",
     "commitlint": "^7.5.2",
     "css-loader": "0.28.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,9 +381,10 @@
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
 
-"@types/tapable@*":
+"@types/tapable@*", "@types/tapable@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
+  integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
 
 "@types/uglify-js@*":
   version "3.0.4"


### PR DESCRIPTION
Fix this error when using strict package managers like pnpm/yarn pnp:

    ERROR in /path/to/project/node_modules/.registry.npmjs.org/fork-ts-checker-webpack-plugin/1.2.0/node_modules/fork-ts-checker-webpack-plugin/lib/index.d.ts(1,26):
    TS7016: Could not find a declaration file for module 'webpack'. '/path/to/project/node_modules/.registry.npmjs.org/webpack/4.30.0/node_modules/webpack/lib/webpack.js' implicitly has an 'any' type.
      Try `npm install @types/webpack` if it exists or add a new declaration (.d.ts) file containing `declare module 'webpack';`
    ERROR in /path/to/project/node_modules/.registry.npmjs.org/fork-ts-checker-webpack-plugin/1.2.0/node_modules/fork-ts-checker-webpack-plugin/lib/index.d.ts(48,209):
    TS7016: Could not find a declaration file for module 'tapable'. '/path/to/project/node_modules/.registry.npmjs.org/tapable/1.1.3/node_modules/tapable/lib/index.js' implicitly has an 'any' type.
      Try `npm install @types/tapable` if it exists or add a new declaration (.d.ts) file containing `declare module 'tapable';`
    ERROR in /path/to/project/node_modules/.registry.npmjs.org/fork-ts-checker-webpack-plugin/1.2.0/node_modules/fork-ts-checker-webpack-plugin/lib/index.d.ts(48,253):
    TS7016: Could not find a declaration file for module 'tapable'. '/path/to/project/node_modules/.registry.npmjs.org/tapable/1.1.3/node_modules/tapable/lib/index.js' implicitly has an 'any' type.
      Try `npm install @types/tapable` if it exists or add a new declaration (.d.ts) file containing `declare module 'tapable';`