### PR TITLE
feat: add built-in support for concurrency limiting

### DIFF
--- a/src/ForkTsCheckerWebpackPlugin.ts
+++ b/src/ForkTsCheckerWebpackPlugin.ts
@@ -20,9 +20,18 @@ import { tapAfterCompileToAddDependencies } from './hooks/tapAfterCompileToAddDe
 import { tapErrorToLogMessage } from './hooks/tapErrorToLogMessage';
 import { getForkTsCheckerWebpackPluginHooks } from './hooks/pluginHooks';
 import { tapAfterEnvironmentToPatchWatching } from './hooks/tapAfterEnvironmentToPatchWatching';
+import { createPool, Pool } from './utils/async/pool';
+import os from 'os';
 
 class ForkTsCheckerWebpackPlugin implements webpack.Plugin {
+  /**
+   * Current version of the plugin
+   */
   static readonly version: string = '{{VERSION}}'; // will be replaced by the @semantic-release/exec
+  /**
+   * Default pool for the plugin concurrency limit
+   */
+  static readonly pool: Pool = createPool(Math.max(1, os.cpus().length));
 
   private readonly options: ForkTsCheckerWebpackPluginOptions;
 

--- a/src/hooks/tapAfterCompileToGetIssues.ts
+++ b/src/hooks/tapAfterCompileToGetIssues.ts
@@ -1,5 +1,4 @@
 import webpack from 'webpack';
-import path from 'path';
 import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';

--- a/src/hooks/tapDoneToAsyncGetIssues.ts
+++ b/src/hooks/tapDoneToAsyncGetIssues.ts
@@ -1,6 +1,5 @@
 import webpack from 'webpack';
 import chalk from 'chalk';
-import path from 'path';
 import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';

--- a/src/utils/async/pool.ts
+++ b/src/utils/async/pool.ts
@@ -1,0 +1,49 @@
+// provide done callback because our promise chain is a little bit complicated
+type Task<T> = (done: () => void) => Promise<T>;
+
+interface Pool {
+  submit<T>(task: Task<T>): Promise<T>;
+  size: number;
+  readonly pending: number;
+}
+
+function createPool(size: number): Pool {
+  let pendingPromises: Promise<unknown>[] = [];
+
+  const pool = {
+    async submit<T>(task: Task<T>): Promise<T> {
+      while (pendingPromises.length >= pool.size) {
+        await Promise.race(pendingPromises).catch(() => undefined);
+      }
+
+      let resolve: (result: T) => void;
+      let reject: (error: Error) => void;
+      const taskPromise = new Promise<T>((taskResolve, taskReject) => {
+        resolve = taskResolve;
+        reject = taskReject;
+      });
+
+      const donePromise = new Promise((doneResolve) => {
+        task(() => {
+          doneResolve(undefined);
+          pendingPromises = pendingPromises.filter(
+            (pendingPromise) => pendingPromise !== donePromise
+          );
+        })
+          .then(resolve)
+          .catch(reject);
+      });
+      pendingPromises.push(donePromise);
+
+      return taskPromise;
+    },
+    size,
+    get pending() {
+      return pendingPromises.length;
+    },
+  };
+
+  return pool;
+}
+
+export { Pool, createPool };

--- a/test/unit/utils/async/pool.spec.ts
+++ b/test/unit/utils/async/pool.spec.ts
@@ -1,0 +1,34 @@
+import { createPool } from 'lib/utils/async/pool';
+
+describe('createPool', () => {
+  it('creates new pool', () => {
+    const pool = createPool(10);
+    expect(pool).toBeDefined();
+    expect(pool.size).toEqual(10);
+    expect(pool.pending).toEqual(0);
+    expect(pool.submit).toBeInstanceOf(Function);
+  });
+
+  it('limits concurrency', async () => {
+    const pool = createPool(2);
+    const task = jest.fn(async (done: () => void) => {
+      setTimeout(done, 100);
+    });
+
+    pool.submit(task);
+    pool.submit(task);
+    pool.submit(task);
+    pool.submit(task);
+    pool.submit(task);
+
+    expect(task).toHaveBeenCalledTimes(2);
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(task).toHaveBeenCalledTimes(4);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(task).toHaveBeenCalledTimes(5);
+  });
+});

--- a/test/unit/utils/async/pool.spec.ts
+++ b/test/unit/utils/async/pool.spec.ts
@@ -11,24 +11,25 @@ describe('createPool', () => {
 
   it('limits concurrency', async () => {
     const pool = createPool(2);
-    const task = jest.fn(async (done: () => void) => {
-      setTimeout(done, 100);
+    const shortTask = jest.fn(async (done: () => void) => {
+      setTimeout(done, 10);
+    });
+    const longTask = jest.fn(async (done: () => void) => {
+      setTimeout(done, 10000);
     });
 
-    pool.submit(task);
-    pool.submit(task);
-    pool.submit(task);
-    pool.submit(task);
-    pool.submit(task);
+    pool.submit(shortTask);
+    pool.submit(shortTask);
+    pool.submit(longTask);
+    pool.submit(longTask);
+    pool.submit(longTask);
 
-    expect(task).toHaveBeenCalledTimes(2);
+    expect(shortTask).toHaveBeenCalledTimes(2);
+    expect(longTask).toHaveBeenCalledTimes(0);
 
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await new Promise((resolve) => setTimeout(resolve, 200));
 
-    expect(task).toHaveBeenCalledTimes(4);
-
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    expect(task).toHaveBeenCalledTimes(5);
+    expect(shortTask).toHaveBeenCalledTimes(2);
+    expect(longTask).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Inspired by the `fork-ts-checker-webpack-plugin-limiter` plugin - thanks @vicary. This implementation uses a global pool to limit plugin concurrency. No configuration needed from the user.

✅ Closes: #441