### PR TITLE
fix: bump patch version because of previous misconfiguration

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 TypeStrong
+Copyright (c) 2020 TypeStrong
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
There were an accident after upgrading semantic-release which released v4.0.0 from the beta branch. As version v4.0.0 was unpublished, we cannot re-publish this package as 4.0.0.