### PR TITLE
docs: update babel-loader example webpack config

### DIFF
--- a/examples/babel-loader/webpack.config.js
+++ b/examples/babel-loader/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
           semantic: true,
           syntactic: true,
         },
+        mode: "write-references",
       },
     }),
   ],


### PR DESCRIPTION
Set mode to 'write-references' as recommended [in the readme](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#typescript-options):

> If you use the babel-loader, it's recommended to use write-references mode to improve initial compilation time. 