### PR TITLE
feat: add typescriptPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Options for the TypeScript checker (`typescript` option object).
 | `diagnosticOptions` | `object`  | `{ syntactic: false, semantic: true, declaration: false, global: false }`                                      | Settings to select which diagnostics do we want to perform. |
 | `extensions`         | `object`  | `{}`                                                                                                           | See [TypeScript extensions options](#typescript-extensions-options). |
 | `profile`            | `boolean` | `false`                                                                                                        | Measures and prints timings related to the TypeScript performance. |
+| `typescriptPath`     | `string`  | `require.resolve('typescript')`                                                                                | If supplied this is a custom path where TypeScript can be found. |
 
 #### TypeScript extensions options
 

--- a/src/ForkTsCheckerWebpackPluginOptions.json
+++ b/src/ForkTsCheckerWebpackPluginOptions.json
@@ -175,6 +175,10 @@
             "profile": {
               "type": "boolean",
               "description": "Measures and prints timings related to the TypeScript performance."
+            },
+            "typescriptPath": {
+              "type": "string",
+              "description": "If supplied this is a custom path where TypeScript can be found."
             }
           }
         }

--- a/src/typescript-reporter/TypeScriptReporterConfiguration.ts
+++ b/src/typescript-reporter/TypeScriptReporterConfiguration.ts
@@ -23,6 +23,7 @@ interface TypeScriptReporterConfiguration {
     vue: TypeScriptVueExtensionConfiguration;
   };
   profile: boolean;
+  typescriptPath: string;
 }
 
 function createTypeScriptReporterConfiguration(
@@ -42,12 +43,14 @@ function createTypeScriptReporterConfiguration(
   const optionsAsObject: Exclude<TypeScriptReporterOptions, boolean> =
     typeof options === 'object' ? options : {};
 
+  const typescriptPath = optionsAsObject.typescriptPath || require.resolve('typescript');
+
   const defaultCompilerOptions: Record<string, unknown> = {
     skipLibCheck: true,
     sourceMap: false,
     inlineSourceMap: false,
   };
-  if (semver.gte(ts.version, '2.9.0')) {
+  if (semver.gte(require(typescriptPath).version, '2.9.0')) {
     defaultCompilerOptions.declarationMap = false;
   }
 
@@ -79,6 +82,7 @@ function createTypeScriptReporterConfiguration(
       global: false,
       ...(optionsAsObject.diagnosticOptions || {}),
     },
+    typescriptPath: typescriptPath,
   };
 }
 

--- a/src/typescript-reporter/TypeScriptReporterOptions.ts
+++ b/src/typescript-reporter/TypeScriptReporterOptions.ts
@@ -17,6 +17,7 @@ type TypeScriptReporterOptions =
         vue?: TypeScriptVueExtensionOptions;
       };
       profile?: boolean;
+      typescriptPath?: string;
     };
 
 export { TypeScriptReporterOptions };

--- a/src/typescript-reporter/TypeScriptSupport.ts
+++ b/src/typescript-reporter/TypeScriptSupport.ts
@@ -8,7 +8,7 @@ function assertTypeScriptSupport(configuration: TypeScriptReporterConfiguration)
   let typescriptVersion: string | undefined;
 
   try {
-    typescriptVersion = require('typescript').version;
+    typescriptVersion = require(configuration.typescriptPath).version;
   } catch (error) {}
 
   if (!typescriptVersion) {

--- a/src/typescript-reporter/issue/TypeScriptIssueFactory.ts
+++ b/src/typescript-reporter/issue/TypeScriptIssueFactory.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 import * as os from 'os';
 import { deduplicateAndSortIssues, Issue, IssueLocation } from '../../issue';
 
-function createIssueFromTsDiagnostic(diagnostic: ts.Diagnostic): Issue {
+function createIssueFromTsDiagnostic(typescript: typeof ts, diagnostic: ts.Diagnostic): Issue {
   let file: string | undefined;
   let location: IssueLocation | undefined;
 
@@ -37,15 +37,18 @@ function createIssueFromTsDiagnostic(diagnostic: ts.Diagnostic): Issue {
     code: 'TS' + String(diagnostic.code),
     // we don't handle Suggestion and Message diagnostics
     severity: diagnostic.category === 0 ? 'warning' : 'error',
-    message: ts.flattenDiagnosticMessageText(diagnostic.messageText, os.EOL),
+    message: typescript.flattenDiagnosticMessageText(diagnostic.messageText, os.EOL),
     file,
     location,
   };
 }
 
-function createIssuesFromTsDiagnostics(diagnostics: ts.Diagnostic[]): Issue[] {
+function createIssuesFromTsDiagnostics(
+  typescript: typeof ts,
+  diagnostics: ts.Diagnostic[]
+): Issue[] {
   return deduplicateAndSortIssues(
-    diagnostics.map((diagnostic) => createIssueFromTsDiagnostic(diagnostic))
+    diagnostics.map((diagnostic) => createIssueFromTsDiagnostic(typescript, diagnostic))
   );
 }
 

--- a/src/typescript-reporter/profile/TypeScriptPerformance.ts
+++ b/src/typescript-reporter/profile/TypeScriptPerformance.ts
@@ -8,13 +8,16 @@ interface TypeScriptPerformance {
   measure(name: string, startMark?: string, endMark?: string): void;
 }
 
-function getTypeScriptPerformance(): TypeScriptPerformance | undefined {
+function getTypeScriptPerformance(typescript: typeof ts): TypeScriptPerformance | undefined {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (ts as any).performance;
+  return (typescript as any).performance;
 }
 
-function connectTypeScriptPerformance(performance: Performance): Performance {
-  const typeScriptPerformance = getTypeScriptPerformance();
+function connectTypeScriptPerformance(
+  typescript: typeof ts,
+  performance: Performance
+): Performance {
+  const typeScriptPerformance = getTypeScriptPerformance(typescript);
 
   if (typeScriptPerformance) {
     const { mark, measure } = typeScriptPerformance;

--- a/src/typescript-reporter/reporter/ControlledWatchCompilerHost.ts
+++ b/src/typescript-reporter/reporter/ControlledWatchCompilerHost.ts
@@ -3,6 +3,7 @@ import { TypeScriptHostExtension } from '../extension/TypeScriptExtension';
 import { ControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
 
 function createControlledWatchCompilerHost<TProgram extends ts.BuilderProgram>(
+  typescript: typeof ts,
   parsedCommandLine: ts.ParsedCommandLine,
   system: ControlledTypeScriptSystem,
   createProgram?: ts.CreateProgram<TProgram>,
@@ -11,7 +12,7 @@ function createControlledWatchCompilerHost<TProgram extends ts.BuilderProgram>(
   afterProgramCreate?: (program: TProgram) => void,
   hostExtensions: TypeScriptHostExtension[] = []
 ): ts.WatchCompilerHostOfFilesAndCompilerOptions<TProgram> {
-  const baseWatchCompilerHost = ts.createWatchCompilerHost(
+  const baseWatchCompilerHost = typescript.createWatchCompilerHost(
     parsedCommandLine.fileNames,
     parsedCommandLine.options,
     system,
@@ -33,7 +34,7 @@ function createControlledWatchCompilerHost<TProgram extends ts.BuilderProgram>(
     ): TProgram {
       // as compilerHost is optional, ensure that we have it
       if (!compilerHost) {
-        compilerHost = ts.createCompilerHost(options || parsedCommandLine.options);
+        compilerHost = typescript.createCompilerHost(options || parsedCommandLine.options);
       }
 
       hostExtensions.forEach((hostExtension) => {

--- a/src/typescript-reporter/reporter/ControlledWatchSolutionBuilderHost.ts
+++ b/src/typescript-reporter/reporter/ControlledWatchSolutionBuilderHost.ts
@@ -4,6 +4,7 @@ import { TypeScriptHostExtension } from '../extension/TypeScriptExtension';
 import { ControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
 
 function createControlledWatchSolutionBuilderHost<TProgram extends ts.BuilderProgram>(
+  typescript: typeof ts,
   parsedCommandLine: ts.ParsedCommandLine,
   system: ControlledTypeScriptSystem,
   createProgram?: ts.CreateProgram<TProgram>,
@@ -15,6 +16,7 @@ function createControlledWatchSolutionBuilderHost<TProgram extends ts.BuilderPro
   hostExtensions: TypeScriptHostExtension[] = []
 ): ts.SolutionBuilderWithWatchHost<TProgram> {
   const controlledWatchCompilerHost = createControlledWatchCompilerHost(
+    typescript,
     parsedCommandLine,
     system,
     createProgram,

--- a/src/typescript-reporter/reporter/TypeScriptConfigurationParser.ts
+++ b/src/typescript-reporter/reporter/TypeScriptConfigurationParser.ts
@@ -2,12 +2,16 @@ import * as ts from 'typescript';
 import { TypeScriptConfigurationOverwrite } from '../TypeScriptConfigurationOverwrite';
 
 function parseTypeScriptConfiguration(
+  typescript: typeof ts,
   configFileName: string,
   configFileContext: string,
   configOverwriteJSON: TypeScriptConfigurationOverwrite,
   parseConfigFileHost: ts.ParseConfigFileHost
 ): ts.ParsedCommandLine {
-  const parsedConfigFileJSON = ts.readConfigFile(configFileName, parseConfigFileHost.readFile);
+  const parsedConfigFileJSON = typescript.readConfigFile(
+    configFileName,
+    parseConfigFileHost.readFile
+  );
 
   const overwrittenConfigFileJSON = {
     ...(parsedConfigFileJSON.config || {}),
@@ -18,7 +22,7 @@ function parseTypeScriptConfiguration(
     },
   };
 
-  const parsedConfigFile = ts.parseJsonConfigFileContent(
+  const parsedConfigFile = typescript.parseJsonConfigFileContent(
     overwrittenConfigFileJSON,
     parseConfigFileHost,
     configFileContext

--- a/test/unit/typescript-reporter/TypeScriptReporterConfiguration.spec.ts
+++ b/test/unit/typescript-reporter/TypeScriptReporterConfiguration.spec.ts
@@ -36,6 +36,7 @@ describe('typescript-reporter/TypeScriptsReporterConfiguration', () => {
       },
     },
     profile: false,
+    typescriptPath: require.resolve('typescript'),
   };
 
   beforeEach(() => {

--- a/test/unit/typescript-reporter/TypeScriptSupport.spec.ts
+++ b/test/unit/typescript-reporter/TypeScriptSupport.spec.ts
@@ -28,6 +28,7 @@ describe('typescript-reporter/TypeScriptSupport', () => {
       },
       memoryLimit: 2048,
       profile: false,
+      typescriptPath: require.resolve('typescript'),
     };
   });
 

--- a/test/unit/typescript-reporter/issue/TypeScriptIssueFactory.spec.ts
+++ b/test/unit/typescript-reporter/issue/TypeScriptIssueFactory.spec.ts
@@ -42,7 +42,7 @@ describe('typescript-reporter/issue/TypeScriptIssueFactory', () => {
   it.each([[[TS_DIAGNOSTIC_WARNING, TS_DIAGNOSTIC_ERROR, TS_DIAGNOSTIC_WITHOUT_FILE]]])(
     'creates Issues from TsDiagnostics: %p',
     (tsDiagnostics) => {
-      const issues = createIssuesFromTsDiagnostics(tsDiagnostics as ts.Diagnostic[]);
+      const issues = createIssuesFromTsDiagnostics(ts, tsDiagnostics as ts.Diagnostic[]);
 
       expect(issues).toMatchSnapshot();
     }


### PR DESCRIPTION
Fixes #474 

Hi, as per the issue I opened the other day, I would love to see the `typescript` option from V4 back.
I tried a "naive" implementation of it, I changed all references to variables/ function call to a `typescript` variable instead of `ts` and this variable is meant to be passed to the function.

I added the option `typescriptPath` that defaults to `require.resolve('typescript')` and initialized TypeScript in 
* `ForkTsCheckerWebpackPlugin.ts`
* `typescript-reporter/reporter/TypeScriptReporter.ts`

As I said, this is a very naive implementation, it definitely adds the argument "typescript" in a lot of functions, if needed I can refactor it to something else if you prefer another style.