### PR TITLE
fix: use cwd in async: false mode for consistency

### DIFF
--- a/src/hooks/tapAfterCompileToGetIssues.ts
+++ b/src/hooks/tapAfterCompileToGetIssues.ts
@@ -40,11 +40,7 @@ function tapAfterCompileToGetIssues(
     issues = hooks.issues.call(issues, compilation);
 
     issues.forEach((issue) => {
-      const error = new IssueWebpackError(
-        configuration.formatter(issue),
-        compiler.options.context || process.cwd(),
-        issue
-      );
+      const error = new IssueWebpackError(configuration.formatter(issue), issue);
 
       if (issue.severity === 'warning') {
         compilation.warnings.push(error);

--- a/src/hooks/tapDoneToAsyncGetIssues.ts
+++ b/src/hooks/tapDoneToAsyncGetIssues.ts
@@ -69,11 +69,7 @@ function tapDoneToAsyncGetIssues(
 
     if (state.webpackDevServerDoneTap) {
       issues.forEach((issue) => {
-        const error = new IssueWebpackError(
-          configuration.formatter(issue),
-          compiler.options.context || process.cwd(),
-          issue
-        );
+        const error = new IssueWebpackError(configuration.formatter(issue), issue);
 
         if (issue.severity === 'warning') {
           stats.compilation.warnings.push(error);

--- a/src/issue/IssueWebpackError.ts
+++ b/src/issue/IssueWebpackError.ts
@@ -7,14 +7,14 @@ class IssueWebpackError extends Error {
   readonly hideStack = true;
   readonly file: string | undefined;
 
-  constructor(message: string, context: string, readonly issue: Issue) {
+  constructor(message: string, readonly issue: Issue) {
     super(message);
 
     // to display issue location using `loc` property, webpack requires `error.module` which
     // should be a NormalModule instance.
     // to avoid such a dependency, we do a workaround - error.file will contain formatted location instead
     if (issue.file) {
-      this.file = forwardSlash(relative(context, issue.file));
+      this.file = forwardSlash(relative(process.cwd(), issue.file));
 
       if (issue.location) {
         this.file += `:${formatIssueLocation(issue.location)}`;

--- a/test/e2e/TypeScriptContextOption.spec.ts
+++ b/test/e2e/TypeScriptContextOption.spec.ts
@@ -69,7 +69,7 @@ describe('TypeScript Context Option', () => {
     await sandbox.patch(
       'webpack.config.js',
       "entry: './src/index.ts',",
-      "entry: path.resolve(__dirname, './src/index.ts'),"
+      ["entry: './src/index.ts',", 'context: path.resolve(__dirname),'].join('\n')
     );
     await sandbox.patch(
       'webpack.config.js',


### PR DESCRIPTION
✅ Closes: #509

Related to https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/pull/524#issuecomment-722708468
@eamodio