### PR TITLE
perf: improve solution builder performance by skipLibCheck

### DIFF
--- a/src/typescript-reporter/reporter/ControlledWatchSolutionBuilderHost.ts
+++ b/src/typescript-reporter/reporter/ControlledWatchSolutionBuilderHost.ts
@@ -56,6 +56,20 @@ function createControlledWatchSolutionBuilderHost<TProgram extends ts.BuilderPro
     deleteFile(fileName: string): void {
       system.deleteFile(fileName);
     },
+    getParsedCommandLine(fileName: string): ts.ParsedCommandLine | undefined {
+      return ts.getParsedCommandLineOfConfigFile(
+        fileName,
+        { skipLibCheck: true },
+        {
+          ...system,
+          onUnRecoverableConfigFileDiagnostic: (diagnostic) => {
+            if (reportDiagnostic) {
+              reportDiagnostic(diagnostic);
+            }
+          },
+        }
+      );
+    },
   };
 
   hostExtensions.forEach((hostExtension) => {


### PR DESCRIPTION
I did some profiling regarding #463 (thanks @nathanforce for the repo) and found that the difference between the plugin and  `tsc` is that `tsc` doesn't check standard library files in referenced projects. I implemented an optional `getParsedCommandLine` method on the watch solution builder host to automatically use `skipLibCheck` in referenced projects.