### PR TITLE
Change import of crypto

### DIFF
--- a/src/CancellationToken.ts
+++ b/src/CancellationToken.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';


### PR DESCRIPTION
To avoid crypto deprecation warnings, need to import crypto as default.

```
(node:10592) [DEP0091] DeprecationWarning: crypto.DEFAULT_ENCODING is deprecated.
(node:10592) [DEP0010] DeprecationWarning: crypto.createCredentials is deprecated. Use tls.createSecureContext instead.
(node:10592) [DEP0011] DeprecationWarning: crypto.Credentials is deprecated. Use tls.SecureContext instead.
(node:4568) [DEP0091] DeprecationWarning: crypto.DEFAULT_ENCODING is deprecated.
(node:4568) [DEP0010] DeprecationWarning: crypto.createCredentials is deprecated. Use tls.createSecureContext instead.
(node:4568) [DEP0011] DeprecationWarning: crypto.Credentials is deprecated. Use tls.SecureContext instead.
```