### PR TITLE
fix: always pass compilation to issues hook

### DIFF
--- a/src/hooks/tapDoneToAsyncGetIssues.ts
+++ b/src/hooks/tapDoneToAsyncGetIssues.ts
@@ -54,7 +54,7 @@ function tapDoneToAsyncGetIssues(
     issues = issues.filter(configuration.issue.predicate);
 
     // modify list of issues in the plugin hooks
-    issues = hooks.issues.call(issues);
+    issues = hooks.issues.call(issues, stats.compilation);
 
     const formatter = createWebpackFormatter(configuration.formatter, compiler.context);
 


### PR DESCRIPTION
Currently on a watch run of webpack this plugin is not passing the compilation argument to the issues hook. This PR fixes that.

Related: the type of the issues hook explicitly defines compilation a possible undefined, maybe if this is approved it could be changed as well.