### PR TITLE
fix: do not emit buildinfo file if outfile is specified

### DIFF
--- a/src/typescript-reporter/reporter/TypeScriptReporter.ts
+++ b/src/typescript-reporter/reporter/TypeScriptReporter.ts
@@ -100,7 +100,8 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
     if (
       configuration.mode !== 'readonly' &&
       parsedConfiguration &&
-      parsedConfiguration.options.incremental
+      parsedConfiguration.options.incremental &&
+      !parsedConfiguration.options.outFile
     ) {
       const program = builderProgram.getProgram();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
In newer TypeScript versions there is an assert expression which throws
an error if outFile is specified in the project configuration

✅ Closes: #608