### PR TITLE
Accept custom logger object

### DIFF
--- a/src/ForkTsCheckerWebpackPluginOptions.json
+++ b/src/ForkTsCheckerWebpackPluginOptions.json
@@ -94,7 +94,18 @@
       "enum": ["console", "webpack-infrastructure", "silent"]
     },
     "Logger": {
-      "instanceof": "Function"
+      "type": "object",
+      "properties": {
+        "error": {
+          "instanceof": "Function"
+        },
+        "info": {
+          "instanceof": "Function"
+        },
+        "log": {
+          "instanceof": "Function"
+        }
+      }
     },
     "TypeScriptReporterOptions": {
       "oneOf": [

--- a/test/unit/ForkTsCheckerWebpackPlugin.spec.ts
+++ b/test/unit/ForkTsCheckerWebpackPlugin.spec.ts
@@ -16,4 +16,14 @@ describe('ForkTsCheckerWebpackPlugin', () => {
   it("doesn't throw an error for empty options", () => {
     expect(() => new ForkTsCheckerWebpackPlugin()).not.toThrowError();
   });
+
+  it('accepts a custom logger', () => {
+    const logger = {
+      error: (message) => console.log(message),
+      info: (message) => console.log(message),
+      log: (message) => console.log(message),
+    };
+
+    expect(() => new ForkTsCheckerWebpackPlugin({ logger: { issues: logger } })).not.toThrowError();
+  });
 });


### PR DESCRIPTION
The runtime validation of the options schema in v5 doesn't seem to like custom logger objects. I believe these are still intended to work, since they're accepted by the TypeScript interface and are invoked correctly.

This PR updates the schema to accept logger objects and adds a test case. Apologies for not opening an issue in advance! Since it was a small change I figured it was quick enough to pull this together all at once. :)