### PR TITLE
feat: improve overall typescript performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,17 +153,18 @@ Options passed to the plugin constructor will overwrite options from the cosmico
 
 Options for the TypeScript checker (`typescript` option object).
 
-| Name                 | Type      | Default value                                                             | Description |
-| -------------------- | --------- | ------------------------------------------------------------------------- | ----------- |
-| `enabled`            | `boolean` | `true`                                                                    | If `true`, it enables TypeScript checker. |
-| `memoryLimit`        | `number`  | `2048`                                                                    | Memory limit for the checker process in MB. If the process exits with the allocation failed error, try to increase this number. |
-| `tsconfig`           | `string`  | `'tsconfig.json'`                                                         | Path to the `tsconfig.json` file (path relative to the `compiler.options.context` or absolute path) |
-| `context`            | `string`  | `dirname(configuration.tsconfig)`                                         | The base path for finding files specified in the `tsconfig.json`. Same as the `context` option from the [ts-loader](https://github.com/TypeStrong/ts-loader#context). Useful if you want to keep your `tsconfig.json` in an external package. Keep in mind that **not** having a `tsconfig.json` in your project root can cause different behaviour between `fork-ts-checker-webpack-plugin` and `tsc`. When using editors like `VS Code` it is advised to add a `tsconfig.json` file to the root of the project and extend the config file referenced in option `tsconfig`.  |
-| `build`              | `boolean` | `false`                                                                   | The equivalent of the `--build` flag for the `tsc` command. To enable `incremental` mode, set it in the `tsconfig.json` file. |
-| `mode`               | `'readonly'` or `'write-tsbuildinfo'` or `'write-references'` | `'readonly'`          | If you use the `babel-loader`, it's recommended to use `write-references` mode to improve initial compilation time. If you use `ts-loader`, it's recommended to use `readonly` mode to not overwrite filed emitted by `ts-loader`. |
-| `compilerOptions`    | `object`  | `{ skipLibCheck: true, skipDefaultLibCheck: true  }`                      | These options will overwrite compiler options from the `tsconfig.json` file. |
-| `diagnosticsOptions` | `object`  | `{ syntactic: false, semantic: true, declaration: false, global: false }` | Settings to select which diagnostics do we want to perform. |
-| `extensions`         | `object`  | `{}`                                                                      | See [TypeScript extensions options](#typescript-extensions-options). |
+| Name                 | Type      | Default value                                                                          | Description |
+| -------------------- | --------- | -------------------------------------------------------------------------------------- | ----------- |
+| `enabled`            | `boolean` | `true`                                                                                 | If `true`, it enables TypeScript checker. |
+| `memoryLimit`        | `number`  | `2048`                                                                                 | Memory limit for the checker process in MB. If the process exits with the allocation failed error, try to increase this number. |
+| `tsconfig`           | `string`  | `'tsconfig.json'`                                                                      | Path to the `tsconfig.json` file (path relative to the `compiler.options.context` or absolute path) |
+| `context`            | `string`  | `dirname(configuration.tsconfig)`                                                      | The base path for finding files specified in the `tsconfig.json`. Same as the `context` option from the [ts-loader](https://github.com/TypeStrong/ts-loader#context). Useful if you want to keep your `tsconfig.json` in an external package. Keep in mind that **not** having a `tsconfig.json` in your project root can cause different behaviour between `fork-ts-checker-webpack-plugin` and `tsc`. When using editors like `VS Code` it is advised to add a `tsconfig.json` file to the root of the project and extend the config file referenced in option `tsconfig`.  |
+| `build`              | `boolean` | `false`                                                                                | The equivalent of the `--build` flag for the `tsc` command. To enable `incremental` mode, set it in the `tsconfig.json` file. |
+| `mode`               | `'readonly'` or `'write-tsbuildinfo'` or `'write-references'` | `'write-tsbuildinfo'`              | If you use the `babel-loader`, it's recommended to use `write-references` mode to improve initial compilation time. If you use `ts-loader`, it's recommended to use `write-tsbuildinfo` mode to not overwrite filed emitted by the `ts-loader`. |
+| `compilerOptions`    | `object`  | `{ skipLibCheck: true, sourceMap: false, inlineSourceMap: false, incremental: true  }` | These options will overwrite compiler options from the `tsconfig.json` file. |
+| `diagnosticsOptions` | `object`  | `{ syntactic: false, semantic: true, declaration: false, global: false }`              | Settings to select which diagnostics do we want to perform. |
+| `extensions`         | `object`  | `{}`                                                                                   | See [TypeScript extensions options](#typescript-extensions-options). |
+| `profile`            | `boolean` | `false`                                                                                | Measures and prints timings related to the TypeScript performance. |
 
 #### TypeScript extensions options
 

--- a/src/ForkTsCheckerWebpackPluginOptions.json
+++ b/src/ForkTsCheckerWebpackPluginOptions.json
@@ -160,6 +160,10 @@
                   "$ref": "#/definitions/TypeScriptVueExtensionOptions"
                 }
               }
+            },
+            "profile": {
+              "type": "boolean",
+              "description": "Measures and prints timings related to the TypeScript performance."
             }
           }
         }

--- a/src/profile/Performance.ts
+++ b/src/profile/Performance.ts
@@ -1,0 +1,85 @@
+import { performance } from 'perf_hooks';
+
+interface Performance {
+  enable(): void;
+  disable(): void;
+  mark(name: string): void;
+  markStart(name: string): void;
+  markEnd(name: string): void;
+  measure(name: string, startMark?: string, endMark?: string): void;
+  print(): void;
+}
+
+function createPerformance(): Performance {
+  let enabled = false;
+  let timeOrigin: number;
+  let marks: Map<string, number>;
+  let measurements: Map<string, number>;
+
+  function enable() {
+    enabled = true;
+    marks = new Map();
+    measurements = new Map();
+    timeOrigin = performance.now();
+  }
+
+  function disable() {
+    enabled = false;
+  }
+
+  function mark(name: string) {
+    if (enabled) {
+      marks.set(name, performance.now());
+    }
+  }
+
+  function measure(name: string, startMark?: string, endMark?: string) {
+    if (enabled) {
+      const start = (startMark && marks.get(startMark)) || timeOrigin;
+      const end = (endMark && marks.get(endMark)) || performance.now();
+
+      measurements.set(name, (measurements.get(name) || 0) + (end - start));
+    }
+  }
+
+  function markStart(name: string) {
+    if (enabled) {
+      mark(`${name} start`);
+    }
+  }
+
+  function markEnd(name: string) {
+    if (enabled) {
+      mark(`${name} end`);
+      measure(name, `${name} start`, `${name} end`);
+    }
+  }
+
+  function formatName(name: string, width = 0) {
+    return `${name}:`.padEnd(width);
+  }
+
+  function formatDuration(duration: number, width = 0) {
+    return `${(duration / 1000).toFixed(2)} s`.padStart(width);
+  }
+
+  function print() {
+    if (enabled) {
+      let nameWidth = 0;
+      let durationWidth = 0;
+
+      measurements.forEach((duration, name) => {
+        nameWidth = Math.max(nameWidth, formatName(name).length);
+        durationWidth = Math.max(durationWidth, formatDuration(duration).length);
+      });
+
+      measurements.forEach((duration, name) => {
+        console.log(`${formatName(name, nameWidth)} ${formatDuration(duration, durationWidth)}`);
+      });
+    }
+  }
+
+  return { enable, disable, mark, markStart, markEnd, measure, print };
+}
+
+export { Performance, createPerformance };

--- a/src/typescript-reporter/TypeScriptReporterOptions.ts
+++ b/src/typescript-reporter/TypeScriptReporterOptions.ts
@@ -15,6 +15,7 @@ type TypeScriptReporterOptions =
       extensions?: {
         vue?: TypeScriptVueExtensionOptions;
       };
+      profile?: boolean;
     };
 
 export { TypeScriptReporterOptions };

--- a/src/typescript-reporter/profile/TypeScriptPerformance.ts
+++ b/src/typescript-reporter/profile/TypeScriptPerformance.ts
@@ -1,0 +1,48 @@
+import * as ts from 'typescript';
+import { Performance } from '../../profile/Performance';
+
+interface TypeScriptPerformance {
+  enable(): void;
+  disable(): void;
+  mark(name: string): void;
+  measure(name: string, startMark?: string, endMark?: string): void;
+}
+
+function getTypeScriptPerformance(): TypeScriptPerformance | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (ts as any).performance;
+}
+
+function connectTypeScriptPerformance(performance: Performance): Performance {
+  const typeScriptPerformance = getTypeScriptPerformance();
+
+  if (typeScriptPerformance) {
+    const { mark, measure } = typeScriptPerformance;
+    const { enable, disable } = performance;
+
+    typeScriptPerformance.mark = (name) => {
+      mark(name);
+      performance.mark(name);
+    };
+    typeScriptPerformance.measure = (name, startMark, endMark) => {
+      measure(name, startMark, endMark);
+      performance.measure(name, startMark, endMark);
+    };
+
+    return {
+      ...performance,
+      enable() {
+        enable();
+        typeScriptPerformance.enable();
+      },
+      disable() {
+        disable();
+        typeScriptPerformance.disable();
+      },
+    };
+  } else {
+    return performance;
+  }
+}
+
+export { TypeScriptPerformance, connectTypeScriptPerformance };

--- a/src/typescript-reporter/reporter/TypeScriptConfigurationParser.ts
+++ b/src/typescript-reporter/reporter/TypeScriptConfigurationParser.ts
@@ -23,7 +23,13 @@ function parseTypeScriptConfiguration(
     parsedConfigFile.errors.push(...customCompilerOptionsConvertResults.errors);
   }
 
-  return parsedConfigFile;
+  return {
+    ...parsedConfigFile,
+    options: {
+      ...parsedConfigFile.options,
+      configFilePath: configFileName,
+    },
+  };
 }
 
 export { parseTypeScriptConfiguration };

--- a/src/typescript-reporter/reporter/TypeScriptReporter.ts
+++ b/src/typescript-reporter/reporter/TypeScriptReporter.ts
@@ -12,6 +12,8 @@ import {
   createControlledTypeScriptSystem,
 } from './ControlledTypeScriptSystem';
 import { parseTypeScriptConfiguration } from './TypeScriptConfigurationParser';
+import { createPerformance } from '../../profile/Performance';
+import { connectTypeScriptPerformance } from '../profile/TypeScriptPerformance';
 
 function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration): Reporter {
   const extensions: TypeScriptExtension[] = [];
@@ -28,6 +30,7 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
   let solutionBuilder: ts.SolutionBuilder<ts.SemanticDiagnosticsBuilderProgram> | undefined;
 
   const diagnosticsPerProject = new Map<string, ts.Diagnostic[]>();
+  const performance = connectTypeScriptPerformance(createPerformance());
 
   if (configuration.extensions.vue.enabled) {
     extensions.push(createTypeScriptVueExtension(configuration.extensions.vue));
@@ -41,23 +44,50 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
     const diagnostics: ts.Diagnostic[] = [];
 
     if (configuration.diagnosticOptions.syntactic) {
+      performance.markStart('Syntactic Diagnostics');
       diagnostics.push(...builderProgram.getSyntacticDiagnostics());
-    }
-    if (configuration.diagnosticOptions.semantic) {
-      diagnostics.push(...builderProgram.getSemanticDiagnostics());
-    }
-    if (configuration.diagnosticOptions.declaration) {
-      diagnostics.push(...builderProgram.getDeclarationDiagnostics());
+      performance.markEnd('Syntactic Diagnostics');
     }
     if (configuration.diagnosticOptions.global) {
+      performance.markStart('Global Diagnostics');
       diagnostics.push(...builderProgram.getGlobalDiagnostics());
+      performance.markEnd('Global Diagnostics');
+    }
+    if (configuration.diagnosticOptions.semantic) {
+      performance.markStart('Semantic Diagnostics');
+      diagnostics.push(...builderProgram.getSemanticDiagnostics());
+      performance.markEnd('Semantic Diagnostics');
+    }
+    if (configuration.diagnosticOptions.declaration) {
+      performance.markStart('Declaration Diagnostics');
+      diagnostics.push(...builderProgram.getDeclarationDiagnostics());
+      performance.markEnd('Declaration Diagnostics');
     }
 
     return diagnostics;
   }
 
+  function emitTsBuildInfoFileForBuilderProgram(builderProgram: ts.BuilderProgram) {
+    if (
+      configuration.mode !== 'readonly' &&
+      parsedConfiguration &&
+      parsedConfiguration.options.incremental
+    ) {
+      const program = builderProgram.getProgram();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (typeof (program as any).emitBuildInfo === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (program as any).emitBuildInfo();
+      }
+    }
+  }
+
   return {
     getReport: async ({ changedFiles = [], deletedFiles = [] }: FilesChange) => {
+      if (configuration.profile) {
+        performance.enable();
+      }
+
       if (!system) {
         system = createControlledTypeScriptSystem(configuration.mode);
       }
@@ -83,6 +113,7 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
       if (!parsedConfiguration) {
         const parseConfigurationDiagnostics: ts.Diagnostic[] = [];
 
+        performance.markStart('Parse Configuration');
         parsedConfiguration = parseTypeScriptConfiguration(
           configuration.tsconfig,
           configuration.context,
@@ -94,6 +125,8 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
             },
           }
         );
+        performance.markEnd('Parse Configuration');
+
         if (parsedConfiguration.errors) {
           parseConfigurationDiagnostics.push(...parsedConfiguration.errors);
         }
@@ -123,6 +156,7 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
         // solution builder case
         // ensure watch solution builder host exists
         if (!watchSolutionBuilderHost) {
+          performance.markStart('Create Solution Builder Host');
           watchSolutionBuilderHost = createControlledWatchSolutionBuilderHost(
             parsedConfiguration,
             system,
@@ -137,25 +171,35 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
 
               // update diagnostics
               diagnosticsPerProject.set(projectName, diagnostics);
+
+              // emit .tsbuildinfo file if needed
+              emitTsBuildInfoFileForBuilderProgram(builderProgram);
             },
             extensions
           );
+          performance.markEnd('Create Solution Builder Host');
           solutionBuilder = undefined;
         }
 
         // ensure solution builder exists
         if (!solutionBuilder) {
+          performance.markStart('Create Solution Builder');
           solutionBuilder = ts.createSolutionBuilderWithWatch(
             watchSolutionBuilderHost,
             [configuration.tsconfig],
             {}
           );
+          performance.markEnd('Create Solution Builder');
+
+          performance.markStart('Build Solutions');
           solutionBuilder.build();
+          performance.markEnd('Build Solutions');
         }
       } else {
         // watch compiler case
         // ensure watch compiler host exists
         if (!watchCompilerHost) {
+          performance.markStart('Create Watch Compiler Host');
           watchCompilerHost = createControlledWatchCompilerHost(
             parsedConfiguration,
             system,
@@ -168,15 +212,21 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
 
               // update diagnostics
               diagnosticsPerProject.set(projectName, diagnostics);
+
+              // emit .tsbuildinfo file if needed
+              emitTsBuildInfoFileForBuilderProgram(builderProgram);
             },
             extensions
           );
+          performance.markEnd('Create Watch Compiler Host');
           watchProgram = undefined;
         }
 
         // ensure watch program exists
         if (!watchProgram) {
+          performance.markStart('Create Watch Program');
           watchProgram = ts.createWatchProgram(watchCompilerHost);
+          performance.markEnd('Create Watch Program');
         }
       }
 
@@ -192,7 +242,9 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
       });
 
       // wait for all queued events to be processed
+      performance.markStart('Queued Tasks');
       await system.waitForQueued();
+      performance.markEnd('Queued Tasks');
 
       // aggregate all diagnostics and map them to issues
       const diagnostics: ts.Diagnostic[] = [];
@@ -206,6 +258,11 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
           issues = extension.extendIssues(issues);
         }
       });
+
+      if (configuration.profile) {
+        performance.print();
+        performance.disable();
+      }
 
       return issues;
     },

--- a/test/e2e/TypeScriptConfigurationChange.spec.ts
+++ b/test/e2e/TypeScriptConfigurationChange.spec.ts
@@ -25,7 +25,7 @@ describe('TypeScript Configuration Change', () => {
   it.each([
     { async: true, webpack: '~4.0.0', typescript: '2.7.1', tsloader: '^5.0.0' },
     { async: false, webpack: '^4.0.0', typescript: '~3.0.0', tsloader: '^6.0.0' },
-    { async: true, webpack: '^5.0.0-beta.16', typescript: '~3.6.0', tsloader: '^7.0.0' },
+    { async: true, webpack: '^5.0.0-beta.16', typescript: '~3.7.0', tsloader: '^7.0.0' },
     { async: false, webpack: '^5.0.0-beta.16', typescript: '~3.8.0', tsloader: '^6.0.0' },
   ])(
     'change in the tsconfig.json affects compilation for %p',

--- a/test/e2e/TypeScriptWatchApi.spec.ts
+++ b/test/e2e/TypeScriptWatchApi.spec.ts
@@ -111,7 +111,7 @@ describe('TypeScript Watch API', () => {
 
       // filter-out ts-loader related errors
       errors = (await driver.waitForErrors()).filter(
-        (error) => !error.includes('Module build failed')
+        (error) => !error.includes('Module build failed') && !error.includes('Module not found')
       );
       expect(errors).toEqual([
         [

--- a/test/unit/typescript-reporter/TypeScriptReporterConfiguration.spec.ts
+++ b/test/unit/typescript-reporter/TypeScriptReporterConfiguration.spec.ts
@@ -14,10 +14,13 @@ describe('typescript-reporter/TypeScriptsReporterConfiguration', () => {
     tsconfig: path.normalize(path.resolve(context, 'tsconfig.json')),
     context: path.normalize(path.dirname(path.resolve(context, 'tsconfig.json'))),
     build: false,
-    mode: 'readonly',
+    mode: 'write-tsbuildinfo',
     compilerOptions: {
-      skipDefaultLibCheck: true,
       skipLibCheck: true,
+      sourceMap: false,
+      inlineSourceMap: false,
+      declarationMap: false,
+      incremental: true,
     },
     diagnosticOptions: {
       semantic: true,
@@ -31,6 +34,7 @@ describe('typescript-reporter/TypeScriptsReporterConfiguration', () => {
         compiler: 'vue-template-compiler',
       },
     },
+    profile: false,
   };
 
   beforeEach(() => {
@@ -66,13 +70,21 @@ describe('typescript-reporter/TypeScriptsReporterConfiguration', () => {
       },
     ],
     [{ build: true }, { ...configuration, build: true }],
+    [{ mode: 'readonly' }, { ...configuration, mode: 'readonly' }],
     [{ mode: 'write-tsbuildinfo' }, { ...configuration, mode: 'write-tsbuildinfo' }],
     [{ mode: 'write-references' }, { ...configuration, mode: 'write-references' }],
     [
       { compilerOptions: { strict: true } },
       {
         ...configuration,
-        compilerOptions: { skipDefaultLibCheck: true, skipLibCheck: true, strict: true },
+        compilerOptions: {
+          skipLibCheck: true,
+          sourceMap: false,
+          inlineSourceMap: false,
+          declarationMap: false,
+          incremental: true,
+          strict: true,
+        },
       },
     ],
     [{ diagnosticOptions: {} }, configuration],
@@ -83,6 +95,7 @@ describe('typescript-reporter/TypeScriptsReporterConfiguration', () => {
         diagnosticOptions: { semantic: false, syntactic: true, declaration: false, global: false },
       },
     ],
+    [{ profile: true }, { ...configuration, profile: true }],
   ])('creates configuration from options %p', async (options, expectedConfiguration) => {
     const { createTypeScriptReporterConfiguration } = await import(
       'lib/typescript-reporter/TypeScriptReporterConfiguration'

--- a/test/unit/typescript-reporter/TypeScriptSupport.spec.ts
+++ b/test/unit/typescript-reporter/TypeScriptSupport.spec.ts
@@ -27,6 +27,7 @@ describe('typescript-reporter/TypeScriptSupport', () => {
         },
       },
       memoryLimit: 2048,
+      profile: false,
     };
   });
 


### PR DESCRIPTION
Aside from general performance improvements, I added a `profile` option to be able to measure timings and compare them with other tools, like tsc.

BREAKING CHANGE: 🧨 Changed default TypeScript compiler options to incremental: true and
the default mode to write-tsbuildinfo

**Related:**
https://github.com/vercel/next.js/pull/13529#issuecomment-635776458

**Results:**
I was testing it on my personal project. With incremental: true mode, the initial compilation time dropped from ~100s to ~30s (faster than initial webpack compilation). The incremental compilation time dropped from ~15s to ~2s. 