### PR TITLE
fix: properly output chained Typescript errors

### DIFF
--- a/src/ApiIncrementalChecker.ts
+++ b/src/ApiIncrementalChecker.ts
@@ -1,3 +1,4 @@
+import * as ts from 'typescript'; // used for types only
 import {
   IncrementalCheckerInterface,
   IncrementalCheckerParams
@@ -13,6 +14,7 @@ import { LintReport } from './types/eslint';
 
 export class ApiIncrementalChecker implements IncrementalCheckerInterface {
   protected readonly tsIncrementalCompiler: CompilerHost;
+  protected readonly typescript: typeof ts;
 
   private currentEsLintErrors = new Map<string, LintReport>();
   private lastUpdatedFiles: string[] = [];
@@ -41,6 +43,8 @@ export class ApiIncrementalChecker implements IncrementalCheckerInterface {
       resolveModuleName,
       resolveTypeReferenceDirective
     );
+
+    this.typescript = typescript;
   }
 
   public hasEsLinter(): boolean {
@@ -60,7 +64,10 @@ export class ApiIncrementalChecker implements IncrementalCheckerInterface {
     this.lastUpdatedFiles = tsDiagnostics.updatedFiles;
     this.lastRemovedFiles = tsDiagnostics.removedFiles;
 
-    return createIssuesFromTsDiagnostics(tsDiagnostics.results);
+    return createIssuesFromTsDiagnostics(
+      tsDiagnostics.results,
+      this.typescript
+    );
   }
 
   public async getEsLintIssues(cancellationToken: CancellationToken) {

--- a/src/IncrementalChecker.ts
+++ b/src/IncrementalChecker.ts
@@ -246,7 +246,7 @@ export class IncrementalChecker implements IncrementalCheckerInterface {
       tsDiagnostics.push(...tsDiagnosticsToRegister);
     });
 
-    return createIssuesFromTsDiagnostics(tsDiagnostics);
+    return createIssuesFromTsDiagnostics(tsDiagnostics, this.typescript);
   }
 
   public async getEsLintIssues(

--- a/src/issue/typescript/TypeScriptIssueFactory.ts
+++ b/src/issue/typescript/TypeScriptIssueFactory.ts
@@ -3,50 +3,10 @@ import { deduplicateAndSortIssues, Issue } from '../Issue';
 import { IssueOrigin } from '../IssueOrigin';
 import { IssueSeverity } from '../IssueSeverity';
 
-/**
- * Based on the TypeScript source - not used directly from the `typescript`
- * package as there is an option to pass a custom TypeScript instance.
- */
-function flattenDiagnosticMessageText(
-  messageText: string | ts.DiagnosticMessageChain,
-  indent = 0
-) {
-  if (typeof messageText === 'string') {
-    return messageText;
-  } else {
-    const diagnosticChain: ts.DiagnosticMessageChain | undefined = messageText;
-    let flattenMessageText = '';
-    if (typeof diagnosticChain === 'undefined') {
-      return flattenMessageText;
-    }
-    flattenMessageText = '  '.repeat(indent) + diagnosticChain.messageText;
-
-    if (typeof diagnosticChain.next !== 'undefined') {
-      const next = diagnosticChain.next as unknown;
-      if (typeof (next as ts.DiagnosticMessageChain[]).length === 'number') {
-        // TS 3.7+
-        (next as ts.DiagnosticMessageChain[]).forEach(
-          (chain: ts.DiagnosticMessageChain): void => {
-            flattenMessageText +=
-              '\n' + flattenDiagnosticMessageText(chain, indent + 1);
-          }
-        );
-      } else {
-        // Older versions of typescript
-        flattenMessageText +=
-          '\n' +
-          flattenDiagnosticMessageText(
-            next as ts.DiagnosticMessageChain,
-            indent + 1
-          );
-      }
-    }
-
-    return flattenMessageText;
-  }
-}
-
-function createIssueFromTsDiagnostic(diagnostic: ts.Diagnostic): Issue {
+function createIssueFromTsDiagnostic(
+  diagnostic: ts.Diagnostic,
+  typescript: typeof ts
+): Issue {
   let file: string | undefined;
   let line: number | undefined;
   let character: number | undefined;
@@ -69,15 +29,26 @@ function createIssueFromTsDiagnostic(diagnostic: ts.Diagnostic): Issue {
     // we don't handle Suggestion and Message diagnostics
     severity:
       diagnostic.category === 0 ? IssueSeverity.WARNING : IssueSeverity.ERROR,
-    message: flattenDiagnosticMessageText(diagnostic.messageText),
+    message: typescript.flattenDiagnosticMessageText(
+      diagnostic.messageText,
+      '\n'
+    ),
     file,
     line,
     character
   };
 }
 
-function createIssuesFromTsDiagnostics(diagnostic: ts.Diagnostic[]): Issue[] {
-  return deduplicateAndSortIssues(diagnostic.map(createIssueFromTsDiagnostic));
+function createIssuesFromTsDiagnostics(
+  diagnostics: ts.Diagnostic[],
+  typescript: typeof ts
+): Issue[] {
+  function createIssueFromTsDiagnosticWithFormatter(diagnostic: ts.Diagnostic) {
+    return createIssueFromTsDiagnostic(diagnostic, typescript);
+  }
+  return deduplicateAndSortIssues(
+    diagnostics.map(createIssueFromTsDiagnosticWithFormatter)
+  );
 }
 
 export { createIssueFromTsDiagnostic, createIssuesFromTsDiagnostics };

--- a/src/issue/typescript/TypeScriptIssueFactory.ts
+++ b/src/issue/typescript/TypeScriptIssueFactory.ts
@@ -8,26 +8,24 @@ import { IssueSeverity } from '../IssueSeverity';
  * package as there is an option to pass a custom TypeScript instance.
  */
 function flattenDiagnosticMessageText(
-  messageText: string | ts.DiagnosticMessageChain
+  messageText: string | ts.DiagnosticMessageChain,
+  indent = 0
 ) {
   if (typeof messageText === 'string') {
     return messageText;
   } else {
-    let diagnosticChain: ts.DiagnosticMessageChain | undefined = messageText;
+    const diagnosticChain: ts.DiagnosticMessageChain | undefined = messageText;
     let flattenMessageText = '';
-    let indent = 0;
+    if (typeof diagnosticChain === 'undefined') {
+      return flattenMessageText;
+    }
+    flattenMessageText = '  '.repeat(indent) + diagnosticChain.messageText;
 
-    while (diagnosticChain) {
-      if (indent) {
-        flattenMessageText += '\n';
-        for (let i = 0; i < indent; i++) {
-          flattenMessageText += '  ';
-        }
-      }
-
-      flattenMessageText += diagnosticChain.messageText;
-      indent++;
-      diagnosticChain = diagnosticChain.next;
+    if (typeof diagnosticChain.next !== 'undefined') {
+      diagnosticChain.next.forEach((chain: ts.DiagnosticMessageChain): void => {
+        flattenMessageText +=
+          '\n' + flattenDiagnosticMessageText(chain, indent + 1);
+      });
     }
 
     return flattenMessageText;

--- a/src/issue/typescript/TypeScriptIssueFactory.ts
+++ b/src/issue/typescript/TypeScriptIssueFactory.ts
@@ -22,9 +22,10 @@ function flattenDiagnosticMessageText(
     flattenMessageText = '  '.repeat(indent) + diagnosticChain.messageText;
 
     if (typeof diagnosticChain.next !== 'undefined') {
-      if (typeof diagnosticChain.next.length === 'number') {
+      const next = diagnosticChain.next as unknown;
+      if (typeof (next as ts.DiagnosticMessageChain[]).length === 'number') {
         // TS 3.7+
-        diagnosticChain.next.forEach(
+        (next as ts.DiagnosticMessageChain[]).forEach(
           (chain: ts.DiagnosticMessageChain): void => {
             flattenMessageText +=
               '\n' + flattenDiagnosticMessageText(chain, indent + 1);
@@ -35,7 +36,7 @@ function flattenDiagnosticMessageText(
         flattenMessageText +=
           '\n' +
           flattenDiagnosticMessageText(
-            (diagnosticChain.next as unknown) as ts.DiagnosticMessageChain,
+            next as ts.DiagnosticMessageChain,
             indent + 1
           );
       }

--- a/src/issue/typescript/TypeScriptIssueFactory.ts
+++ b/src/issue/typescript/TypeScriptIssueFactory.ts
@@ -22,10 +22,23 @@ function flattenDiagnosticMessageText(
     flattenMessageText = '  '.repeat(indent) + diagnosticChain.messageText;
 
     if (typeof diagnosticChain.next !== 'undefined') {
-      diagnosticChain.next.forEach((chain: ts.DiagnosticMessageChain): void => {
+      if (typeof diagnosticChain.next.length === 'number') {
+        // TS 3.7+
+        diagnosticChain.next.forEach(
+          (chain: ts.DiagnosticMessageChain): void => {
+            flattenMessageText +=
+              '\n' + flattenDiagnosticMessageText(chain, indent + 1);
+          }
+        );
+      } else {
+        // Older versions of typescript
         flattenMessageText +=
-          '\n' + flattenDiagnosticMessageText(chain, indent + 1);
-      });
+          '\n' +
+          flattenDiagnosticMessageText(
+            (diagnosticChain.next as unknown) as ts.DiagnosticMessageChain,
+            indent + 1
+          );
+      }
     }
 
     return flattenMessageText;

--- a/test/unit/issue/typescript/TypeScriptIssueFactory.spec.ts
+++ b/test/unit/issue/typescript/TypeScriptIssueFactory.spec.ts
@@ -2,10 +2,66 @@ import {
   createIssueFromTsDiagnostic,
   createIssuesFromTsDiagnostics
 } from '../../../../lib/issue';
-import { Diagnostic } from 'typescript';
+import * as ts from 'typescript';
+
+function makeDiagnosticMessageChainTestCase(): ts.Diagnostic {
+  const version: number = Number.parseFloat(ts.versionMajorMinor);
+  if (version <= 3.5) {
+    return ({
+      start: 12,
+      code: 1221,
+      category: 0,
+      length: 3,
+      file: undefined,
+      messageText: {
+        messageText: 'Cannot assign object to the string type',
+        category: 0,
+        code: 1221,
+        next: {
+          messageText: 'Another ident message',
+          category: 0,
+          code: 1221,
+          next: {
+            messageText: 'The most ident message',
+            category: 0,
+            code: 1221
+          }
+        }
+      }
+    } as unknown) as ts.Diagnostic;
+  } else {
+    // newer versions of typescript have the |next| property as an array
+    return ({
+      start: 12,
+      code: 1221,
+      category: 0,
+      length: 3,
+      file: undefined,
+      messageText: {
+        messageText: 'Cannot assign object to the string type',
+        category: 0,
+        code: 1221,
+        next: [
+          {
+            messageText: 'Another ident message',
+            category: 0,
+            code: 1221,
+            next: [
+              {
+                messageText: 'The most ident message',
+                category: 0,
+                code: 1221
+              }
+            ]
+          }
+        ]
+      }
+    } as unknown) as ts.Diagnostic;
+  }
+}
 
 describe('[UNIT] issue/typescript/TypeScriptIssueFactory', () => {
-  const TS_DIAGNOSTIC_WARNING: Diagnostic = {
+  const TS_DIAGNOSTIC_WARNING: ts.Diagnostic = {
     start: 100,
     code: 4221,
     category: 1,
@@ -20,7 +76,7 @@ describe('[UNIT] issue/typescript/TypeScriptIssueFactory', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any
   };
-  const TS_DIAGNOSTIC_ERROR: Diagnostic = {
+  const TS_DIAGNOSTIC_ERROR: ts.Diagnostic = {
     start: 12,
     code: 1221,
     category: 0,
@@ -35,7 +91,7 @@ describe('[UNIT] issue/typescript/TypeScriptIssueFactory', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any
   };
-  const TS_DIAGNOSTIC_WITHOUT_FILE: Diagnostic = {
+  const TS_DIAGNOSTIC_WITHOUT_FILE: ts.Diagnostic = {
     start: 12,
     code: 1221,
     category: 0,
@@ -43,77 +99,15 @@ describe('[UNIT] issue/typescript/TypeScriptIssueFactory', () => {
     messageText: 'Cannot assign object to the string type',
     file: undefined
   };
-  // Newer versions of TS have a DiagnosticMessageChain[] for the `next` field
-  const TS_DIAGNOSTIC_MESSAGE_CHAIN_ARRAY_NEXT: Diagnostic = {
-    start: 12,
-    code: 1221,
-    category: 0,
-    length: 3,
-    file: undefined,
-    messageText: {
-      messageText: 'Cannot assign object to the string type',
-      category: 0,
-      code: 1221,
-      next: [
-        {
-          messageText: 'Another ident message',
-          category: 0,
-          code: 1221,
-          next: [
-            {
-              messageText: 'The most ident message',
-              category: 0,
-              code: 1221
-            }
-          ]
-        },
-        {
-          messageText: 'Sibling message',
-          category: 0,
-          code: 1221,
-          next: [
-            {
-              messageText: 'Indented sibling message',
-              category: 0,
-              code: 1221
-            }
-          ]
-        }
-      ]
-    } as any // Cast required else this will fail on older versions of TS
-  };
-  // Older versions of TS have a DiagnosticMessageChain for the `next` field
-  const TS_DIAGNOSTIC_MESSAGE_CHAIN_NON_ARRAY_NEXT: Diagnostic = {
-    start: 12,
-    code: 1221,
-    category: 0,
-    length: 3,
-    file: undefined,
-    messageText: {
-      messageText: 'Cannot assign object to the string type',
-      category: 0,
-      code: 1221,
-      next: {
-        messageText: 'Another ident message',
-        category: 0,
-        code: 1221,
-        next: {
-          messageText: 'The most ident message',
-          category: 0,
-          code: 1221
-        }
-      }
-    } as any // Cast required else this will fail on newer versions of TS
-  };
+  const TS_DIAGNOSTIC_MESSAGE_CHAIN: ts.Diagnostic = makeDiagnosticMessageChainTestCase();
 
   it.each([
     [TS_DIAGNOSTIC_WARNING],
     [TS_DIAGNOSTIC_ERROR],
     [TS_DIAGNOSTIC_WITHOUT_FILE],
-    [TS_DIAGNOSTIC_MESSAGE_CHAIN_NON_ARRAY_NEXT],
-    [TS_DIAGNOSTIC_MESSAGE_CHAIN_ARRAY_NEXT]
+    [TS_DIAGNOSTIC_MESSAGE_CHAIN]
   ])('creates Issue from TsDiagnostic: %p', tsDiagnostic => {
-    const issue = createIssueFromTsDiagnostic(tsDiagnostic);
+    const issue = createIssueFromTsDiagnostic(tsDiagnostic, ts);
 
     expect(issue).toMatchSnapshot();
   });
@@ -124,12 +118,11 @@ describe('[UNIT] issue/typescript/TypeScriptIssueFactory', () => {
         TS_DIAGNOSTIC_WARNING,
         TS_DIAGNOSTIC_ERROR,
         TS_DIAGNOSTIC_WITHOUT_FILE,
-        TS_DIAGNOSTIC_MESSAGE_CHAIN_NON_ARRAY_NEXT,
-        TS_DIAGNOSTIC_MESSAGE_CHAIN_ARRAY_NEXT
+        TS_DIAGNOSTIC_MESSAGE_CHAIN
       ]
     ]
   ])('creates Issues from TsDiagnostics: %p', tsDiagnostics => {
-    const issues = createIssuesFromTsDiagnostics(tsDiagnostics);
+    const issues = createIssuesFromTsDiagnostics(tsDiagnostics, ts);
 
     expect(issues).toMatchSnapshot();
   });

--- a/test/unit/issue/typescript/TypeScriptIssueFactory.spec.ts
+++ b/test/unit/issue/typescript/TypeScriptIssueFactory.spec.ts
@@ -43,7 +43,8 @@ describe('[UNIT] issue/typescript/TypeScriptIssueFactory', () => {
     messageText: 'Cannot assign object to the string type',
     file: undefined
   };
-  const TS_DIAGNOSTIC_MESSAGE_CHAIN: Diagnostic = {
+  // Newer versions of TS have a DiagnosticMessageChain[] for the `next` field
+  const TS_DIAGNOSTIC_MESSAGE_CHAIN_ARRAY_NEXT: Diagnostic = {
     start: 12,
     code: 1221,
     category: 0,
@@ -79,14 +80,38 @@ describe('[UNIT] issue/typescript/TypeScriptIssueFactory', () => {
           ]
         }
       ]
-    }
+    } as any // Cast required else this will fail on older versions of TS
+  };
+  // Older versions of TS have a DiagnosticMessageChain for the `next` field
+  const TS_DIAGNOSTIC_MESSAGE_CHAIN_NON_ARRAY_NEXT: Diagnostic = {
+    start: 12,
+    code: 1221,
+    category: 0,
+    length: 3,
+    file: undefined,
+    messageText: {
+      messageText: 'Cannot assign object to the string type',
+      category: 0,
+      code: 1221,
+      next: {
+        messageText: 'Another ident message',
+        category: 0,
+        code: 1221,
+        next: {
+          messageText: 'The most ident message',
+          category: 0,
+          code: 1221
+        }
+      }
+    } as any // Cast required else this will fail on newer versions of TS
   };
 
   it.each([
     [TS_DIAGNOSTIC_WARNING],
     [TS_DIAGNOSTIC_ERROR],
     [TS_DIAGNOSTIC_WITHOUT_FILE],
-    [TS_DIAGNOSTIC_MESSAGE_CHAIN]
+    [TS_DIAGNOSTIC_MESSAGE_CHAIN_NON_ARRAY_NEXT],
+    [TS_DIAGNOSTIC_MESSAGE_CHAIN_ARRAY_NEXT]
   ])('creates Issue from TsDiagnostic: %p', tsDiagnostic => {
     const issue = createIssueFromTsDiagnostic(tsDiagnostic);
 
@@ -99,7 +124,8 @@ describe('[UNIT] issue/typescript/TypeScriptIssueFactory', () => {
         TS_DIAGNOSTIC_WARNING,
         TS_DIAGNOSTIC_ERROR,
         TS_DIAGNOSTIC_WITHOUT_FILE,
-        TS_DIAGNOSTIC_MESSAGE_CHAIN
+        TS_DIAGNOSTIC_MESSAGE_CHAIN_NON_ARRAY_NEXT,
+        TS_DIAGNOSTIC_MESSAGE_CHAIN_ARRAY_NEXT
       ]
     ]
   ])('creates Issues from TsDiagnostics: %p', tsDiagnostics => {

--- a/test/unit/issue/typescript/TypeScriptIssueFactory.spec.ts
+++ b/test/unit/issue/typescript/TypeScriptIssueFactory.spec.ts
@@ -53,16 +53,32 @@ describe('[UNIT] issue/typescript/TypeScriptIssueFactory', () => {
       messageText: 'Cannot assign object to the string type',
       category: 0,
       code: 1221,
-      next: {
-        messageText: 'Another ident message',
-        category: 0,
-        code: 1221,
-        next: {
-          messageText: 'The most ident message',
+      next: [
+        {
+          messageText: 'Another ident message',
           category: 0,
-          code: 1221
+          code: 1221,
+          next: [
+            {
+              messageText: 'The most ident message',
+              category: 0,
+              code: 1221
+            }
+          ]
+        },
+        {
+          messageText: 'Sibling message',
+          category: 0,
+          code: 1221,
+          next: [
+            {
+              messageText: 'Indented sibling message',
+              category: 0,
+              code: 1221
+            }
+          ]
         }
-      }
+      ]
     }
   };
 

--- a/test/unit/issue/typescript/__snapshots__/TypeScriptIssueFactory.spec.ts.snap
+++ b/test/unit/issue/typescript/__snapshots__/TypeScriptIssueFactory.spec.ts.snap
@@ -38,22 +38,6 @@ Object {
 }
 `;
 
-exports[`[UNIT] issue/typescript/TypeScriptIssueFactory creates Issue from TsDiagnostic: {"category": 0, "code": 1221, "file": undefined, "length": 3, "messageText": [Object], "start": 12} 2`] = `
-Object {
-  "character": undefined,
-  "code": "1221",
-  "file": undefined,
-  "line": undefined,
-  "message": "Cannot assign object to the string type
-  Another ident message
-    The most ident message
-  Sibling message
-    Indented sibling message",
-  "origin": "typescript",
-  "severity": "warning",
-}
-`;
-
 exports[`[UNIT] issue/typescript/TypeScriptIssueFactory creates Issue from TsDiagnostic: {"category": 1, "code": 4221, "file": [Object], "length": 1, "messageText": "Cannot assign string to the number type", "start": 100} 1`] = `
 Object {
   "character": 3,
@@ -66,7 +50,7 @@ Object {
 }
 `;
 
-exports[`[UNIT] issue/typescript/TypeScriptIssueFactory creates Issues from TsDiagnostics: [[Object], [Object], [Object], [Object], [Object]] 1`] = `
+exports[`[UNIT] issue/typescript/TypeScriptIssueFactory creates Issues from TsDiagnostics: [[Object], [Object], [Object], [Object]] 1`] = `
 Array [
   Object {
     "character": undefined,
@@ -85,19 +69,6 @@ Array [
     "message": "Cannot assign object to the string type
   Another ident message
     The most ident message",
-    "origin": "typescript",
-    "severity": "warning",
-  },
-  Object {
-    "character": undefined,
-    "code": "1221",
-    "file": undefined,
-    "line": undefined,
-    "message": "Cannot assign object to the string type
-  Another ident message
-    The most ident message
-  Sibling message
-    Indented sibling message",
     "origin": "typescript",
     "severity": "warning",
   },

--- a/test/unit/issue/typescript/__snapshots__/TypeScriptIssueFactory.spec.ts.snap
+++ b/test/unit/issue/typescript/__snapshots__/TypeScriptIssueFactory.spec.ts.snap
@@ -32,6 +32,20 @@ Object {
   "line": undefined,
   "message": "Cannot assign object to the string type
   Another ident message
+    The most ident message",
+  "origin": "typescript",
+  "severity": "warning",
+}
+`;
+
+exports[`[UNIT] issue/typescript/TypeScriptIssueFactory creates Issue from TsDiagnostic: {"category": 0, "code": 1221, "file": undefined, "length": 3, "messageText": [Object], "start": 12} 2`] = `
+Object {
+  "character": undefined,
+  "code": "1221",
+  "file": undefined,
+  "line": undefined,
+  "message": "Cannot assign object to the string type
+  Another ident message
     The most ident message
   Sibling message
     Indented sibling message",
@@ -52,7 +66,7 @@ Object {
 }
 `;
 
-exports[`[UNIT] issue/typescript/TypeScriptIssueFactory creates Issues from TsDiagnostics: [[Object], [Object], [Object], [Object]] 1`] = `
+exports[`[UNIT] issue/typescript/TypeScriptIssueFactory creates Issues from TsDiagnostics: [[Object], [Object], [Object], [Object], [Object]] 1`] = `
 Array [
   Object {
     "character": undefined,
@@ -60,6 +74,17 @@ Array [
     "file": undefined,
     "line": undefined,
     "message": "Cannot assign object to the string type",
+    "origin": "typescript",
+    "severity": "warning",
+  },
+  Object {
+    "character": undefined,
+    "code": "1221",
+    "file": undefined,
+    "line": undefined,
+    "message": "Cannot assign object to the string type
+  Another ident message
+    The most ident message",
     "origin": "typescript",
     "severity": "warning",
   },

--- a/test/unit/issue/typescript/__snapshots__/TypeScriptIssueFactory.spec.ts.snap
+++ b/test/unit/issue/typescript/__snapshots__/TypeScriptIssueFactory.spec.ts.snap
@@ -32,7 +32,9 @@ Object {
   "line": undefined,
   "message": "Cannot assign object to the string type
   Another ident message
-    The most ident message",
+    The most ident message
+  Sibling message
+    Indented sibling message",
   "origin": "typescript",
   "severity": "warning",
 }
@@ -68,7 +70,9 @@ Array [
     "line": undefined,
     "message": "Cannot assign object to the string type
   Another ident message
-    The most ident message",
+    The most ident message
+  Sibling message
+    Indented sibling message",
     "origin": "typescript",
     "severity": "warning",
   },


### PR DESCRIPTION
Updates `flattenDiagnosticMessageText` to properly traverse a `ts.DiagnosticMessageChain.next`, which is an array of `ts.DiagnosticMessageChain` rather than a single object