### PR TITLE
fix: use `:line:col` format in webpack errors

### DIFF
--- a/src/formatter/WebpackFormatter.ts
+++ b/src/formatter/WebpackFormatter.ts
@@ -15,7 +15,7 @@ function createWebpackFormatter(formatter: Formatter, context: string): Formatte
     if (issue.file) {
       let location = forwardSlash(path.relative(context, issue.file));
       if (issue.location) {
-        location += ` ${formatIssueLocation(issue.location)}`;
+        location += `:${formatIssueLocation(issue.location)}`;
       }
 
       return [color(`${severity} in ${location}`), formatter(issue), ''].join(os.EOL);

--- a/src/issue/IssueLocation.ts
+++ b/src/issue/IssueLocation.ts
@@ -25,12 +25,7 @@ function compareIssueLocations(locationA?: IssueLocation, locationB?: IssueLocat
 }
 
 function formatIssueLocation(location: IssueLocation) {
-  return [
-    `${location.start.line}:${location.start.column}`,
-    location.start.line !== location.end.line
-      ? `${location.end.line}:${location.end.column}`
-      : `${location.end.column}`,
-  ].join('-');
+  return `${location.start.line}:${location.start.column}`;
 }
 
 export { IssueLocation, compareIssueLocations, formatIssueLocation };

--- a/src/issue/IssueWebpackError.ts
+++ b/src/issue/IssueWebpackError.ts
@@ -17,7 +17,7 @@ class IssueWebpackError extends Error {
       this.file = forwardSlash(relative(context, issue.file));
 
       if (issue.location) {
-        this.file += ` ${formatIssueLocation(issue.location)}`;
+        this.file += `:${formatIssueLocation(issue.location)}`;
       }
     }
 

--- a/test/e2e/EsLint.spec.ts
+++ b/test/e2e/EsLint.spec.ts
@@ -6,6 +6,7 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
+import { fileLocation } from './fileLocationHelper';
 
 describe('EsLint', () => {
   let sandbox: Sandbox;
@@ -59,7 +60,7 @@ describe('EsLint', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'WARNING in src/authenticate.ts 14:34-37',
+        fileLocation('WARNING in src/authenticate.ts', '14:34', async),
         '@typescript-eslint/no-explicit-any: Unexpected any. Specify a different type.',
         '    12 | }',
         '    13 | ',
@@ -70,7 +71,7 @@ describe('EsLint', () => {
         '    17 |     {',
       ].join('\n'),
       [
-        'WARNING in src/index.ts 31:44-49',
+        fileLocation('WARNING in src/index.ts', '31:44', async),
         "@typescript-eslint/no-unused-vars: 'event' is defined but never used.",
         '    29 |   }',
         '    30 | });',
@@ -126,7 +127,7 @@ describe('EsLint', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'WARNING in src/model/User.ts 11:5-19',
+        fileLocation('WARNING in src/model/User.ts', '11:5', async),
         "@typescript-eslint/no-unused-vars: 'temporary' is defined but never used.",
         '     9 | }',
         '    10 | ',
@@ -137,7 +138,7 @@ describe('EsLint', () => {
         '    14 | function getUserName(user: User): string {',
       ].join('\n'),
       [
-        'WARNING in src/model/User.ts 11:16-19',
+        fileLocation('WARNING in src/model/User.ts', '11:16', async),
         '@typescript-eslint/no-explicit-any: Unexpected any. Specify a different type.',
         '     9 | }',
         '    10 | ',

--- a/test/e2e/EsLint.spec.ts
+++ b/test/e2e/EsLint.spec.ts
@@ -6,7 +6,6 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
-import { fileLocation } from './fileLocationHelper';
 
 describe('EsLint', () => {
   let sandbox: Sandbox;
@@ -60,7 +59,7 @@ describe('EsLint', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('WARNING in src/authenticate.ts', '14:34', async),
+        'WARNING in src/authenticate.ts:14:34',
         '@typescript-eslint/no-explicit-any: Unexpected any. Specify a different type.',
         '    12 | }',
         '    13 | ',
@@ -71,7 +70,7 @@ describe('EsLint', () => {
         '    17 |     {',
       ].join('\n'),
       [
-        fileLocation('WARNING in src/index.ts', '31:44', async),
+        'WARNING in src/index.ts:31:44',
         "@typescript-eslint/no-unused-vars: 'event' is defined but never used.",
         '    29 |   }',
         '    30 | });',
@@ -127,7 +126,7 @@ describe('EsLint', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('WARNING in src/model/User.ts', '11:5', async),
+        'WARNING in src/model/User.ts:11:5',
         "@typescript-eslint/no-unused-vars: 'temporary' is defined but never used.",
         '     9 | }',
         '    10 | ',
@@ -138,7 +137,7 @@ describe('EsLint', () => {
         '    14 | function getUserName(user: User): string {',
       ].join('\n'),
       [
-        fileLocation('WARNING in src/model/User.ts', '11:16', async),
+        'WARNING in src/model/User.ts:11:16',
         '@typescript-eslint/no-explicit-any: Unexpected any. Specify a different type.',
         '     9 | }',
         '    10 | ',

--- a/test/e2e/TypeScriptContextOption.spec.ts
+++ b/test/e2e/TypeScriptContextOption.spec.ts
@@ -6,6 +6,7 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
+import { fileLocation } from './fileLocationHelper';
 
 describe('TypeScript Context Option', () => {
   let sandbox: Sandbox;
@@ -102,7 +103,7 @@ describe('TypeScript Context Option', () => {
     const errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'ERROR in src/model/User.ts 11:16-25',
+        fileLocation('ERROR in src/model/User.ts', '11:16', async),
         "TS2339: Property 'firstName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',
@@ -113,7 +114,7 @@ describe('TypeScript Context Option', () => {
         '    14 | }',
       ].join('\n'),
       [
-        'ERROR in src/model/User.ts 11:32-40',
+        fileLocation('ERROR in src/model/User.ts', '11:32', async),
         "TS2339: Property 'lastName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',

--- a/test/e2e/TypeScriptContextOption.spec.ts
+++ b/test/e2e/TypeScriptContextOption.spec.ts
@@ -6,7 +6,6 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
-import { fileLocation } from './fileLocationHelper';
 
 describe('TypeScript Context Option', () => {
   let sandbox: Sandbox;
@@ -103,7 +102,7 @@ describe('TypeScript Context Option', () => {
     const errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('ERROR in src/model/User.ts', '11:16', async),
+        'ERROR in src/model/User.ts:11:16',
         "TS2339: Property 'firstName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',
@@ -114,7 +113,7 @@ describe('TypeScript Context Option', () => {
         '    14 | }',
       ].join('\n'),
       [
-        fileLocation('ERROR in src/model/User.ts', '11:32', async),
+        'ERROR in src/model/User.ts:11:32',
         "TS2339: Property 'lastName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',

--- a/test/e2e/TypeScriptPnpSupport.spec.ts
+++ b/test/e2e/TypeScriptPnpSupport.spec.ts
@@ -11,7 +11,6 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
-import { fileLocation } from './fileLocationHelper';
 
 describe('TypeScript PnP Support', () => {
   let sandbox: Sandbox;
@@ -68,7 +67,7 @@ describe('TypeScript PnP Support', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('ERROR in src/model/User.ts', '11:16', async),
+        'ERROR in src/model/User.ts:11:16',
         "TS2339: Property 'firstName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',
@@ -79,7 +78,7 @@ describe('TypeScript PnP Support', () => {
         '    14 | }',
       ].join('\n'),
       [
-        fileLocation('ERROR in src/model/User.ts', '11:32', async),
+        'ERROR in src/model/User.ts:11:32',
         "TS2339: Property 'lastName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',
@@ -110,7 +109,7 @@ describe('TypeScript PnP Support', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('ERROR in src/index.ts', '1:23', async),
+        'ERROR in src/index.ts:1:23',
         "TS2307: Cannot find module './authenticate'.",
         "  > 1 | import { login } from './authenticate';",
         '      |                       ^^^^^^^^^^^^^^^^',
@@ -154,7 +153,7 @@ describe('TypeScript PnP Support', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('ERROR in src/index.ts', '34:12', async),
+        'ERROR in src/index.ts:34:12',
         "TS2339: Property 'role' does not exist on type 'void'.",
         '    32 |   const user = await login(email, password);',
         '    33 | ',
@@ -165,7 +164,7 @@ describe('TypeScript PnP Support', () => {
         '    37 |     console.log(`Logged in as ${getUserName(user)}`);',
       ].join('\n'),
       [
-        fileLocation('ERROR in src/index.ts', '35:45', async),
+        'ERROR in src/index.ts:35:45',
         "TS2345: Argument of type 'void' is not assignable to parameter of type 'User'.",
         '    33 | ',
         "    34 |   if (user.role === 'admin') {",
@@ -176,7 +175,7 @@ describe('TypeScript PnP Support', () => {
         '    38 |   }',
       ].join('\n'),
       [
-        fileLocation('ERROR in src/index.ts', '37:45', async),
+        'ERROR in src/index.ts:37:45',
         "TS2345: Argument of type 'void' is not assignable to parameter of type 'User'.",
         '    35 |     console.log(`Logged in as ${getUserName(user)} [admin].`);',
         '    36 |   } else {',

--- a/test/e2e/TypeScriptPnpSupport.spec.ts
+++ b/test/e2e/TypeScriptPnpSupport.spec.ts
@@ -11,6 +11,7 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
+import { fileLocation } from './fileLocationHelper';
 
 describe('TypeScript PnP Support', () => {
   let sandbox: Sandbox;
@@ -67,7 +68,7 @@ describe('TypeScript PnP Support', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'ERROR in src/model/User.ts 11:16-25',
+        fileLocation('ERROR in src/model/User.ts', '11:16', async),
         "TS2339: Property 'firstName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',
@@ -78,7 +79,7 @@ describe('TypeScript PnP Support', () => {
         '    14 | }',
       ].join('\n'),
       [
-        'ERROR in src/model/User.ts 11:32-40',
+        fileLocation('ERROR in src/model/User.ts', '11:32', async),
         "TS2339: Property 'lastName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',
@@ -109,7 +110,7 @@ describe('TypeScript PnP Support', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'ERROR in src/index.ts 1:23-39',
+        fileLocation('ERROR in src/index.ts', '1:23', async),
         "TS2307: Cannot find module './authenticate'.",
         "  > 1 | import { login } from './authenticate';",
         '      |                       ^^^^^^^^^^^^^^^^',
@@ -153,7 +154,7 @@ describe('TypeScript PnP Support', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'ERROR in src/index.ts 34:12-16',
+        fileLocation('ERROR in src/index.ts', '34:12', async),
         "TS2339: Property 'role' does not exist on type 'void'.",
         '    32 |   const user = await login(email, password);',
         '    33 | ',
@@ -164,7 +165,7 @@ describe('TypeScript PnP Support', () => {
         '    37 |     console.log(`Logged in as ${getUserName(user)}`);',
       ].join('\n'),
       [
-        'ERROR in src/index.ts 35:45-49',
+        fileLocation('ERROR in src/index.ts', '35:45', async),
         "TS2345: Argument of type 'void' is not assignable to parameter of type 'User'.",
         '    33 | ',
         "    34 |   if (user.role === 'admin') {",
@@ -175,7 +176,7 @@ describe('TypeScript PnP Support', () => {
         '    38 |   }',
       ].join('\n'),
       [
-        'ERROR in src/index.ts 37:45-49',
+        fileLocation('ERROR in src/index.ts', '37:45', async),
         "TS2345: Argument of type 'void' is not assignable to parameter of type 'User'.",
         '    35 |     console.log(`Logged in as ${getUserName(user)} [admin].`);',
         '    36 |   } else {',

--- a/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
+++ b/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
@@ -6,6 +6,7 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
+import { fileLocation } from './fileLocationHelper';
 
 describe('TypeScript SolutionBuilder API', () => {
   let sandbox: Sandbox;
@@ -56,7 +57,7 @@ describe('TypeScript SolutionBuilder API', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'ERROR in packages/shared/src/intersect.ts 2:41-49',
+        fileLocation('ERROR in packages/shared/src/intersect.ts', '2:41', async),
         "TS2339: Property 'includes' does not exist on type 'T'.",
         '    1 | function intersect<T>(arrayA: T[] = [], arrayB: T): T[] {',
         '  > 2 |   return arrayA.filter((item) => arrayB.includes(item));',
@@ -78,7 +79,7 @@ describe('TypeScript SolutionBuilder API', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'ERROR in packages/client/src/index.ts 4:42-48',
+        fileLocation('ERROR in packages/client/src/index.ts', '4:42', async),
         "TS2345: Argument of type 'T[]' is not assignable to parameter of type 'T'.",
         "  'T[]' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint '{}'.",
         '    2 | ',

--- a/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
+++ b/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
@@ -6,7 +6,6 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
-import { fileLocation } from './fileLocationHelper';
 
 describe('TypeScript SolutionBuilder API', () => {
   let sandbox: Sandbox;
@@ -57,7 +56,7 @@ describe('TypeScript SolutionBuilder API', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('ERROR in packages/shared/src/intersect.ts', '2:41', async),
+        'ERROR in packages/shared/src/intersect.ts:2:41',
         "TS2339: Property 'includes' does not exist on type 'T'.",
         '    1 | function intersect<T>(arrayA: T[] = [], arrayB: T): T[] {',
         '  > 2 |   return arrayA.filter((item) => arrayB.includes(item));',
@@ -79,7 +78,7 @@ describe('TypeScript SolutionBuilder API', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('ERROR in packages/client/src/index.ts', '4:42', async),
+        'ERROR in packages/client/src/index.ts:4:42',
         "TS2345: Argument of type 'T[]' is not assignable to parameter of type 'T'.",
         "  'T[]' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint '{}'.",
         '    2 | ',

--- a/test/e2e/TypeScriptVueExtension.spec.ts
+++ b/test/e2e/TypeScriptVueExtension.spec.ts
@@ -6,7 +6,6 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
-import { fileLocation } from './fileLocationHelper';
 
 describe('TypeScript Vue Extension', () => {
   let sandbox: Sandbox;
@@ -95,7 +94,7 @@ describe('TypeScript Vue Extension', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          fileLocation('ERROR in src/component/LoggedIn.vue', '27:21', async),
+          'ERROR in src/component/LoggedIn.vue:27:21',
           "TS2304: Cannot find name 'getUserName'.",
           '    25 |       const user: User = this.user;',
           '    26 | ',
@@ -123,7 +122,7 @@ describe('TypeScript Vue Extension', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          fileLocation('ERROR in src/component/LoggedIn.vue', '27:29', async),
+          'ERROR in src/component/LoggedIn.vue:27:29',
           "TS2339: Property 'firstName' does not exist on type 'User'.",
           '    25 |       const user: User = this.user;',
           '    26 | ',
@@ -134,7 +133,7 @@ describe('TypeScript Vue Extension', () => {
           '    30 |   async logout() {',
         ].join('\n'),
         [
-          fileLocation('ERROR in src/model/User.ts', '11:16', async),
+          'ERROR in src/model/User.ts:11:16',
           "TS2339: Property 'firstName' does not exist on type 'User'.",
           '     9 | ',
           '    10 | function getUserName(user: User): string {',

--- a/test/e2e/TypeScriptVueExtension.spec.ts
+++ b/test/e2e/TypeScriptVueExtension.spec.ts
@@ -6,6 +6,7 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
+import { fileLocation } from './fileLocationHelper';
 
 describe('TypeScript Vue Extension', () => {
   let sandbox: Sandbox;
@@ -94,7 +95,7 @@ describe('TypeScript Vue Extension', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          'ERROR in src/component/LoggedIn.vue 27:21-32',
+          fileLocation('ERROR in src/component/LoggedIn.vue', '27:21', async),
           "TS2304: Cannot find name 'getUserName'.",
           '    25 |       const user: User = this.user;',
           '    26 | ',
@@ -122,7 +123,7 @@ describe('TypeScript Vue Extension', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          'ERROR in src/component/LoggedIn.vue 27:29-38',
+          fileLocation('ERROR in src/component/LoggedIn.vue', '27:29', async),
           "TS2339: Property 'firstName' does not exist on type 'User'.",
           '    25 |       const user: User = this.user;',
           '    26 | ',
@@ -133,7 +134,7 @@ describe('TypeScript Vue Extension', () => {
           '    30 |   async logout() {',
         ].join('\n'),
         [
-          'ERROR in src/model/User.ts 11:16-25',
+          fileLocation('ERROR in src/model/User.ts', '11:16', async),
           "TS2339: Property 'firstName' does not exist on type 'User'.",
           '     9 | ',
           '    10 | function getUserName(user: User): string {',

--- a/test/e2e/TypeScriptWatchApi.spec.ts
+++ b/test/e2e/TypeScriptWatchApi.spec.ts
@@ -6,7 +6,6 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
-import { fileLocation } from './fileLocationHelper';
 
 describe('TypeScript Watch API', () => {
   let sandbox: Sandbox;
@@ -74,7 +73,7 @@ describe('TypeScript Watch API', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          fileLocation('ERROR in src/index.ts', '34:7', async),
+          'ERROR in src/index.ts:34:7',
           `TS2367: This condition will always return 'false' since the types 'Role' and '"admin"' have no overlap.`,
           '    32 |   const user = await login(email, password);',
           '    33 | ',
@@ -116,7 +115,7 @@ describe('TypeScript Watch API', () => {
       );
       expect(errors).toEqual([
         [
-          fileLocation('ERROR in src/model/User.ts', '1:22', async),
+          'ERROR in src/model/User.ts:1:22',
           "TS2307: Cannot find module './Role'.",
           "  > 1 | import { Role } from './Role';",
           '      |                      ^^^^^^^^',
@@ -136,7 +135,7 @@ describe('TypeScript Watch API', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          fileLocation('ERROR in src/index.ts', '34:7', async),
+          'ERROR in src/index.ts:34:7',
           "TS2367: This condition will always return 'false' since the types 'Role' and '\"provider\"' have no overlap.",
           '    32 |   const user = await login(email, password);',
           '    33 | ',
@@ -195,7 +194,7 @@ describe('TypeScript Watch API', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          fileLocation('ERROR in src/index.ts', '34:7', async),
+          'ERROR in src/index.ts:34:7',
           `TS2367: This condition will always return 'false' since the types 'Role' and '"admin"' have no overlap.`,
           '    32 |   const user = await login(email, password);',
           '    33 | ',
@@ -237,7 +236,7 @@ describe('TypeScript Watch API', () => {
       );
       expect(errors).toEqual([
         [
-          fileLocation('ERROR in src/model/User.ts', '1:22', async),
+          'ERROR in src/model/User.ts:1:22',
           "TS2307: Cannot find module './Role'.",
           "  > 1 | import { Role } from './Role';",
           '      |                      ^^^^^^^^',
@@ -257,7 +256,7 @@ describe('TypeScript Watch API', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          fileLocation('ERROR in src/index.ts', '34:7', async),
+          'ERROR in src/index.ts:34:7',
           "TS2367: This condition will always return 'false' since the types 'Role' and '\"provider\"' have no overlap.",
           '    32 |   const user = await login(email, password);',
           '    33 | ',
@@ -309,7 +308,7 @@ describe('TypeScript Watch API', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('ERROR in src/model/User.ts', '11:16', async),
+        'ERROR in src/model/User.ts:11:16',
         "TS2339: Property 'firstName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',
@@ -320,7 +319,7 @@ describe('TypeScript Watch API', () => {
         '    14 | }',
       ].join('\n'),
       [
-        fileLocation('ERROR in src/model/User.ts', '11:32', async),
+        'ERROR in src/model/User.ts:11:32',
         "TS2339: Property 'lastName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',
@@ -351,7 +350,7 @@ describe('TypeScript Watch API', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('ERROR in src/index.ts', '1:23', async),
+        'ERROR in src/index.ts:1:23',
         "TS2307: Cannot find module './authenticate'.",
         "  > 1 | import { login } from './authenticate';",
         '      |                       ^^^^^^^^^^^^^^^^',
@@ -395,7 +394,7 @@ describe('TypeScript Watch API', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        fileLocation('ERROR in src/index.ts', '34:12', async),
+        'ERROR in src/index.ts:34:12',
         "TS2339: Property 'role' does not exist on type 'void'.",
         '    32 |   const user = await login(email, password);',
         '    33 | ',
@@ -406,7 +405,7 @@ describe('TypeScript Watch API', () => {
         '    37 |     console.log(`Logged in as ${getUserName(user)}`);',
       ].join('\n'),
       [
-        fileLocation('ERROR in src/index.ts', '35:45', async),
+        'ERROR in src/index.ts:35:45',
         "TS2345: Argument of type 'void' is not assignable to parameter of type 'User'.",
         '    33 | ',
         "    34 |   if (user.role === 'admin') {",
@@ -417,7 +416,7 @@ describe('TypeScript Watch API', () => {
         '    38 |   }',
       ].join('\n'),
       [
-        fileLocation('ERROR in src/index.ts', '37:45', async),
+        'ERROR in src/index.ts:37:45',
         "TS2345: Argument of type 'void' is not assignable to parameter of type 'User'.",
         '    35 |     console.log(`Logged in as ${getUserName(user)} [admin].`);',
         '    36 |   } else {',

--- a/test/e2e/TypeScriptWatchApi.spec.ts
+++ b/test/e2e/TypeScriptWatchApi.spec.ts
@@ -6,6 +6,7 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
+import { fileLocation } from './fileLocationHelper';
 
 describe('TypeScript Watch API', () => {
   let sandbox: Sandbox;
@@ -73,7 +74,7 @@ describe('TypeScript Watch API', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          'ERROR in src/index.ts 34:7-28',
+          fileLocation('ERROR in src/index.ts', '34:7', async),
           `TS2367: This condition will always return 'false' since the types 'Role' and '"admin"' have no overlap.`,
           '    32 |   const user = await login(email, password);',
           '    33 | ',
@@ -115,7 +116,7 @@ describe('TypeScript Watch API', () => {
       );
       expect(errors).toEqual([
         [
-          'ERROR in src/model/User.ts 1:22-30',
+          fileLocation('ERROR in src/model/User.ts', '1:22', async),
           "TS2307: Cannot find module './Role'.",
           "  > 1 | import { Role } from './Role';",
           '      |                      ^^^^^^^^',
@@ -135,7 +136,7 @@ describe('TypeScript Watch API', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          'ERROR in src/index.ts 34:7-31',
+          fileLocation('ERROR in src/index.ts', '34:7', async),
           "TS2367: This condition will always return 'false' since the types 'Role' and '\"provider\"' have no overlap.",
           '    32 |   const user = await login(email, password);',
           '    33 | ',
@@ -194,7 +195,7 @@ describe('TypeScript Watch API', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          'ERROR in src/index.ts 34:7-28',
+          fileLocation('ERROR in src/index.ts', '34:7', async),
           `TS2367: This condition will always return 'false' since the types 'Role' and '"admin"' have no overlap.`,
           '    32 |   const user = await login(email, password);',
           '    33 | ',
@@ -236,7 +237,7 @@ describe('TypeScript Watch API', () => {
       );
       expect(errors).toEqual([
         [
-          'ERROR in src/model/User.ts 1:22-30',
+          fileLocation('ERROR in src/model/User.ts', '1:22', async),
           "TS2307: Cannot find module './Role'.",
           "  > 1 | import { Role } from './Role';",
           '      |                      ^^^^^^^^',
@@ -256,7 +257,7 @@ describe('TypeScript Watch API', () => {
       errors = await driver.waitForErrors();
       expect(errors).toEqual([
         [
-          'ERROR in src/index.ts 34:7-31',
+          fileLocation('ERROR in src/index.ts', '34:7', async),
           "TS2367: This condition will always return 'false' since the types 'Role' and '\"provider\"' have no overlap.",
           '    32 |   const user = await login(email, password);',
           '    33 | ',
@@ -308,7 +309,7 @@ describe('TypeScript Watch API', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'ERROR in src/model/User.ts 11:16-25',
+        fileLocation('ERROR in src/model/User.ts', '11:16', async),
         "TS2339: Property 'firstName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',
@@ -319,7 +320,7 @@ describe('TypeScript Watch API', () => {
         '    14 | }',
       ].join('\n'),
       [
-        'ERROR in src/model/User.ts 11:32-40',
+        fileLocation('ERROR in src/model/User.ts', '11:32', async),
         "TS2339: Property 'lastName' does not exist on type 'User'.",
         '     9 | ',
         '    10 | function getUserName(user: User): string {',
@@ -350,7 +351,7 @@ describe('TypeScript Watch API', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'ERROR in src/index.ts 1:23-39',
+        fileLocation('ERROR in src/index.ts', '1:23', async),
         "TS2307: Cannot find module './authenticate'.",
         "  > 1 | import { login } from './authenticate';",
         '      |                       ^^^^^^^^^^^^^^^^',
@@ -394,7 +395,7 @@ describe('TypeScript Watch API', () => {
     errors = await driver.waitForErrors();
     expect(errors).toEqual([
       [
-        'ERROR in src/index.ts 34:12-16',
+        fileLocation('ERROR in src/index.ts', '34:12', async),
         "TS2339: Property 'role' does not exist on type 'void'.",
         '    32 |   const user = await login(email, password);',
         '    33 | ',
@@ -405,7 +406,7 @@ describe('TypeScript Watch API', () => {
         '    37 |     console.log(`Logged in as ${getUserName(user)}`);',
       ].join('\n'),
       [
-        'ERROR in src/index.ts 35:45-49',
+        fileLocation('ERROR in src/index.ts', '35:45', async),
         "TS2345: Argument of type 'void' is not assignable to parameter of type 'User'.",
         '    33 | ',
         "    34 |   if (user.role === 'admin') {",
@@ -416,7 +417,7 @@ describe('TypeScript Watch API', () => {
         '    38 |   }',
       ].join('\n'),
       [
-        'ERROR in src/index.ts 37:45-49',
+        fileLocation('ERROR in src/index.ts', '37:45', async),
         "TS2345: Argument of type 'void' is not assignable to parameter of type 'User'.",
         '    35 |     console.log(`Logged in as ${getUserName(user)} [admin].`);',
         '    36 |   } else {',

--- a/test/e2e/WebpackIssueScope.spec.ts
+++ b/test/e2e/WebpackIssueScope.spec.ts
@@ -6,6 +6,7 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
+import { fileLocation } from './fileLocationHelper';
 
 describe('Webpack Issue Scope', () => {
   let sandbox: Sandbox;
@@ -81,7 +82,7 @@ describe('Webpack Issue Scope', () => {
         const errors = await driver.waitForErrors();
         expect(errors).toEqual([
           [
-            'ERROR in src/notUsedFile.ts 1:7-8',
+            fileLocation('ERROR in src/notUsedFile.ts', '1:7', async),
             "TS2322: Type '\"1\"' is not assignable to type 'number'.",
             '  > 1 | const x: number = "1";',
             '      |       ^',
@@ -96,7 +97,7 @@ describe('Webpack Issue Scope', () => {
         const errors = await driver.waitForErrors();
         expect(errors).toEqual([
           [
-            'ERROR in src/notUsedFile.ts 1:7-8',
+            fileLocation('ERROR in src/notUsedFile.ts', '1:7', async),
             "TS2322: Type '\"1\"' is not assignable to type 'number'.",
             '  > 1 | const x: number = "1";',
             '      |       ^',

--- a/test/e2e/WebpackIssueScope.spec.ts
+++ b/test/e2e/WebpackIssueScope.spec.ts
@@ -6,7 +6,6 @@ import {
   WEBPACK_CLI_VERSION,
   WEBPACK_DEV_SERVER_VERSION,
 } from './sandbox/WebpackDevServerDriver';
-import { fileLocation } from './fileLocationHelper';
 
 describe('Webpack Issue Scope', () => {
   let sandbox: Sandbox;
@@ -82,7 +81,7 @@ describe('Webpack Issue Scope', () => {
         const errors = await driver.waitForErrors();
         expect(errors).toEqual([
           [
-            fileLocation('ERROR in src/notUsedFile.ts', '1:7', async),
+            'ERROR in src/notUsedFile.ts:1:7',
             "TS2322: Type '\"1\"' is not assignable to type 'number'.",
             '  > 1 | const x: number = "1";',
             '      |       ^',
@@ -97,7 +96,7 @@ describe('Webpack Issue Scope', () => {
         const errors = await driver.waitForErrors();
         expect(errors).toEqual([
           [
-            fileLocation('ERROR in src/notUsedFile.ts', '1:7', async),
+            'ERROR in src/notUsedFile.ts:1:7',
             "TS2322: Type '\"1\"' is not assignable to type 'number'.",
             '  > 1 | const x: number = "1";',
             '      |       ^',

--- a/test/e2e/WebpackProductionBuild.spec.ts
+++ b/test/e2e/WebpackProductionBuild.spec.ts
@@ -120,7 +120,7 @@ describe('Webpack Production Build', () => {
           // first error is from the webpack module resolution
           expect.anything(),
           [
-            'ERROR in src/authenticate.ts 1:22',
+            'ERROR in src/authenticate.ts:1:22',
             "TS2307: Cannot find module './model/User'.",
             "  > 1 | import { User } from './model/User';",
             '      |                      ^^^^^^^^^^^^^^',
@@ -129,7 +129,7 @@ describe('Webpack Production Build', () => {
             '    4 |   const response = await fetch(',
           ].join('\n'),
           [
-            'ERROR in src/index.ts 2:29',
+            'ERROR in src/index.ts:2:29',
             "TS2307: Cannot find module './model/User'.",
             "    1 | import { login } from './authenticate';",
             "  > 2 | import { getUserName } from './model/User';",

--- a/test/e2e/WebpackProductionBuild.spec.ts
+++ b/test/e2e/WebpackProductionBuild.spec.ts
@@ -120,7 +120,7 @@ describe('Webpack Production Build', () => {
           // first error is from the webpack module resolution
           expect.anything(),
           [
-            'ERROR in src/authenticate.ts 1:22-36',
+            'ERROR in src/authenticate.ts 1:22',
             "TS2307: Cannot find module './model/User'.",
             "  > 1 | import { User } from './model/User';",
             '      |                      ^^^^^^^^^^^^^^',
@@ -129,7 +129,7 @@ describe('Webpack Production Build', () => {
             '    4 |   const response = await fetch(',
           ].join('\n'),
           [
-            'ERROR in src/index.ts 2:29-43',
+            'ERROR in src/index.ts 2:29',
             "TS2307: Cannot find module './model/User'.",
             "    1 | import { login } from './authenticate';",
             "  > 2 | import { getUserName } from './model/User';",

--- a/test/e2e/fileLocationHelper.ts
+++ b/test/e2e/fileLocationHelper.ts
@@ -1,8 +1,0 @@
-export function fileLocation(file: string, location: string, async: boolean): string {
-  // async: true uses our own WebpackFormatter which
-  // separates file and location with a colon
-  const locationSeperator = async ? ':' : ' ';
-
-  // e.g. `/a/b/c.ts:2:10` or `/a/b/c.ts 2:10`
-  return `${file}${locationSeperator}${location}`;
-}

--- a/test/e2e/fileLocationHelper.ts
+++ b/test/e2e/fileLocationHelper.ts
@@ -1,0 +1,8 @@
+export function fileLocation(file: string, location: string, async: boolean): string {
+  // async: true uses our own WebpackFormatter which
+  // separates file and location with a colon
+  const locationSeperator = async ? ':' : ' ';
+
+  // e.g. `/a/b/c.ts:2:10` or `/a/b/c.ts 2:10`
+  return `${file}${locationSeperator}${location}`;
+}

--- a/test/unit/formatter/WebpackFormatter.spec.ts
+++ b/test/unit/formatter/WebpackFormatter.spec.ts
@@ -42,18 +42,18 @@ describe('formatter/WebpackFormatter', () => {
   });
 
   it('formats location', () => {
-    expect(formatter(issue)).toContain('1:7-16');
+    expect(formatter(issue)).toContain(':1:7');
     expect(
       formatter({
         ...issue,
         location: { start: { line: 1, column: 7 }, end: { line: 10, column: 16 } },
       })
-    ).toContain('1:7-10:16');
+    ).toContain(':1:7');
   });
 
   it('formats issue header like webpack', () => {
     expect(formatter(issue)).toEqual(
-      [`ERROR in some/file.ts 1:7-16`, 'TS123: Some issue content', ''].join(os.EOL)
+      [`ERROR in some/file.ts:1:7`, 'TS123: Some issue content', ''].join(os.EOL)
     );
   });
 });


### PR DESCRIPTION
Fixes #481

As discussed in #481, changes the format of TypeScript error file locations to use `file:line:col`. This means files can be opened from the terminal at the location the error occurred (e.g. cmd+click on Mac).  Like this:

```ts
ERROR in /Users/.../customer.ts:86:16
TS2551: Property 'giveName' does not exist on type 'Customer'. Did you mean 'givenName'?
    84 |     }
    85 |     if (c.givenName) {
  > 86 |       return c.giveName;
       |                ^^^^^^^^
    87 |     }
    88 |     if (c.familyName) {
    89 |       return c.familyName;
```

The location end is still used in the code frame.