### PR TITLE
fix "ESLint fix option silently fails" issue

### DIFF
--- a/src/createEslinter.ts
+++ b/src/createEslinter.ts
@@ -24,7 +24,7 @@ export function createEslinter(eslintOptions: EslintOptions) {
       const lintReport = eslinter.executeOnFiles([filepath]);
 
       if (eslintOptions && eslintOptions.fix) {
-        eslinter.outputFixes(lintReport);
+        CLIEngine.outputFixes(lintReport);
       }
 
       return lintReport;


### PR DESCRIPTION
Call `outputFixes` on the correct object to propagate changes back to the original files.

Closes #400