### PR TITLE
fix: include files that are outside project context

### DIFF
--- a/src/hooks/getChangedFiles.ts
+++ b/src/hooks/getChangedFiles.ts
@@ -15,17 +15,7 @@ function getChangedFiles(compiler: webpack.Compiler): string[] {
     changedFiles = Object.keys((watcher && watcher.mtimes) || {});
   }
 
-  return (
-    changedFiles
-      // normalize paths
-      .map((changedFile) => path.normalize(changedFile))
-      // check if path is inside the context to filer-out some trash from fs
-      .filter(
-        (changedFile) =>
-          !compiler.options.context ||
-          changedFile.startsWith(path.normalize(compiler.options.context))
-      )
-  );
+  return changedFiles.map((changedFile) => path.normalize(changedFile));
 }
 
 export { getChangedFiles };

--- a/src/hooks/getDeletedFiles.ts
+++ b/src/hooks/getDeletedFiles.ts
@@ -17,17 +17,7 @@ function getDeletedFiles(
     deletedFiles = [...state.removedFiles];
   }
 
-  return (
-    deletedFiles
-      // normalize paths
-      .map((changedFile) => path.normalize(changedFile))
-      // check if path is inside the context to filer-out some trash from fs
-      .filter(
-        (changedFile) =>
-          !compiler.options.context ||
-          changedFile.startsWith(path.normalize(compiler.options.context))
-      )
-  );
+  return deletedFiles.map((changedFile) => path.normalize(changedFile));
 }
 
 export { getDeletedFiles };


### PR DESCRIPTION
In the case that the referenced project was outside the webpack context, changes didn't update the issues list.