### PR TITLE
refactor: upgrade schema-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,13 +61,14 @@
   },
   "dependencies": {
     "@babel/code-frame": "^7.8.3",
+    "@types/json-schema": "^7.0.5",
     "chalk": "^4.1.0",
     "cosmiconfig": "^6.0.0",
     "deepmerge": "^4.2.2",
     "fs-extra": "^9.0.0",
     "memfs": "^3.1.2",
     "minimatch": "^3.0.4",
-    "schema-utils": "1.0.0",
+    "schema-utils": "2.7.0",
     "semver": "^7.3.2",
     "tapable": "^1.0.0"
   },
@@ -87,7 +88,6 @@
     "@types/mock-fs": "^4.10.0",
     "@types/node": "^13.11.1",
     "@types/rimraf": "^3.0.0",
-    "@types/schema-utils": "1.0.0",
     "@types/semver": "^7.1.0",
     "@types/webpack": "^4.41.11",
     "@typescript-eslint/eslint-plugin": "^2.27.0",

--- a/src/ForkTsCheckerWebpackPlugin.ts
+++ b/src/ForkTsCheckerWebpackPlugin.ts
@@ -1,5 +1,8 @@
 import webpack from 'webpack';
 import validateOptions from 'schema-utils';
+// type only dependency
+// eslint-disable-next-line node/no-extraneous-import
+import type { JSONSchema7 } from 'json-schema';
 import { cosmiconfigSync } from 'cosmiconfig';
 import merge from 'deepmerge';
 import schema from './ForkTsCheckerWebpackPluginOptions.json';
@@ -28,12 +31,13 @@ class ForkTsCheckerWebpackPlugin implements webpack.Plugin {
     const { config: externalOptions } = explorerSync.search() || {};
 
     // first validate options directly passed to the constructor
-    validateOptions(schema, options, 'ForkTsCheckerWebpackPlugin');
+    const configuration = { name: 'ForkTsCheckerWebpackPlugin' };
+    validateOptions(schema as JSONSchema7, options, configuration);
 
     this.options = merge(externalOptions || {}, options || {});
 
     // then validate merged options
-    validateOptions(schema, this.options, 'ForkTsCheckerWebpackPlugin');
+    validateOptions(schema as JSONSchema7, this.options, configuration);
   }
 
   public static getCompilerHooks(compiler: webpack.Compiler) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,10 +1077,10 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
-  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
+"@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5":
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
+  integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
 "@types/minimatch@*", "@types/minimatch@^3.0.1":
   version "3.0.3"
@@ -1139,11 +1139,6 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
-
-"@types/schema-utils@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/schema-utils/-/schema-utils-1.0.0.tgz#295d36f01e2cb8bc3207ca1d9a68e210db6b40cb"
-  integrity sha512-YesPanU1+WCigC/Aj1Mga8UCOjHIfMNHZ3zzDsUY7lI8GlKnh/Kv2QwJOQ+jNQ36Ru7IfzSedlG14hppYaN13A==
 
 "@types/semver@^7.1.0":
   version "7.1.0"
@@ -1526,7 +1521,7 @@ ajv@^6.10.2:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.5.5:
+ajv@^6.12.2, ajv@^6.5.5:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
   integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
@@ -7976,7 +7971,16 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-schema-utils@1.0.0, schema-utils@^1.0.0:
+schema-utils@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
+  integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
+  dependencies:
+    "@types/json-schema" "^7.0.4"
+    ajv "^6.12.2"
+    ajv-keywords "^3.4.1"
+
+schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
   dependencies:


### PR DESCRIPTION
Ref https://github.com/webpack/schema-utils/blob/master/CHANGELOG.md#200-2019-07-17

A lot of webpack packages already upgraded to new version..
Api is changed and types are provided out of the box though required to
add json-schema types.