### PR TITLE
feat: support for noEmitOnErrors property in webpack.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ This plugin provides some custom webpack hooks (all are sync):
 | `fork-ts-checker-service-start-error`   | `serviceStartError`  | Cannot start service                                                           | `error`                                                                    |
 | `fork-ts-checker-service-out-of-memory` | `serviceOutOfMemory` | Service is out of memory                                                       | -                                                                          |
 | `fork-ts-checker-receive`               | `receive`            | Plugin receives diagnostics and lints from service                             | `diagnostics`, `lints`                                                     |
-| `fork-ts-checker-emit`                  | `emit`               | Service will add errors and warnings to webpack compilation ('build' mode)     | `diagnostics`, `lints`, `elapsed`                                          |
+| `fork-ts-checker-after-compile`         | `after-compile`      | Service will add errors and warnings to webpack compilation ('build' mode)     | `diagnostics`, `lints`, `elapsed`                                          |
 | `fork-ts-checker-done`                  | `done`               | Service finished type checking and webpack finished compilation ('watch' mode) | `diagnostics`, `lints`, `elapsed`                                          |
 
 The **Event name** is there for backward compatibility with webpack 2/3. Regardless

--- a/src/index.ts
+++ b/src/index.ts
@@ -571,7 +571,7 @@ class ForkTsCheckerWebpackPlugin {
 
     if ('hooks' in this.compiler) {
       // webpack 4+
-      this.compiler.hooks.emit.tapAsync(checkerPluginName, emit);
+      this.compiler.hooks.afterCompile.tapAsync(checkerPluginName, emit);
     } else {
       // webpack 2 / 3
       this.compiler.plugin('emit', emit);

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ class ForkTsCheckerWebpackPlugin {
   private diagnostics: NormalizedMessage[] = [];
   private lints: NormalizedMessage[] = [];
 
-  private emitCallback: () => void;
+  private afterCompileCallback: () => void;
   private doneCallback: () => void;
   private typescriptPath: string;
   private typescript: typeof ts;
@@ -184,7 +184,7 @@ class ForkTsCheckerWebpackPlugin {
             options.formatterOptions || {}
           );
 
-    this.emitCallback = this.createNoopEmitCallback();
+    this.afterCompileCallback = this.createNoopAfterCompileCallback();
     this.doneCallback = this.createDoneCallback();
 
     const {
@@ -560,10 +560,13 @@ class ForkTsCheckerWebpackPlugin {
         return;
       }
 
-      this.emitCallback = this.createEmitCallback(compilation, callback);
+      this.afterCompileCallback = this.createAfterCompileCallback(
+        compilation,
+        callback
+      );
 
       if (this.checkDone) {
-        this.emitCallback();
+        this.afterCompileCallback();
       }
 
       this.compilationDone = true;
@@ -834,7 +837,9 @@ class ForkTsCheckerWebpackPlugin {
     }
 
     if (this.compilationDone) {
-      this.isWatching && this.async ? this.doneCallback() : this.emitCallback();
+      this.isWatching && this.async
+        ? this.doneCallback()
+        : this.afterCompileCallback();
     }
   }
 
@@ -865,11 +870,11 @@ class ForkTsCheckerWebpackPlugin {
     }
   }
 
-  private createEmitCallback(
+  private createAfterCompileCallback(
     compilation: webpack.compilation.Compilation,
     callback: () => void
   ) {
-    return function emitCallback(this: ForkTsCheckerWebpackPlugin) {
+    return function afterCompileCallback(this: ForkTsCheckerWebpackPlugin) {
       if (!this.elapsed) {
         throw new Error('Execution order error');
       }
@@ -921,9 +926,9 @@ class ForkTsCheckerWebpackPlugin {
     };
   }
 
-  private createNoopEmitCallback() {
+  private createNoopAfterCompileCallback() {
     // tslint:disable-next-line:no-empty
-    return function noopEmitCallback() {};
+    return function noopAfterCompileCallback() {};
   }
 
   private printLoggerMessage(


### PR DESCRIPTION
Currently [noEmitOnErrors property](https://webpack.js.org/configuration/optimization/#optimizationnoemitonerrors) is not respected from webpack compilation in case it is set in `webpack.config.js`. As a result, the files are emitted even when there is an error in the source code. However, it turns out that `ts-loader` is working correctly in `transpileOnly: false` mode and the problem is only in case when `ts-loader` is started in `transpileOnly: true` + `ForkTsCheckerWebpackPlugin`.

After investigating the issue, it turns out that the problem is [here](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/4e8c6f98fb14dced5f40a56723b459e519d59362/src/index.ts#L574). Webpack has a logic that checks if the files should be emitted based on `compilation.errors` array. This logic is executed on `shouldEmit` hook as can be seen [here](https://github.com/webpack/webpack/blob/95d21bb39a1e700f28be776b300492c50a169fc7/lib/NoEmitOnErrorsPlugin.js#L9-L11). So, we need to put our reported `diagnostics` and `lints` in `compilation.errors` **before** `shouldEmit`. 

The `afterCompile` hook seems as a perfect solution as it is executed before `shouldEmit` and is an `async` hook. As supporting this feature is important for our error handling story, we implemented the change, spent a little time testing it and it works for our cases.

However, we're not absolutely sure for the impact of the mentioned change so we'd be glad to hear your opinion and suggestions.

Rel to: https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/57