### PR TITLE
Import webpack using "* as webpack" syntax.

### DIFF
--- a/src/ForkTsCheckerWebpackPlugin.ts
+++ b/src/ForkTsCheckerWebpackPlugin.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import validateOptions from 'schema-utils';
 // type only dependency
 // eslint-disable-next-line node/no-extraneous-import

--- a/src/ForkTsCheckerWebpackPluginConfiguration.ts
+++ b/src/ForkTsCheckerWebpackPluginConfiguration.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { ForkTsCheckerWebpackPluginOptions } from './ForkTsCheckerWebpackPluginOptions';
 import { createIssueConfiguration, IssueConfiguration } from './issue/IssueConfiguration';
 import { createFormatterConfiguration, FormatterConfiguration } from './formatter';

--- a/src/eslint-reporter/EsLintReporterConfiguration.ts
+++ b/src/eslint-reporter/EsLintReporterConfiguration.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { isAbsolute, join } from 'path';
 import { EsLintReporterOptions } from './EsLintReporterOptions';
 import { CLIEngineOptions } from './types/eslint';

--- a/src/hooks/interceptDoneToGetWebpackDevServerTap.ts
+++ b/src/hooks/interceptDoneToGetWebpackDevServerTap.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 

--- a/src/hooks/tapAfterCompileToAddDependencies.ts
+++ b/src/hooks/tapAfterCompileToAddDependencies.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 

--- a/src/hooks/tapAfterCompileToGetIssues.ts
+++ b/src/hooks/tapAfterCompileToGetIssues.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';

--- a/src/hooks/tapAfterEnvironmentToPatchWatching.ts
+++ b/src/hooks/tapAfterEnvironmentToPatchWatching.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 import { InclusiveNodeWatchFileSystem } from '../watch/InclusiveNodeWatchFileSystem';
 import { CompilerWithWatchFileSystem } from '../watch/CompilerWithWatchFileSystem';

--- a/src/hooks/tapDoneToAsyncGetIssues.ts
+++ b/src/hooks/tapDoneToAsyncGetIssues.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import chalk from 'chalk';
 import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';

--- a/src/hooks/tapErrorToLogMessage.ts
+++ b/src/hooks/tapErrorToLogMessage.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
 import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
 import { RpcIpcMessagePortClosedError } from '../rpc/rpc-ipc/error/RpcIpcMessagePortClosedError';

--- a/src/hooks/tapStartToConnectAndRunReporter.ts
+++ b/src/hooks/tapStartToConnectAndRunReporter.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';

--- a/src/hooks/tapStopToDisconnectReporter.ts
+++ b/src/hooks/tapStopToDisconnectReporter.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 import { ReporterRpcClient } from '../reporter';
 

--- a/src/issue/IssueConfiguration.ts
+++ b/src/issue/IssueConfiguration.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { createIssuePredicateFromIssueMatch } from './IssueMatch';
 import {
   composeIssuePredicates,

--- a/src/logger/LoggerConfiguration.ts
+++ b/src/logger/LoggerConfiguration.ts
@@ -1,6 +1,6 @@
+import * as webpack from 'webpack';
 import LoggerOptions from './LoggerOptions';
 import Logger from './Logger';
-import webpack from 'webpack';
 import { createLogger } from './LoggerFactory';
 
 interface LoggerConfiguration {

--- a/src/logger/LoggerFactory.ts
+++ b/src/logger/LoggerFactory.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import Logger from './Logger';
 import { createWebpackInfrastructureLogger } from './WebpackInfrastructureLogger';
 import { createPartialLogger } from './PartialLogger';

--- a/src/logger/WebpackInfrastructureLogger.ts
+++ b/src/logger/WebpackInfrastructureLogger.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import Logger from './Logger';
 
 interface InfrastructureLoggerProvider {

--- a/src/typescript-reporter/TypeScriptReporterConfiguration.ts
+++ b/src/typescript-reporter/TypeScriptReporterConfiguration.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import path from 'path';
 import semver from 'semver';
 import { TypeScriptDiagnosticsOptions } from './TypeScriptDiagnosticsOptions';

--- a/src/watch/CompilerWithWatchFileSystem.ts
+++ b/src/watch/CompilerWithWatchFileSystem.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 import { WatchFileSystem } from './WatchFileSystem';
 
 interface CompilerWithWatchFileSystem<TWatchFileSystem extends WatchFileSystem = WatchFileSystem>


### PR DESCRIPTION
Otherwise curtain typescript configuration might complain during "tsc --noEmit" with the following error:

```
node_modules/fork-ts-checker-webpack-plugin/lib/ForkTsCheckerWebpackPlugin.d.ts:1:8 - error TS1259: Module '"/Users/apepper/repos/scrivito_js/js/node_modules/@types/webpack/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag

1 import webpack from 'webpack';
         ~~~~~~~

  node_modules/@types/webpack/index.d.ts:49:1
    49 export = webpack;
       ~~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.

node_modules/fork-ts-checker-webpack-plugin/lib/logger/LoggerFactory.d.ts:1:8 - error TS1259: Module '"/Users/apepper/repos/scrivito_js/js/node_modules/@types/webpack/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag

1 import webpack from 'webpack';
         ~~~~~~~

  node_modules/@types/webpack/index.d.ts:49:1
    49 export = webpack;
       ~~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.


Found 2 errors.
```