### PR TITLE
fix: use typescript watcher for directories to prevent TS6307

### DIFF
--- a/src/typescript-reporter/reporter/ControlledTypeScriptSystem.ts
+++ b/src/typescript-reporter/reporter/ControlledTypeScriptSystem.ts
@@ -9,7 +9,7 @@ interface ControlledTypeScriptSystem extends ts.System {
   invokeFileCreated(path: string): void;
   invokeFileChanged(path: string): void;
   invokeFileDeleted(path: string): void;
-  pullAndInvokeCreatedOrDeleted(): void;
+  pollAndInvokeCreatedOrDeleted(): void;
   // control cache
   clearCache(): void;
   // mark these methods as defined - not optional
@@ -267,7 +267,7 @@ function createControlledTypeScriptSystem(
         deletedFiles.set(normalizedPath, true);
       }
     },
-    pullAndInvokeCreatedOrDeleted() {
+    pollAndInvokeCreatedOrDeleted() {
       const prevDirectorySnapshots = new Map(directorySnapshots);
 
       directorySnapshots.clear();

--- a/src/typescript-reporter/reporter/TypeScriptReporter.ts
+++ b/src/typescript-reporter/reporter/TypeScriptReporter.ts
@@ -264,6 +264,7 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
           system.invokeFileDeleted(removedFile);
         }
       });
+      system.invokeQueuedChanged();
 
       // wait for all queued events to be processed
       performance.markStart('Queued Tasks');

--- a/src/typescript-reporter/reporter/TypeScriptReporter.ts
+++ b/src/typescript-reporter/reporter/TypeScriptReporter.ts
@@ -254,6 +254,10 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
         }
       }
 
+      performance.markStart('Pull And Invoke Created Or Deleted');
+      system.pullAndInvokeCreatedOrDeleted();
+      performance.markEnd('Pull And Invoke Created Or Deleted');
+
       changedFiles.forEach((changedFile) => {
         if (system) {
           system.invokeFileChanged(changedFile);
@@ -264,7 +268,6 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
           system.invokeFileDeleted(removedFile);
         }
       });
-      system.invokeQueuedChanged();
 
       // wait for all queued events to be processed
       performance.markStart('Queued Tasks');

--- a/src/typescript-reporter/reporter/TypeScriptReporter.ts
+++ b/src/typescript-reporter/reporter/TypeScriptReporter.ts
@@ -254,9 +254,9 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
         }
       }
 
-      performance.markStart('Pull And Invoke Created Or Deleted');
-      system.pullAndInvokeCreatedOrDeleted();
-      performance.markEnd('Pull And Invoke Created Or Deleted');
+      performance.markStart('Poll And Invoke Created Or Deleted');
+      system.pollAndInvokeCreatedOrDeleted();
+      performance.markEnd('Poll And Invoke Created Or Deleted');
 
       changedFiles.forEach((changedFile) => {
         if (system) {

--- a/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
+++ b/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
@@ -101,6 +101,16 @@ describe('TypeScript SolutionBuilder API', () => {
     // this compilation should be successful
     await driver.waitForNoErrors();
 
+    await sandbox.write('packages/client/src/additional.ts', 'export const x = 10;');
+    await sandbox.patch(
+      'packages/client/src/index.ts',
+      'import { intersect, subtract } from "@project-references-fixture/shared";',
+      'import { intersect, subtract } from "@project-references-fixture/shared";\nimport { x } from "./additional";'
+    );
+
+    // this compilation should be successful
+    await driver.waitForNoErrors();
+
     switch (mode) {
       case 'readonly':
         expect(await sandbox.exists('packages/shared/tsconfig.tsbuildinfo')).toEqual(false);

--- a/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
+++ b/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
@@ -101,11 +101,11 @@ describe('TypeScript SolutionBuilder API', () => {
     // this compilation should be successful
     await driver.waitForNoErrors();
 
-    await sandbox.write('packages/client/src/additional.ts', 'export const x = 10;');
+    await sandbox.write('packages/client/src/nested/additional.ts', 'export const x = 10;');
     await sandbox.patch(
       'packages/client/src/index.ts',
       'import { intersect, subtract } from "@project-references-fixture/shared";',
-      'import { intersect, subtract } from "@project-references-fixture/shared";\nimport { x } from "./additional";'
+      'import { intersect, subtract } from "@project-references-fixture/shared";\nimport { x } from "./nested/additional";'
     );
 
     // this compilation should be successful


### PR DESCRIPTION
Webpack watcher notifies only about changes of files that are in the compilation dependencies graph. This means that it will not notice if we create a new file that is not missing. This is a difference between webpack and typescript watch mechanism that can lead to errors like
TS6307. This fix uses typescript watcher for directories.