### PR TITLE
fix: emit global errors even when checkSyntacticErrors: false

### DIFF
--- a/src/CompilerHost.ts
+++ b/src/CompilerHost.ts
@@ -82,7 +82,12 @@ export class CompilerHost
       typescript.sys,
       typescript.createEmitAndSemanticDiagnosticsBuilderProgram,
       (diag: ts.Diagnostic) => {
-        if (!checkSyntacticErrors && diag.code >= 1000 && diag.code < 2000) {
+        if (
+          !checkSyntacticErrors &&
+          diag.code >= 1000 &&
+          diag.code < 2000 &&
+          diag.file // if diag.file is undefined, this is not a syntactic error, but a global error that should be emitted
+        ) {
           return;
         }
         this.gatheredDiagnostic.push(diag);

--- a/test/fixtures/caseSensitiveProject/src/index.ts
+++ b/test/fixtures/caseSensitiveProject/src/index.ts
@@ -1,0 +1,3 @@
+import y from './Lib';
+
+console.log(y);

--- a/test/fixtures/caseSensitiveProject/src/lib.ts
+++ b/test/fixtures/caseSensitiveProject/src/lib.ts
@@ -1,0 +1,1 @@
+export default 'test';

--- a/test/fixtures/caseSensitiveProject/tsconfig.json
+++ b/test/fixtures/caseSensitiveProject/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "lib": ["es2016"],
+    "forceConsistentCasingInFileNames": true
+  },
+  "import": ["./src/**/*"]
+}

--- a/test/integration/helpers/index.ts
+++ b/test/integration/helpers/index.ts
@@ -8,5 +8,6 @@ export { webpackMajorVersion } from './webpackVersion';
 
 export const expectedErrorCodes = {
   expectedSyntacticErrorCode: 'TS1005',
-  expectedSemanticErrorCode: 'TS2322'
+  expectedSemanticErrorCode: 'TS2322',
+  expectedGlobalErrorCode: 'TS1149'
 };

--- a/test/integration/incrementalApi.spec.ts
+++ b/test/integration/incrementalApi.spec.ts
@@ -112,4 +112,28 @@ describe('[INTEGRATION] specific tests for useTypescriptIncrementalApi: true', (
         })
     );
   });
+
+  const isCaseInsensitiveFilesystem = fs.existsSync(
+    __dirname + '/../fixtures/caseSensitiveProject/src/Lib.ts'
+  );
+
+  (isCaseInsensitiveFilesystem ? it : it.skip)(
+    'should find global errors even when checkSyntacticErrors is false (can only be tested on case-insensitive file systems)',
+    callback => {
+      const compiler = createCompiler({
+        context: './caseSensitiveProject',
+        pluginOptions: { checkSyntacticErrors: false }
+      });
+
+      compiler.run((_error, stats) => {
+        const globalErrorFoundInStats = stats.compilation.errors.some(error =>
+          error.rawMessage.includes(
+            helpers.expectedErrorCodes.expectedGlobalErrorCode
+          )
+        );
+        expect(globalErrorFoundInStats).toBe(true);
+        callback();
+      });
+    }
+  );
 });


### PR DESCRIPTION
This should close #289

Previously, global errors (judging from the TS source: errors without a file name) were suppressed when only syntactic errors should have been suppressed.
Unfortunately, `ts-loader` with `transpileOnly: true` would not report those either.

This lead to this error not being reported:

```
ERROR in undefined(undefined,undefined):
TS1149: File name 'removed/DispatchBinder.ts' differs from already included file name 'removed/dispatchBinder.ts' only in casing.
```

Thanks to @Reeywhaar for providing a reproduction repo: https://github.com/Reeywhaar/fork-ts-checker-289

(this reproduction only works on case-insensitive file-systems, so in linux it has to be checked out on a VFAT mount. As that in return won't support symlinks, *node_modules*  has to be mounted as tmpfs or something similar) 