### PR TITLE
Fix bug where compiler is not accessible by computeContextPath

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -338,10 +338,11 @@ class ForkTsCheckerWebpackPlugin {
     }
   }
 
-  private computeContextPath = (filePath: string) =>
-    path.isAbsolute(filePath)
-      ? filePath
-      : path.resolve(this.compiler.options.context, filePath);
+  private computeContextPath(filePath: string) {
+    return path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(this.compiler.options.context, filePath);
+  }
 
   private pluginStart() {
     const run = (_compiler: webpack.Compiler, callback: () => void) => {


### PR DESCRIPTION
I'm not 100% certain why this was causing a problem. I did some debugging and it turned out that computeContextPath as an arrow function had not the same `this` context. When changing it to a normal function, it works as expected.

Fixes #267 

For me this bug was happening in conjunction with serverless-webpack and having individual packaging enabled.