### PR TITLE
fix: revert 2.0.0 afterCompileCallback changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ This plugin provides some custom webpack hooks (all are sync):
 | `fork-ts-checker-service-start-error`   | `serviceStartError`  | Cannot start service                                                           | `error`                                                                    |
 | `fork-ts-checker-service-out-of-memory` | `serviceOutOfMemory` | Service is out of memory                                                       | -                                                                          |
 | `fork-ts-checker-receive`               | `receive`            | Plugin receives diagnostics and lints from service                             | `diagnostics`, `lints`                                                     |
-| `fork-ts-checker-after-compile`         | `after-compile`      | Service will add errors and warnings to webpack compilation ('build' mode)     | `diagnostics`, `lints`, `elapsed`                                          |
+| `fork-ts-checker-emit`                  | `emit`               | Service will add errors and warnings to webpack compilation ('build' mode)     | `diagnostics`, `lints`, `elapsed`                                          |
 | `fork-ts-checker-done`                  | `done`               | Service finished type checking and webpack finished compilation ('watch' mode) | `diagnostics`, `lints`, `elapsed`                                          |
 
 The **Event name** is there for backward compatibility with webpack 2/3. Regardless

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ class ForkTsCheckerWebpackPlugin {
   private diagnostics: NormalizedMessage[] = [];
   private lints: NormalizedMessage[] = [];
 
-  private afterCompileCallback: () => void;
+  private emitCallback: () => void;
   private doneCallback: () => void;
   private typescriptPath: string;
   private typescript: typeof ts;
@@ -184,7 +184,7 @@ class ForkTsCheckerWebpackPlugin {
             options.formatterOptions || {}
           );
 
-    this.afterCompileCallback = this.createNoopAfterCompileCallback();
+    this.emitCallback = this.createNoopEmitCallback();
     this.doneCallback = this.createDoneCallback();
 
     const {
@@ -560,13 +560,10 @@ class ForkTsCheckerWebpackPlugin {
         return;
       }
 
-      this.afterCompileCallback = this.createAfterCompileCallback(
-        compilation,
-        callback
-      );
+      this.emitCallback = this.createEmitCallback(compilation, callback);
 
       if (this.checkDone) {
-        this.afterCompileCallback();
+        this.emitCallback();
       }
 
       this.compilationDone = true;
@@ -837,9 +834,7 @@ class ForkTsCheckerWebpackPlugin {
     }
 
     if (this.compilationDone) {
-      this.isWatching && this.async
-        ? this.doneCallback()
-        : this.afterCompileCallback();
+      this.isWatching && this.async ? this.doneCallback() : this.emitCallback();
     }
   }
 
@@ -870,11 +865,11 @@ class ForkTsCheckerWebpackPlugin {
     }
   }
 
-  private createAfterCompileCallback(
+  private createEmitCallback(
     compilation: webpack.compilation.Compilation,
     callback: () => void
   ) {
-    return function afterCompileCallback(this: ForkTsCheckerWebpackPlugin) {
+    return function emitCallback(this: ForkTsCheckerWebpackPlugin) {
       if (!this.elapsed) {
         throw new Error('Execution order error');
       }
@@ -926,9 +921,9 @@ class ForkTsCheckerWebpackPlugin {
     };
   }
 
-  private createNoopAfterCompileCallback() {
+  private createNoopEmitCallback() {
     // tslint:disable-next-line:no-empty
-    return function noopAfterCompileCallback() {};
+    return function noopEmitCallback() {};
   }
 
   private printLoggerMessage(


### PR DESCRIPTION
BREAKING CHANGE: 🧨 afterCompileCallback replaced with emitCallback

✅ Closes: #351