### PR TITLE
Changed to check for the existence of .vue files by the embedded source extension

### DIFF
--- a/src/typescript-reporter/extension/TypeScriptEmbeddedExtension.ts
+++ b/src/typescript-reporter/extension/TypeScriptEmbeddedExtension.ts
@@ -50,10 +50,13 @@ function createTypeScriptEmbeddedExtension({
   type FileExists = (fileName: string) => boolean;
   function createEmbeddedFileExists(fileExists: FileExists): FileExists {
     return function embeddedFileExists(fileName) {
-      const { embeddedExtension, embeddedFileName } = parsePotentiallyEmbeddedFileName(fileName);
+      const { embeddedExtension, embeddedFileName, extension } = parsePotentiallyEmbeddedFileName(
+        fileName
+      );
 
       if (embeddedExtensions.includes(embeddedExtension) && fileExists(embeddedFileName)) {
-        return true;
+        const embeddedSource = getCachedEmbeddedSource(embeddedFileName);
+        return !!(embeddedSource && embeddedSource.extension === extension);
       }
 
       return fileExists(fileName);


### PR DESCRIPTION
## background
The type information of the `.vue` file written by `lang='tsx'` cannot be imported correctly, because there is a bug in the file existence check and it cannot be load.

## details
Typescript module resolution order is `.ts`, `.tsx`, `.d.ts`, `package.json` ...., so the `.ts` extension is processed before the `.tsx` extension.
File existence check as a `.ts` returns true (*1), but the file cannot be loaded correctly because the subsequent check by the embedded source extension is false(*2).
Also, the module is considered resolved as a `.ts`, which causes problems with checking jsx statements.

- `*1`  https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/65ab0cc994b627648fb872a8ced33de33808efc3/src/typescript-reporter/extension/TypeScriptEmbeddedExtension.ts#L55-L57

- `*2` https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/65ab0cc994b627648fb872a8ced33de33808efc3/src/typescript-reporter/extension/TypeScriptEmbeddedExtension.ts#L73-L76

Expected behavior in `*1` is that a check as a `.ts` should return false and a check as a `.tsx` should return true.

Thanks!