### PR TITLE
feat: use simple program for single compilation (no watch)

### DIFF
--- a/src/hooks/tapStartToConnectAndRunReporter.ts
+++ b/src/hooks/tapStartToConnectAndRunReporter.ts
@@ -90,7 +90,7 @@ function tapStartToConnectAndRunReporter(
               await previousReport.close();
             }
 
-            const report = await reporter.getReport(change);
+            const report = await reporter.getReport(change, state.watching);
             resolve(report);
 
             report

--- a/src/reporter/AggregatedReporter.ts
+++ b/src/reporter/AggregatedReporter.ts
@@ -12,7 +12,7 @@ function createAggregatedReporter<TReporter extends Reporter>(reporter: TReporte
 
   const aggregatedReporter: TReporter = {
     ...reporter,
-    getReport: async (change) => {
+    getReport: async (change, watching) => {
       if (!pendingPromise) {
         let resolvePending: () => void;
         pendingPromise = new Promise((resolve) => {
@@ -23,7 +23,7 @@ function createAggregatedReporter<TReporter extends Reporter>(reporter: TReporte
         });
 
         return reporter
-          .getReport(change)
+          .getReport(change, watching)
           .then((report) => ({
             ...report,
             async close() {
@@ -45,7 +45,7 @@ function createAggregatedReporter<TReporter extends Reporter>(reporter: TReporte
             const change = aggregateFilesChanges(queuedChanges);
             queuedChanges = [];
 
-            return aggregatedReporter.getReport(change);
+            return aggregatedReporter.getReport(change, watching);
           } else {
             throw new OperationCanceledError('getReport canceled - new report requested.');
           }

--- a/src/reporter/Reporter.ts
+++ b/src/reporter/Reporter.ts
@@ -2,7 +2,7 @@ import { FilesChange } from './FilesChange';
 import { Report } from './Report';
 
 interface Reporter {
-  getReport(change: FilesChange): Promise<Report>;
+  getReport(change: FilesChange, watching: boolean): Promise<Report>;
 }
 
 export { Reporter };

--- a/src/reporter/reporter-rpc/ReporterRpcClient.ts
+++ b/src/reporter/reporter-rpc/ReporterRpcClient.ts
@@ -41,8 +41,8 @@ function createReporterRpcClient<TConfiguration extends object>(
         await channel.close();
       }
     },
-    getReport: async (change) => {
-      const reportId = await rpcClient.dispatchCall(getReport, change);
+    getReport: async (change, watching) => {
+      const reportId = await rpcClient.dispatchCall(getReport, { change, watching });
 
       return {
         getDependencies() {
@@ -65,8 +65,8 @@ function composeReporterRpcClients(clients: ReporterRpcClient[]): ReporterRpcCli
     connect: () => Promise.all(clients.map((client) => client.connect())).then(() => undefined),
     disconnect: () =>
       Promise.all(clients.map((client) => client.disconnect())).then(() => undefined),
-    getReport: (change: FilesChange) =>
-      Promise.all(clients.map((client) => client.getReport(change))).then((reports) => ({
+    getReport: (change: FilesChange, watching: boolean) =>
+      Promise.all(clients.map((client) => client.getReport(change, watching))).then((reports) => ({
         getDependencies: () =>
           Promise.all(reports.map((report) => report.getDependencies())).then((dependencies) =>
             dependencies.reduce(

--- a/src/reporter/reporter-rpc/ReporterRpcProcedure.ts
+++ b/src/reporter/reporter-rpc/ReporterRpcProcedure.ts
@@ -4,7 +4,7 @@ import { Issue } from '../../issue';
 import { Dependencies } from '../Dependencies';
 
 const configure: RpcProcedure<object, void> = 'configure';
-const getReport: RpcProcedure<FilesChange, void> = 'getReport';
+const getReport: RpcProcedure<{ change: FilesChange; watching: boolean }, void> = 'getReport';
 const getDependencies: RpcProcedure<void, Dependencies> = 'getDependencies';
 const getIssues: RpcProcedure<void, Issue[]> = 'getIssues';
 const closeReport: RpcProcedure<void, void> = 'closeReport';

--- a/src/reporter/reporter-rpc/ReporterRpcService.ts
+++ b/src/reporter/reporter-rpc/ReporterRpcService.ts
@@ -29,12 +29,12 @@ function registerReporterRpcService<TConfiguration extends object>(
 
       const reporter = reporterFactory(configuration);
 
-      rpcService.addCallHandler(getReport, async (change) => {
+      rpcService.addCallHandler(getReport, async ({ change, watching }) => {
         if (report) {
           throw new Error(`Close previous report before opening the next one.`);
         }
 
-        report = await reporter.getReport(change);
+        report = await reporter.getReport(change, watching);
       });
       rpcService.addCallHandler(getDependencies, () => {
         if (!report) {

--- a/src/typescript-reporter/reporter/ControlledCompilerHost.ts
+++ b/src/typescript-reporter/reporter/ControlledCompilerHost.ts
@@ -1,0 +1,34 @@
+import * as ts from 'typescript';
+import { TypeScriptHostExtension } from '../extension/TypeScriptExtension';
+import { ControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
+
+function createControlledCompilerHost(
+  typescript: typeof ts,
+  parsedCommandLine: ts.ParsedCommandLine,
+  system: ControlledTypeScriptSystem,
+  hostExtensions: TypeScriptHostExtension[] = []
+): ts.CompilerHost {
+  const baseCompilerHost = typescript.createCompilerHost(parsedCommandLine.options);
+
+  let controlledCompilerHost: ts.CompilerHost = {
+    ...baseCompilerHost,
+    fileExists: system.fileExists,
+    readFile: system.readFile,
+    directoryExists: system.directoryExists,
+    getDirectories: system.getDirectories,
+    realpath: system.realpath,
+  };
+
+  hostExtensions.forEach((hostExtension) => {
+    if (hostExtension.extendCompilerHost) {
+      controlledCompilerHost = hostExtension.extendCompilerHost(
+        controlledCompilerHost,
+        parsedCommandLine
+      );
+    }
+  });
+
+  return controlledCompilerHost;
+}
+
+export { createControlledCompilerHost };


### PR DESCRIPTION
Use simple `ts.Program` and `ts.CompilerHost` when running webpack in non-watch mode. This can improve check time in CI for some cases.

BREAKING CHANGE: 🧨 Use ts.Program and ts.CompilerHost for single compilation by default

✅ Closes: #572