### PR TITLE
feat: ctrl click on error filename sends to the file line

### DIFF
--- a/src/formatter/codeframeFormatter.ts
+++ b/src/formatter/codeframeFormatter.ts
@@ -24,7 +24,11 @@ export function createCodeframeFormatter(options: any) {
 
     if (message.code === NormalizedMessage.ERROR_CODE_INTERNAL) {
       return (
-        messageColor(`INTERNAL ${message.severity.toUpperCase()}: `) +
+        messageColor(
+          `INTERNAL ${message.severity.toUpperCase()}(${message.line},${
+            message.character
+          }) `
+        ) +
         message.content +
         (message.stack
           ? os.EOL + 'stack trace:' + os.EOL + colors.gray(message.stack)
@@ -53,7 +57,11 @@ export function createCodeframeFormatter(options: any) {
     }
 
     return (
-      messageColor(message.severity.toUpperCase() + ' in ' + message.file) +
+      messageColor(
+        message.severity.toUpperCase() +
+          ' in ' +
+          `${message.file}(${message.line},${message.character}):`
+      ) +
       os.EOL +
       positionColor(message.line + ':' + message.character) +
       ' ' +

--- a/test/unit/codeframeFormatter.spec.js
+++ b/test/unit/codeframeFormatter.spec.js
@@ -42,7 +42,7 @@ describe('[UNIT] formatter/codeframeFormatter', () => {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).toBe(
-      'ERROR in some/file.ts' +
+      'ERROR in some/file.ts(1,7):' +
         os.EOL +
         '1:7 Some diagnostic content' +
         os.EOL +
@@ -71,7 +71,7 @@ describe('[UNIT] formatter/codeframeFormatter', () => {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).toBe(
-      'WARNING in some/file.ts' +
+      'WARNING in some/file.ts(2,11):' +
         os.EOL +
         '2:11 Some lint content' +
         os.EOL +
@@ -102,7 +102,9 @@ describe('[UNIT] formatter/codeframeFormatter', () => {
     var formattedMessage = formatter(message, false);
 
     expect(formattedMessage).toBe(
-      'WARNING in some/unknown-file.ts' + os.EOL + '2:11 Some lint content'
+      'WARNING in some/unknown-file.ts(2,11):' +
+        os.EOL +
+        '2:11 Some lint content'
     );
   });
 });


### PR DESCRIPTION
When an error message is shown on an IDE console, most IDEs will allow
you to ctrl+click the file name to go directly to the proper file, line
and character. In order for this to work properly, the error filename,
line and character must have a specific format: "<filename>:<line
number>:<character number>".