### PR TITLE
chore: upgrade semantic-release to the stable version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,4 +111,4 @@ jobs:
           name: lib
 
       - name: Release
-        run: npx semantic-release@16.0.0-beta.18
+        run: npx semantic-release@16.0.2

--- a/package.json
+++ b/package.json
@@ -73,21 +73,6 @@
       "path": "cz-conventional-changelog"
     }
   },
-  "release": {
-    "branches": [
-      "master",
-      {
-        "name": "beta",
-        "prerelease": true
-      }
-    ],
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      "@semantic-release/npm",
-      "@semantic-release/github"
-    ]
-  },
   "dependencies": {
     "babel-code-frame": "^6.22.0",
     "chalk": "^2.4.1",

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  branches: ['master', 'beta'],
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/npm',
+    '@semantic-release/github'
+  ]
+};


### PR DESCRIPTION
As `semantic-release` finally released a stable version, I think we should upgrade it and use for next releases 😃 