### PR TITLE
fix: resolve issue with publishing empty package on the npm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,8 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: lib
-      
+        path: lib
+
     - name: Run unit tests
       run: yarn test:unit
 
@@ -93,6 +94,7 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: lib
+          path: lib
 
       - name: Release
         run: npx semantic-release@16.0.2

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "John Reilly <johnny_reilly@hotmail.com> (https://blog.johnnyreilly.com)"
   ],
   "files": [
-    "./lib"
+    "lib"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Changed "files" field in the package.json from "./lib" back to "lib". It seems that there is different behavior between npm and yarn.

Closes: #412