### PR TITLE
fix: do not lint tsconfig.json

### DIFF
--- a/src/ApiIncrementalChecker.ts
+++ b/src/ApiIncrementalChecker.ts
@@ -201,13 +201,18 @@ export class ApiIncrementalChecker implements IncrementalCheckerInterface {
 
     for (const updatedFile of this.lastUpdatedFiles) {
       cancellationToken.throwIfCancellationRequested();
-      if (this.isFileExcluded(updatedFile)) {
+      if (
+        this.isFileExcluded(updatedFile) ||
+        updatedFile.endsWith('tsconfig.json')
+      ) {
         continue;
       }
 
       const lints = this.eslinter!.getLints(updatedFile);
       if (lints !== undefined) {
         this.currentEsLintErrors.set(updatedFile, lints);
+      } else if (this.currentEsLintErrors.has(updatedFile)) {
+        this.currentEsLintErrors.delete(updatedFile);
       }
     }
 


### PR DESCRIPTION
Prospective fix for https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/312

@Austaras can you try out this fix locally and test against your issue?  If it resolves it then I'd like to get this merged and shipped.  Thanks!