### PR TITLE
Make logging readable in Windows Command Prompt

### DIFF
--- a/src/hooks/tapDoneToAsyncGetIssues.ts
+++ b/src/hooks/tapDoneToAsyncGetIssues.ts
@@ -29,7 +29,7 @@ function tapDoneToAsyncGetIssues(
     try {
       if (await isPending(issuesPromise)) {
         hooks.waiting.call(stats.compilation);
-        configuration.logger.issues.log(chalk.blue('Issues checking in progress...'));
+        configuration.logger.issues.log(chalk.cyan('Issues checking in progress...'));
       } else {
         // wait 10ms to log issues after webpack stats
         await wait(10);


### PR DESCRIPTION
Logging text in blue is unfortunately not readable on the Windows Command Prompt with default color settings. Cyan, however, is.

Before: 
![](https://user-images.githubusercontent.com/171086/110010351-35b34800-7cec-11eb-840e-ee71b0d3a84a.png)

After:
![](https://user-images.githubusercontent.com/171086/110010409-42d03700-7cec-11eb-8689-2aef91e84cc8.png)
