### PR TITLE
fix: close service on the `failed` hook

### DIFF
--- a/src/ForkTsCheckerWebpackPlugin.ts
+++ b/src/ForkTsCheckerWebpackPlugin.ts
@@ -13,8 +13,9 @@ import { assertEsLintSupport } from './eslint-reporter/assertEsLintSupport';
 import { createEsLintReporterRpcClient } from './eslint-reporter/reporter/EsLintReporterRpcClient';
 import { tapStartToConnectAndRunReporter } from './hooks/tapStartToConnectAndRunReporter';
 import { tapStopToDisconnectReporter } from './hooks/tapStopToDisconnectReporter';
-import { getForkTsCheckerWebpackPluginHooks } from './hooks/pluginHooks';
 import { tapDoneToCollectRemoved } from './hooks/tapDoneToCollectRemoved';
+import { tapErrorToLogMessage } from './hooks/tapErrorToLogMessage';
+import { getForkTsCheckerWebpackPluginHooks } from './hooks/pluginHooks';
 
 class ForkTsCheckerWebpackPlugin implements webpack.Plugin {
   private readonly options: ForkTsCheckerWebpackPluginOptions;
@@ -56,7 +57,8 @@ class ForkTsCheckerWebpackPlugin implements webpack.Plugin {
 
       tapStartToConnectAndRunReporter(compiler, reporter, configuration, state);
       tapDoneToCollectRemoved(compiler, configuration, state);
-      tapStopToDisconnectReporter(compiler, reporter, configuration, state);
+      tapStopToDisconnectReporter(compiler, reporter, state);
+      tapErrorToLogMessage(compiler, configuration);
     } else {
       throw new Error(
         `ForkTsCheckerWebpackPlugin is configured to not use any issue reporter. It's probably a configuration issue.`

--- a/src/hooks/tapErrorToLogMessage.ts
+++ b/src/hooks/tapErrorToLogMessage.ts
@@ -1,0 +1,38 @@
+import webpack from 'webpack';
+import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
+import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
+import { RpcIpcMessagePortClosedError } from '../rpc/rpc-ipc/error/RpcIpcMessagePortClosedError';
+import chalk from 'chalk';
+
+function tapErrorToLogMessage(
+  compiler: webpack.Compiler,
+  configuration: ForkTsCheckerWebpackPluginConfiguration
+) {
+  const hooks = getForkTsCheckerWebpackPluginHooks(compiler);
+
+  hooks.error.tap('ForkTsCheckerWebpackPlugin', (error) => {
+    configuration.logger.issues.error(String(error));
+
+    if (error instanceof RpcIpcMessagePortClosedError) {
+      if (error.signal === 'SIGINT') {
+        configuration.logger.issues.error(
+          chalk.red(
+            'Issues checking service interrupted - If running in a docker container, this may be caused ' +
+              "by the container running out of memory. If so, try increasing the container's memory limit " +
+              'or lowering the `memoryLimit` value in the ForkTsCheckerWebpackPlugin configuration.'
+          )
+        );
+      } else {
+        configuration.logger.issues.error(
+          chalk.red(
+            'Issues checking service aborted - probably out of memory. ' +
+              'Check the `memoryLimit` option in the ForkTsCheckerWebpackPlugin configuration.\n' +
+              "If increasing the memory doesn't solve the issue, it's most probably a bug in the TypeScript or EsLint."
+          )
+        );
+      }
+    }
+  });
+}
+
+export { tapErrorToLogMessage };

--- a/src/hooks/tapStopToDisconnectReporter.ts
+++ b/src/hooks/tapStopToDisconnectReporter.ts
@@ -1,15 +1,10 @@
 import webpack from 'webpack';
-import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 import { ReporterRpcClient } from '../reporter';
-import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
-import { RpcIpcMessagePortClosedError } from '../rpc/rpc-ipc/error/RpcIpcMessagePortClosedError';
-import chalk from 'chalk';
 
 function tapStopToDisconnectReporter(
   compiler: webpack.Compiler,
   reporter: ReporterRpcClient,
-  configuration: ForkTsCheckerWebpackPluginConfiguration,
   state: ForkTsCheckerWebpackPluginState
 ) {
   compiler.hooks.watchClose.tap('ForkTsCheckerWebpackPlugin', () => {
@@ -22,29 +17,9 @@ function tapStopToDisconnectReporter(
     }
   });
 
-  const hooks = getForkTsCheckerWebpackPluginHooks(compiler);
-
-  hooks.error.tap('ForkTsCheckerWebpackPlugin', (error) => {
-    configuration.logger.issues.error(String(error));
-
-    if (error instanceof RpcIpcMessagePortClosedError) {
-      if (error.signal === 'SIGINT') {
-        configuration.logger.issues.error(
-          chalk.red(
-            'Issues checking service interrupted - If running in a docker container, this may be caused ' +
-              "by the container running out of memory. If so, try increasing the container's memory limit " +
-              'or lowering the `memoryLimit` value in the ForkTsCheckerWebpackPlugin configuration.'
-          )
-        );
-      } else {
-        configuration.logger.issues.error(
-          chalk.red(
-            'Issues checking service aborted - probably out of memory. ' +
-              'Check the `memoryLimit` option in the ForkTsCheckerWebpackPlugin configuration.\n' +
-              "If increasing the memory doesn't solve the issue, it's most probably a bug in the TypeScript or EsLint."
-          )
-        );
-      }
+  compiler.hooks.failed.tap('ForkTsCheckerWebpackPlugin', () => {
+    if (!state.watching) {
+      reporter.disconnect();
     }
   });
 }

--- a/test/e2e/WebpackProductionBuild.spec.ts
+++ b/test/e2e/WebpackProductionBuild.spec.ts
@@ -1,0 +1,145 @@
+import { readFixture } from './sandbox/Fixture';
+import { join } from 'path';
+import { createSandbox, FORK_TS_CHECKER_WEBPACK_PLUGIN_VERSION, Sandbox } from './sandbox/Sandbox';
+import { WEBPACK_CLI_VERSION, WEBPACK_DEV_SERVER_VERSION } from './sandbox/WebpackDevServerDriver';
+import { extractWebpackErrors } from './sandbox/WebpackErrorsExtractor';
+import stripAnsi from 'strip-ansi';
+
+describe('Webpack Production Build', () => {
+  let sandbox: Sandbox;
+
+  beforeAll(async () => {
+    sandbox = await createSandbox();
+  });
+
+  beforeEach(async () => {
+    await sandbox.reset();
+  });
+
+  afterAll(async () => {
+    await sandbox.cleanup();
+  });
+
+  it.each([{ webpack: '4.0.0' }, { webpack: '^4.0.0' }, { webpack: '^5.0.0-beta.16' }])(
+    'compiles the project successfully with %p',
+    async ({ webpack }) => {
+      await sandbox.load([
+        await readFixture(join(__dirname, 'fixtures/environment/typescript-basic.fixture'), {
+          FORK_TS_CHECKER_WEBPACK_PLUGIN_VERSION: JSON.stringify(
+            FORK_TS_CHECKER_WEBPACK_PLUGIN_VERSION
+          ),
+          TS_LOADER_VERSION: JSON.stringify('^5.0.0'),
+          TYPESCRIPT_VERSION: JSON.stringify('~3.8.0'),
+          WEBPACK_VERSION: JSON.stringify(webpack),
+          WEBPACK_CLI_VERSION: JSON.stringify(WEBPACK_CLI_VERSION),
+          WEBPACK_DEV_SERVER_VERSION: JSON.stringify(WEBPACK_DEV_SERVER_VERSION),
+          ASYNC: JSON.stringify(false),
+        }),
+        await readFixture(join(__dirname, 'fixtures/implementation/typescript-basic.fixture')),
+      ]);
+
+      // lets remove the async option at all as the plugin should now how to set it by default
+      await sandbox.patch(
+        'webpack.config.js',
+        [
+          '    new ForkTsCheckerWebpackPlugin({',
+          '      async: false,',
+          '      logger: {',
+          '        infrastructure: "console"',
+          '      }',
+          '    })',
+        ].join('\n'),
+        [
+          '    new ForkTsCheckerWebpackPlugin({',
+          '      logger: {',
+          '        infrastructure: "console"',
+          '      }',
+          '    })',
+        ].join('\n')
+      );
+
+      const result = await sandbox.exec('npm run webpack');
+      const errors = extractWebpackErrors(result);
+
+      expect(errors).toEqual([]);
+    }
+  );
+
+  it.each([{ webpack: '4.0.0' }, { webpack: '^4.0.0' }, { webpack: '^5.0.0-beta.16' }])(
+    'exits with error on the project error with %p',
+    async ({ webpack }) => {
+      await sandbox.load([
+        await readFixture(join(__dirname, 'fixtures/environment/typescript-basic.fixture'), {
+          FORK_TS_CHECKER_WEBPACK_PLUGIN_VERSION: JSON.stringify(
+            FORK_TS_CHECKER_WEBPACK_PLUGIN_VERSION
+          ),
+          TS_LOADER_VERSION: JSON.stringify('^5.0.0'),
+          TYPESCRIPT_VERSION: JSON.stringify('~3.8.0'),
+          WEBPACK_VERSION: JSON.stringify(webpack),
+          WEBPACK_CLI_VERSION: JSON.stringify(WEBPACK_CLI_VERSION),
+          WEBPACK_DEV_SERVER_VERSION: JSON.stringify(WEBPACK_DEV_SERVER_VERSION),
+          ASYNC: JSON.stringify(false),
+        }),
+        await readFixture(join(__dirname, 'fixtures/implementation/typescript-basic.fixture')),
+      ]);
+
+      // remove the async option at all as the plugin should now how to set it by default
+      await sandbox.patch(
+        'webpack.config.js',
+        [
+          '    new ForkTsCheckerWebpackPlugin({',
+          '      async: false,',
+          '      logger: {',
+          '        infrastructure: "console"',
+          '      }',
+          '    })',
+        ].join('\n'),
+        [
+          '    new ForkTsCheckerWebpackPlugin({',
+          '      logger: {',
+          '        infrastructure: "console"',
+          '      }',
+          '    })',
+        ].join('\n')
+      );
+
+      // introduce an error in the project
+      await sandbox.remove('src/model/User.ts');
+
+      try {
+        await sandbox.exec('npm run webpack');
+
+        throw new Error('The webpack command should exit with an error code.');
+      } catch (error) {
+        // remove npm related output
+        const output = stripAnsi(String(error)).replace(/npm (ERR!|WARN).*/g, '');
+        // extract errors
+        const errors = extractWebpackErrors(output);
+
+        expect(errors).toEqual([
+          // first error is from the webpack module resolution
+          expect.anything(),
+          [
+            'ERROR in src/authenticate.ts 1:22-36',
+            "TS2307: Cannot find module './model/User'.",
+            "  > 1 | import { User } from './model/User';",
+            '      |                      ^^^^^^^^^^^^^^',
+            '    2 | ',
+            '    3 | async function login(email: string, password: string): Promise<User> {',
+            '    4 |   const response = await fetch(',
+          ].join('\n'),
+          [
+            'ERROR in src/index.ts 2:29-43',
+            "TS2307: Cannot find module './model/User'.",
+            "    1 | import { login } from './authenticate';",
+            "  > 2 | import { getUserName } from './model/User';",
+            '      |                             ^^^^^^^^^^^^^^',
+            '    3 | ',
+            "    4 | const emailInput = document.getElementById('email');",
+            "    5 | const passwordInput = document.getElementById('password');",
+          ].join('\n'),
+        ]);
+      }
+    }
+  );
+});

--- a/test/e2e/fixtures/environment/typescript-basic.fixture
+++ b/test/e2e/fixtures/environment/typescript-basic.fixture
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
+    "webpack": "webpack -p",
     "webpack-dev-server": "webpack-dev-server"
   },
   "devDependencies": {

--- a/test/e2e/sandbox/WebpackErrorsExtractor.ts
+++ b/test/e2e/sandbox/WebpackErrorsExtractor.ts
@@ -1,9 +1,11 @@
+import stripAnsi from 'strip-ansi';
+
 function isLineRelatedToTsLoader(line: string) {
   return line.includes('[tsl]') || line.includes('ts-loader');
 }
 
 function extractWebpackErrors(content: string): string[] {
-  const lines = content.split(/\r\n?|\n/);
+  const lines = stripAnsi(content).split(/\r\n?|\n/);
   const errors: string[] = [];
   let currentError: string | undefined = undefined;
 


### PR DESCRIPTION
When a compilation is not successful and webpack is not watching, the
plugin should close the service.

✅ Closes: #411