### PR TITLE
fix(eslint): don't lint ignored files

### DIFF
--- a/src/eslint-reporter/reporter/EsLintReporter.ts
+++ b/src/eslint-reporter/reporter/EsLintReporter.ts
@@ -40,7 +40,8 @@ function createEsLintReporter(configuration: EsLintReporterConfiguration): Repor
             ) &&
             (configuration.options.extensions || []).some((extension) =>
               changedFile.endsWith(extension)
-            )
+            ) &&
+            !engine.isPathIgnored(changedFile)
         );
 
         if (changedAndIncludedFiles.length) {


### PR DESCRIPTION
Filter out files ignored by the eslint config when linting on watched builds. This happened already for initial and non-watched builds.

This should stop the warnings every time a file ignored by eslintrc is changed that look like

> [unknown]: File ignored because of a matching ignore pattern. Use "--no-ignore" to override.

Closes #485