### PR TITLE
fix: invoke watcher in relevant .d.ts files

### DIFF
--- a/src/typescript-reporter/reporter/ControlledTypeScriptSystem.ts
+++ b/src/typescript-reporter/reporter/ControlledTypeScriptSystem.ts
@@ -85,6 +85,11 @@ function createControlledTypeScriptSystem(
 
   function invokeFileWatchers(path: string, event: ts.FileWatcherEventKind) {
     const normalizedPath = realFileSystem.normalizePath(path);
+    if (normalizedPath.endsWith('.js')) {
+      // trigger relevant .d.ts file watcher - handles the case, when we have webpack watcher
+      // that points to a symlinked package
+      invokeFileWatchers(normalizedPath.slice(0, -3) + '.d.ts', event);
+    }
 
     const fileWatcherCallbacks = fileWatcherCallbacksMap.get(normalizedPath);
     if (fileWatcherCallbacks) {


### PR DESCRIPTION
When webpack watches symlinked packages, it watches only for .js files.
TypeScript, on the other hand, watches only for .d.ts files. To handle this case, we trigger a .d.ts watcher for every .js file.

✅ Closes: #593