### PR TITLE
feat: support eslint fix (#323)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ There's a good explanation on setting up TypeScript ESLint support by Robert Coo
 
 - **eslintOptions** `object`:
 
-  - Options that can be used to initialise ESLint. See https://eslint.org/docs/1.0.0/developer-guide/nodejs-api#cliengine
+  - Options that can be used to initialise ESLint. See https://eslint.org/docs/developer-guide/nodejs-api#cliengine
   
 - **async** `boolean`:
   True by default - `async: false` can block webpack's emit to wait for type checker/linter and to add errors to the webpack's compilation.

--- a/src/createEslinter.ts
+++ b/src/createEslinter.ts
@@ -1,13 +1,13 @@
 import * as path from 'path';
 
-import { LintReport } from './types/eslint';
+import { LintReport, Options as EslintOptions } from './types/eslint';
 import { throwIfIsInvalidSourceFileError } from './FsHelper';
 
-export function createEslinter(eslintOptions: object) {
+export function createEslinter(eslintOptions: EslintOptions) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { CLIEngine } = require('eslint');
 
-  // See https://eslint.org/docs/1.0.0/developer-guide/nodejs-api#cliengine
+  // See https://eslint.org/docs/developer-guide/nodejs-api#cliengine
   const eslinter = new CLIEngine(eslintOptions);
 
   function getReport(filepath: string): LintReport | undefined {
@@ -21,7 +21,13 @@ export function createEslinter(eslintOptions: object) {
         return undefined;
       }
 
-      return eslinter.executeOnFiles([filepath]);
+      const lintReport = eslinter.executeOnFiles([filepath]);
+
+      if (eslintOptions && eslintOptions.fix) {
+        eslinter.outputFixes(lintReport);
+      }
+
+      return lintReport;
     } catch (e) {
       throwIfIsInvalidSourceFileError(filepath, e);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { getForkTsCheckerWebpackPluginHooks } from './hooks';
 import { RUN, RunPayload, RunResult } from './RpcTypes';
 import { Issue, IssueSeverity } from './issue';
 import { VueOptions } from './types/vue-options';
+import { Options as EslintOptions } from './types/eslint';
 
 const checkerPluginName = 'fork-ts-checker-webpack-plugin';
 
@@ -39,8 +40,8 @@ namespace ForkTsCheckerWebpackPlugin {
     tsconfig: string;
     compilerOptions: object;
     eslint: boolean;
-    /** Options to supply to eslint https://eslint.org/docs/1.0.0/developer-guide/nodejs-api#cliengine */
-    eslintOptions: object;
+    /** Options to supply to eslint https://eslint.org/docs/developer-guide/nodejs-api#cliengine */
+    eslintOptions: EslintOptions;
     async: boolean;
     ignoreDiagnostics: number[];
     ignoreLints: string[];
@@ -79,7 +80,7 @@ class ForkTsCheckerWebpackPlugin {
   private tsconfig: string;
   private compilerOptions: object;
   private eslint = false;
-  private eslintOptions: object = {};
+  private eslintOptions: EslintOptions = {};
   private ignoreDiagnostics: number[];
   private ignoreLints: string[];
   private ignoreLintWarnings: boolean;

--- a/src/types/eslint.ts
+++ b/src/types/eslint.ts
@@ -34,3 +34,65 @@ export interface LintReport {
   fixableErrorCount: number;
   fixableWarningCount: number;
 }
+
+export interface Options {
+  allowInlineConfig?: boolean;
+  baseConfig?: false | { [name: string]: any };
+  cache?: boolean;
+  cacheFile?: string;
+  cacheLocation?: string;
+  configFile?: string;
+  cwd?: string;
+  envs?: string[];
+  errorOnUnmatchedPattern?: boolean;
+  extensions?: string[];
+  fix?: boolean;
+  globals?: string[];
+  ignore?: boolean;
+  ignorePath?: string;
+  ignorePattern?: string | string[];
+  useEslintrc?: boolean;
+  parser?: string;
+  parserOptions?: ParserOptions;
+  plugins?: string[];
+  resolvePluginsRelativeTo?: string;
+  rules?: {
+    [name: string]: RuleLevel | RuleLevelAndOptions;
+  };
+  rulePaths?: string[];
+  reportUnusedDisableDirectives?: boolean;
+}
+
+interface ParserOptions {
+  ecmaVersion?:
+    | 3
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 2015
+    | 2016
+    | 2017
+    | 2018
+    | 2019
+    | 2020;
+  sourceType?: 'script' | 'module';
+  ecmaFeatures?: {
+    globalReturn?: boolean;
+    impliedStrict?: boolean;
+    jsx?: boolean;
+    experimentalObjectRestSpread?: boolean;
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
+type RuleLevel = Severity | 'off' | 'warn' | 'error';
+type Severity = 0 | 1 | 2;
+
+interface RuleLevelAndOptions extends Array<any> {
+  0: RuleLevel;
+}

--- a/src/types/eslint.ts
+++ b/src/types/eslint.ts
@@ -36,63 +36,11 @@ export interface LintReport {
 }
 
 export interface Options {
-  allowInlineConfig?: boolean;
-  baseConfig?: false | { [name: string]: any };
-  cache?: boolean;
-  cacheFile?: string;
-  cacheLocation?: string;
-  configFile?: string;
-  cwd?: string;
-  envs?: string[];
-  errorOnUnmatchedPattern?: boolean;
-  extensions?: string[];
   fix?: boolean;
-  globals?: string[];
-  ignore?: boolean;
-  ignorePath?: string;
-  ignorePattern?: string | string[];
-  useEslintrc?: boolean;
-  parser?: string;
-  parserOptions?: ParserOptions;
-  plugins?: string[];
-  resolvePluginsRelativeTo?: string;
-  rules?: {
-    [name: string]: RuleLevel | RuleLevelAndOptions;
-  };
-  rulePaths?: string[];
-  reportUnusedDisableDirectives?: boolean;
-}
 
-interface ParserOptions {
-  ecmaVersion?:
-    | 3
-    | 5
-    | 6
-    | 7
-    | 8
-    | 9
-    | 10
-    | 11
-    | 2015
-    | 2016
-    | 2017
-    | 2018
-    | 2019
-    | 2020;
-  sourceType?: 'script' | 'module';
-  ecmaFeatures?: {
-    globalReturn?: boolean;
-    impliedStrict?: boolean;
-    jsx?: boolean;
-    experimentalObjectRestSpread?: boolean;
-    [key: string]: any;
-  };
+  // The rest of the properties are not specified here because they are not
+  // directly used by this package and are instead just passed to eslint.
+  // We do this in order to avoid a dependency on @types/eslint (since the use
+  // of eslint is optional) and to avoid copying types from @types/eslint.
   [key: string]: any;
-}
-
-type RuleLevel = Severity | 'off' | 'warn' | 'error';
-type Severity = 0 | 1 | 2;
-
-interface RuleLevelAndOptions extends Array<any> {
-  0: RuleLevel;
 }


### PR DESCRIPTION
Reopening https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/pull/342 without the dependency on @types/eslint.

Resolves https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/323.