### PR TITLE
fix: eslint configuration should be enabled if files passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ module.exports = {
   plugins: [
     new ForkTsCheckerWebpackPlugin({
       eslint: {
-        files: './src/**/*' // required - same as command `eslint ./src/**/* --ext .ts,.tsx,.js,.jsx`
+        files: './src/**/*.{ts,tsx,js,jsx}' // required - same as command `eslint ./src/**/*.{ts,tsx,js,jsx} --ext .ts,.tsx,.js,.jsx`
       }
     })
   ]
@@ -182,7 +182,7 @@ Options for the ESLint linter (`eslint` option object).
 
 | Name                 | Type                   | Default value             | Description |
 | -------------------- | ---------------------- | ------------------------- | ----------- |
-| `enabled`            | `boolean`              | `false`                   | If `true`, it enables ESLint linter. |
+| `enabled`            | `boolean`              | `false`                   | If `true`, it enables ESLint linter. If you set the `files` option, it will be `true` by default. |
 | `files`              | `string` or `string[]` | This value is required    | One or more [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) to the files that should be linted. Works the same as the `eslint` command. |
 | `memoryLimit`        | `number`               | `2048`                    | Memory limit for the linter process in MB. If the process exits with the allocation failed error, try to increase this number. |
 | `options`            | `object`               | `{}`                      | [Options](https://eslint.org/docs/developer-guide/nodejs-api#cliengine) that can be used to initialize ESLint. |

--- a/src/eslint-reporter/EsLintReporterConfiguration.ts
+++ b/src/eslint-reporter/EsLintReporterConfiguration.ts
@@ -24,16 +24,23 @@ function createEsLintReporterConfiguration(
   compiler: webpack.Compiler,
   options: EsLintReporterOptions | undefined
 ): EsLintReporterConfiguration {
-  return {
-    enabled: !!(options && options.enabled === true),
-    memoryLimit: 2048,
-    ...(typeof options === 'object' ? options : {}),
-    files: (typeof options === 'object' ? castToArray(options.files) : []).map((filesPattern) =>
+  const filesPatterns = (typeof options === 'object' ? castToArray(options.files) : []).map(
+    (filesPattern) =>
       // ensure that `filesPattern` is an absolute path
       isAbsolute(filesPattern)
         ? filesPattern
         : join(compiler.options.context || process.cwd(), filesPattern)
-    ),
+  );
+
+  return {
+    enabled:
+      !!options &&
+      typeof options !== 'boolean' &&
+      filesPatterns.length > 0 && // enable by default if files are provided
+      options.enabled !== false,
+    memoryLimit: 2048,
+    ...(typeof options === 'object' ? options : {}),
+    files: filesPatterns,
     options: {
       cwd: compiler.options.context || process.cwd(),
       extensions: ['.ts', '.tsx', '.js', '.jsx'],

--- a/test/unit/eslint-reporter/EsLintReporterConfiguration.spec.ts
+++ b/test/unit/eslint-reporter/EsLintReporterConfiguration.spec.ts
@@ -1,0 +1,53 @@
+import webpack from 'webpack';
+import { join } from 'path';
+import { EsLintReporterConfiguration } from '../../../lib/eslint-reporter/EsLintReporterConfiguration';
+import { EsLintReporterOptions } from '../../../lib/eslint-reporter/EsLintReporterOptions';
+
+describe('eslint-reporter/EsLintReporterConfiguration', () => {
+  let compiler: webpack.Compiler;
+  const context = '/webpack/context';
+
+  const configuration: EsLintReporterConfiguration = {
+    enabled: false,
+    memoryLimit: 2048,
+    options: {
+      cwd: context,
+      extensions: ['.ts', '.tsx', '.js', '.jsx'],
+    },
+    files: [],
+  };
+
+  beforeEach(() => {
+    compiler = {
+      options: {
+        context,
+      },
+    } as webpack.Compiler;
+  });
+
+  it.each([
+    [undefined, configuration],
+    [{}, configuration],
+    [
+      { files: 'src/**/*.{js,ts,tsx,jsx}' },
+      {
+        ...configuration,
+        enabled: true,
+        files: [join(context, 'src/**/*.{js,ts,tsx,jsx}')],
+      },
+    ],
+    [{ files: [] }, configuration],
+    [{ enabled: true }, { ...configuration, enabled: true }],
+    [{ memoryLimit: 512 }, { ...configuration, memoryLimit: 512 }],
+  ])('creates configuration from options %p', async (options, expectedConfiguration) => {
+    const { createEsLintReporterConfiguration } = await import(
+      'lib/eslint-reporter/EsLintReporterConfiguration'
+    );
+    const configuration = createEsLintReporterConfiguration(
+      compiler,
+      options as EsLintReporterOptions
+    );
+
+    expect(configuration).toEqual(expectedConfiguration);
+  });
+});


### PR DESCRIPTION
If we pass the `files` option to the `eslint` configuration, it should be enabled by default. This fix also updates documentation of default eslint configuration to prevent common issues.

✅ Closes: #458