### PR TITLE
fix: fix measurement formatting as per SI rules

### DIFF
--- a/src/CancellationToken.ts
+++ b/src/CancellationToken.ts
@@ -57,7 +57,7 @@ export class CancellationToken {
     const duration = Math.abs(time - this.lastCancellationCheckTime);
 
     if (duration > 10) {
-      // check no more than once every 10ms
+      // check no more than once every 10 ms
       this.lastCancellationCheckTime = time;
       this.isCancelled = fileExistsSync(this.getCancellationFilePath());
     }

--- a/src/CompilerHost.ts
+++ b/src/CompilerHost.ts
@@ -242,7 +242,7 @@ export class CompilerHost
     // We are intercepting all change notifications, and letting
     // them through only when webpack starts processing changes.
     // Therefore, at this point normally files are already all saved,
-    // so we do not need to waste another 250ms (hardcoded in TypeScript).
+    // so we do not need to waste another 250 ms (hardcoded in TypeScript).
     // On the other hand there may be occasional glitch, when our incremental
     // compiler will receive the notification too late, and process it when
     // next compilation would start.

--- a/src/index.ts
+++ b/src/index.ts
@@ -716,7 +716,7 @@ class ForkTsCheckerWebpackPlugin {
               : '')
         );
         this.logger.info(
-          'Time: ' + chalk.bold(Math.round(elapsed / 1e6).toString()) + 'ms'
+          `Time: ${chalk.bold(Math.round(elapsed / 1e6).toString())} ms`
         );
       }
     };

--- a/test/unit/CancellationToken.spec.ts
+++ b/test/unit/CancellationToken.spec.ts
@@ -123,7 +123,7 @@ describe('[UNIT] CancellationToken', () => {
     }).not.toThrowError();
   });
 
-  it('should throttle check for 10ms', done => {
+  it('should throttle check for 10 ms', done => {
     const tokenA = new CancellationToken(require('typescript'));
     const tokenB = CancellationToken.createFromJSON(
       // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
According to the SI, there should be a space between a measurement
quantity and its unit symbol, so this commit fixes this issue.