### PR TITLE
refactor(dependency): update babel-code-frame to @babel/code-frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ new ForkTsCheckerWebpackPlugin({
   (see `src/issue/` and `src/formatter/` for API reference).
 
 - **formatterOptions** `object`:
-  Options passed to formatters (currently only `codeframe` - see [available options](https://www.npmjs.com/package/babel-code-frame#options))
+  Options passed to formatters (currently only `codeframe` - see [available options](https://babeljs.io/docs/en/next/babel-code-frame.html#options))
 
 - **silent** `boolean`:
   If `true`, logger will not be used. Default: `false`.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     }
   },
   "dependencies": {
-    "babel-code-frame": "^6.22.0",
+    "@babel/code-frame": "^7.5.5",
     "chalk": "^2.4.1",
     "micromatch": "^3.1.10",
     "minimatch": "^3.0.4",
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^7.5.0",
-    "@types/babel-code-frame": "^6.20.1",
+    "@types/babel__code-frame": "^7.0.1",
     "@types/jest": "^24.0.11",
     "@types/lodash": "^4.14.134",
     "@types/micromatch": "^3.1.0",

--- a/src/formatter/CodeframeFormatter.ts
+++ b/src/formatter/CodeframeFormatter.ts
@@ -6,7 +6,7 @@ import { fileExistsSync } from '../FsHelper';
 import { IssueSeverity, IssueOrigin } from '../issue';
 import { Formatter } from './Formatter';
 import { createInternalFormatter } from './InternalFormatter';
-import codeFrame from 'babel-code-frame';
+import { codeFrameColumns } from '@babel/code-frame';
 
 interface CodeFrameFormatterOptions {
   /** Syntax highlight the code as JavaScript for terminals. default: false */
@@ -45,12 +45,15 @@ function createCodeframeFormatter(
     let frame = '';
 
     if (source) {
-      frame = codeFrame(
+      frame = codeFrameColumns(
         source,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        issue.line!, // Assertion: `codeFrame` allows passing undefined, typings are incorrect
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        issue.character!,
+        {
+          start: {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            line: issue.line!, // Assertion: `codeFrame` allows passing undefined, typings are incorrect
+            column: issue.character
+          }
+        },
         {
           highlightCode: true,
           ...(options || {})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,13 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.5.5":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  dependencies:
+    "@babel/highlight" "^7.8.3"
+
 "@babel/core@^7.1.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.4.tgz#84055750b05fcd50f9915a826b44fa347a825250"
@@ -67,6 +74,11 @@
   dependencies:
     "@babel/types" "^7.4.4"
 
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+
 "@babel/helpers@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.4.tgz#868b0ef59c1dd4e78744562d5ce1b59c89f2f2a5"
@@ -82,6 +94,15 @@
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.8.3":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
+  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
+    chalk "^2.0.0"
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.4":
@@ -444,9 +465,10 @@
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.0.tgz#d1d55958d1fccc5527d4aba29fc9c4b942f563ff"
 
-"@types/babel-code-frame@^6.20.1":
-  version "6.20.1"
-  resolved "https://registry.yarnpkg.com/@types/babel-code-frame/-/babel-code-frame-6.20.1.tgz#e79a40ea81435034df7b46b5e32e8ed638aea4dd"
+"@types/babel__code-frame@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@types/babel__code-frame/-/babel__code-frame-7.0.1.tgz#baf2529c4abbfb5e4008c845efcfe39a187e2f99"
+  integrity sha512-FFfbQozKxYmOnCKFYV+EQprjBI7u2yaNc2ly/K9AhzyC8MzXtCtSRqptpw+HUJxhwCOo5mLwf1ATmzyhOaVbDg==
 
 "@types/babel__core@^7.1.0":
   version "7.1.1"
@@ -1137,7 +1159,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
+babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:


### PR DESCRIPTION
Update code-frame dependency from v6 to v7 so that we can drop the chalk v1 dependency.

Closes #408