### PR TITLE
chore: fix travis deployment - revert to all_branches: true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,4 @@ jobs:
         script:
           - yarn exec semantic-release
         on:
-          branches:
-            only:
-              - beta
-              - master
+          all_branches: true


### PR DESCRIPTION
It's hard to test travis deployment on protected branches - that's why
we have to revert changes and use "all_branches: true" - specyfing more
than one branch won't work.