### PR TITLE
feat: add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:12
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# The node image comes with a base non-root 'node' user which this Dockerfile
+# gives sudo access. However, for Linux, this user's GID/UID must match your local
+# user UID/GID to avoid permission issues with bind mounts. Update USER_UID / USER_GID 
+# if yours is not 1000. See https://aka.ms/vscode-remote/containers/non-root-user.
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
+    #
+    # Verify git and needed tools are installed
+    && apt-get install -y git procps \
+    #
+    # Remove outdated yarn from /opt and install via package 
+    # so it can be easily updated via apt-get upgrade yarn
+    && rm -rf /opt/yarn-* \
+    && rm -f /usr/local/bin/yarn \
+    && rm -f /usr/local/bin/yarnpkg \
+    && apt-get install -y curl apt-transport-https lsb-release \
+    && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
+    && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends yarn \
+    #
+    # Install eslint globally
+    && npm install -g eslint \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && if [ "$USER_GID" != "1000" ]; then groupmod node --gid $USER_GID; fi \
+    && if [ "$USER_UID" != "1000" ]; then usermod --uid $USER_UID node; fi \
+    # [Optional] Add sudo support for non-root users
+    && apt-get install -y sudo \
+    && echo node ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/node \
+    && chmod 0440 /etc/sudoers.d/node \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+    "name": "fork-ts-checker-webpack-plugin devcontainer",
+    "dockerFile": "Dockerfile",
+
+    // Specifies a list of ports that should be published.
+    "appPort": [3000],
+
+    // Comment out the next line to run as root instead. Linux users, update
+    // Dockerfile with your user's UID/GID if not 1000.
+    "runArgs": [ "-u", "node" ],
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+
+    // Specifies a command that should be run after the container has been created.
+    "postCreateCommand": "yarn install",
+
+    "extensions": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,8 @@
     "name": "fork-ts-checker-webpack-plugin devcontainer",
     "dockerFile": "Dockerfile",
 
+    "user":  "node",
+
     // Comment out the next line to run as root instead. Linux users, update
     // Dockerfile with your user's UID/GID if not 1000.
     "runArgs": [ "-u", "node" ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,6 @@
     "name": "fork-ts-checker-webpack-plugin devcontainer",
     "dockerFile": "Dockerfile",
 
-    // Specifies a list of ports that should be published.
-    "appPort": [3000],
-
     // Comment out the next line to run as root instead. Linux users, update
     // Dockerfile with your user's UID/GID if not 1000.
     "runArgs": [ "-u", "node" ],

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 os:
   - linux
   - osx
-  # - windows - travis isn't windows ready yet; tests fail for meaningless reasons
 
 language: node_js
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   include:
     - stage: release
-      node_js: 10
+      node_js: 12
       script: skip
       deploy:
         provider: script


### PR DESCRIPTION
I use a Windows machine; the test pack for the `fork-ts-checker-webpack-plugin` has never entirely worked with Windows.  This is fine; I just switch to WSL and go with it.

This PR adds in support for VS Code's dev containers; see: https://code.visualstudio.com/docs/remote/containers#_getting-started

This helps me and may help other Windows users that would like to contribute.