### PR TITLE
fix: use memfs for ts artifacts to prevent mtime conflict

### DIFF
--- a/src/ForkTsCheckerWebpackPluginState.ts
+++ b/src/ForkTsCheckerWebpackPluginState.ts
@@ -1,12 +1,12 @@
 import { Tap } from 'tapable';
-import { Dependencies, Report } from './reporter';
+import { FilesMatch, Report } from './reporter';
 import { Issue } from './issue';
 
 interface ForkTsCheckerWebpackPluginState {
   reportPromise: Promise<Report | undefined>;
   issuesPromise: Promise<Issue[] | undefined>;
-  dependenciesPromise: Promise<Dependencies | undefined>;
-  lastDependencies: Dependencies | undefined;
+  dependenciesPromise: Promise<FilesMatch | undefined>;
+  lastDependencies: FilesMatch | undefined;
   watching: boolean;
   initialized: boolean;
   webpackDevServerDoneTap: Tap | undefined;

--- a/src/hooks/tapStartToConnectAndRunReporter.ts
+++ b/src/hooks/tapStartToConnectAndRunReporter.ts
@@ -2,7 +2,7 @@ import webpack from 'webpack';
 import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
 import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
-import { Dependencies, FilesChange, getFilesChange, ReporterRpcClient } from '../reporter';
+import { FilesMatch, FilesChange, getFilesChange, ReporterRpcClient } from '../reporter';
 import { OperationCanceledError } from '../error/OperationCanceledError';
 import { tapDoneToAsyncGetIssues } from './tapDoneToAsyncGetIssues';
 import { tapAfterCompileToGetIssues } from './tapAfterCompileToGetIssues';
@@ -63,7 +63,7 @@ function tapStartToConnectAndRunReporter(
       configuration.logger.infrastructure.info('Calling reporter service for single check.');
     }
 
-    let resolveDependencies: (dependencies: Dependencies | undefined) => void;
+    let resolveDependencies: (dependencies: FilesMatch | undefined) => void;
     let rejectedDependencies: (error: Error) => void;
     let resolveIssues: (issues: Issue[] | undefined) => void;
     let rejectIssues: (error: Error) => void;

--- a/src/reporter/FilesMatch.ts
+++ b/src/reporter/FilesMatch.ts
@@ -1,7 +1,7 @@
-interface Dependencies {
+interface FilesMatch {
   files: string[];
   dirs: string[];
   extensions: string[];
 }
 
-export { Dependencies };
+export { FilesMatch };

--- a/src/reporter/Report.ts
+++ b/src/reporter/Report.ts
@@ -1,8 +1,8 @@
-import { Dependencies } from './Dependencies';
+import { FilesMatch } from './FilesMatch';
 import { Issue } from '../issue';
 
 interface Report {
-  getDependencies(): Promise<Dependencies>;
+  getDependencies(): Promise<FilesMatch>;
   getIssues(): Promise<Issue[]>;
   close(): Promise<void>;
 }

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -3,7 +3,7 @@ export * from './Reporter';
 export * from './AggregatedReporter';
 
 export * from './FilesChange';
-export * from './Dependencies';
+export * from './FilesMatch';
 
 export * from './reporter-rpc/ReporterRpcClient';
 export * from './reporter-rpc/ReporterRpcService';

--- a/src/reporter/reporter-rpc/ReporterRpcProcedure.ts
+++ b/src/reporter/reporter-rpc/ReporterRpcProcedure.ts
@@ -1,11 +1,11 @@
 import { RpcProcedure } from '../../rpc';
 import { FilesChange } from '../FilesChange';
 import { Issue } from '../../issue';
-import { Dependencies } from '../Dependencies';
+import { FilesMatch } from '../FilesMatch';
 
 const configure: RpcProcedure<object, void> = 'configure';
 const getReport: RpcProcedure<FilesChange, void> = 'getReport';
-const getDependencies: RpcProcedure<void, Dependencies> = 'getDependencies';
+const getDependencies: RpcProcedure<void, FilesMatch> = 'getDependencies';
 const getIssues: RpcProcedure<void, Issue[]> = 'getIssues';
 const closeReport: RpcProcedure<void, void> = 'closeReport';
 

--- a/src/typescript-reporter/extension/TypeScriptEmbeddedExtension.ts
+++ b/src/typescript-reporter/extension/TypeScriptEmbeddedExtension.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 import { extname } from 'path';
 import { TypeScriptExtension } from './TypeScriptExtension';
 import { Issue } from '../../issue';
-import { Dependencies } from '../../reporter';
+import { FilesMatch } from '../../reporter';
 
 interface TypeScriptEmbeddedSource {
   sourceText: string;
@@ -168,7 +168,7 @@ function createTypeScriptEmbeddedExtension({
         },
       };
     },
-    extendDependencies(dependencies: Dependencies) {
+    extendDependencies(dependencies: FilesMatch) {
       return {
         ...dependencies,
         files: dependencies.files.map((fileName) => {

--- a/src/typescript-reporter/extension/TypeScriptExtension.ts
+++ b/src/typescript-reporter/extension/TypeScriptExtension.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import { Issue } from '../../issue';
-import { Dependencies } from '../../reporter';
+import { FilesMatch } from '../../reporter';
 
 interface TypeScriptHostExtension {
   extendWatchSolutionBuilderHost?<
@@ -26,7 +26,7 @@ interface TypeScriptHostExtension {
 
 interface TypeScriptReporterExtension {
   extendIssues?(issues: Issue[]): Issue[];
-  extendDependencies?(dependencies: Dependencies): Dependencies;
+  extendDependencies?(dependencies: FilesMatch): FilesMatch;
 }
 
 interface TypeScriptExtension extends TypeScriptHostExtension, TypeScriptReporterExtension {}

--- a/src/typescript-reporter/file-system/MemFileSystem.ts
+++ b/src/typescript-reporter/file-system/MemFileSystem.ts
@@ -1,0 +1,99 @@
+import { dirname } from 'path';
+import { fs as mem } from 'memfs';
+import { FileSystem } from './FileSystem';
+// eslint-disable-next-line node/no-unsupported-features/node-builtins
+import { Dirent, Stats } from 'fs';
+
+/**
+ * It's an implementation of FileSystem interface which reads and writes to the in-memory file system.
+ *
+ * @param realFileSystem
+ */
+function createMemFileSystem(realFileSystem: FileSystem): FileSystem {
+  function exists(path: string): boolean {
+    return mem.existsSync(realFileSystem.normalizePath(path));
+  }
+
+  function readStats(path: string): Stats | undefined {
+    return exists(path) ? mem.statSync(realFileSystem.normalizePath(path)) : undefined;
+  }
+
+  function readFile(path: string, encoding?: string): string | undefined {
+    const stats = readStats(path);
+
+    if (stats && stats.isFile()) {
+      return mem
+        .readFileSync(realFileSystem.normalizePath(path), { encoding: encoding as BufferEncoding })
+        .toString();
+    }
+  }
+
+  function readDir(path: string): Dirent[] {
+    const stats = readStats(path);
+
+    if (stats && stats.isDirectory()) {
+      return mem.readdirSync(realFileSystem.normalizePath(path), {
+        withFileTypes: true,
+      }) as Dirent[];
+    }
+
+    return [];
+  }
+
+  function createDir(path: string) {
+    mem.mkdirSync(realFileSystem.normalizePath(path), { recursive: true });
+  }
+
+  function writeFile(path: string, data: string) {
+    if (!exists(dirname(path))) {
+      createDir(dirname(path));
+    }
+
+    mem.writeFileSync(realFileSystem.normalizePath(path), data);
+  }
+
+  function deleteFile(path: string) {
+    if (exists(path)) {
+      mem.unlinkSync(realFileSystem.normalizePath(path));
+    }
+  }
+
+  function updateTimes(path: string, atime: Date, mtime: Date) {
+    if (exists(path)) {
+      mem.utimesSync(realFileSystem.normalizePath(path), atime, mtime);
+    }
+  }
+
+  return {
+    ...realFileSystem,
+    exists(path: string) {
+      return exists(realFileSystem.realPath(path));
+    },
+    readFile(path: string, encoding?: string) {
+      return readFile(realFileSystem.realPath(path), encoding);
+    },
+    readDir(path: string) {
+      return readDir(realFileSystem.realPath(path));
+    },
+    readStats(path: string) {
+      return readStats(realFileSystem.realPath(path));
+    },
+    writeFile(path: string, data: string) {
+      writeFile(realFileSystem.realPath(path), data);
+    },
+    deleteFile(path: string) {
+      deleteFile(realFileSystem.realPath(path));
+    },
+    createDir(path: string) {
+      createDir(realFileSystem.realPath(path));
+    },
+    updateTimes(path: string, atime: Date, mtime: Date) {
+      updateTimes(realFileSystem.realPath(path), atime, mtime);
+    },
+    clearCache() {
+      realFileSystem.clearCache();
+    },
+  };
+}
+
+export { createMemFileSystem };

--- a/src/typescript-reporter/reporter/TypeScriptConfigurationParser.ts
+++ b/src/typescript-reporter/reporter/TypeScriptConfigurationParser.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
-import { normalize, dirname } from 'path';
+import { normalize, dirname, basename, resolve, relative } from 'path';
 import { TypeScriptConfigurationOverwrite } from '../TypeScriptConfigurationOverwrite';
-import { Dependencies } from '../../reporter';
+import { FilesMatch } from '../../reporter';
 
 function parseTypeScriptConfiguration(
   typescript: typeof ts,
@@ -43,43 +43,39 @@ function parseTypeScriptConfiguration(
 function getDependenciesFromTypeScriptConfiguration(
   typescript: typeof ts,
   parsedConfiguration: ts.ParsedCommandLine,
-  configFileContext: string,
   parseConfigFileHost: ts.ParseConfigFileHost,
   processedConfigFiles: string[] = []
-): Dependencies {
+): FilesMatch {
   const files = new Set<string>(parsedConfiguration.fileNames);
   if (typeof parsedConfiguration.options.configFilePath === 'string') {
     files.add(parsedConfiguration.options.configFilePath);
   }
   const dirs = new Set(Object.keys(parsedConfiguration.wildcardDirectories || {}));
 
-  if (parsedConfiguration.projectReferences) {
-    parsedConfiguration.projectReferences.forEach((projectReference) => {
-      const configFile = typescript.resolveProjectReferencePath(projectReference);
-      if (processedConfigFiles.includes(configFile)) {
-        // handle circular dependencies
-        return;
-      }
-      const parsedConfiguration = parseTypeScriptConfiguration(
-        typescript,
-        configFile,
-        dirname(configFile),
-        {},
-        parseConfigFileHost
-      );
-      const childDependencies = getDependenciesFromTypeScriptConfiguration(
-        typescript,
-        parsedConfiguration,
-        dirname(configFile),
-        parseConfigFileHost,
-        [...processedConfigFiles, configFile]
-      );
-      childDependencies.files.forEach((file) => {
-        files.add(file);
-      });
-      childDependencies.dirs.forEach((dir) => {
-        dirs.add(dir);
-      });
+  for (const projectReference of parsedConfiguration.projectReferences || []) {
+    const configFile = typescript.resolveProjectReferencePath(projectReference);
+    if (processedConfigFiles.includes(configFile)) {
+      // handle circular dependencies
+      continue;
+    }
+    const parsedConfiguration = parseTypeScriptConfiguration(
+      typescript,
+      configFile,
+      dirname(configFile),
+      {},
+      parseConfigFileHost
+    );
+    const childDependencies = getDependenciesFromTypeScriptConfiguration(
+      typescript,
+      parsedConfiguration,
+      parseConfigFileHost,
+      [...processedConfigFiles, configFile]
+    );
+    childDependencies.files.forEach((file) => {
+      files.add(file);
+    });
+    childDependencies.dirs.forEach((dir) => {
+      dirs.add(dir);
     });
   }
 
@@ -98,4 +94,116 @@ function getDependenciesFromTypeScriptConfiguration(
   };
 }
 
-export { parseTypeScriptConfiguration, getDependenciesFromTypeScriptConfiguration };
+export function isIncrementalCompilation(options: ts.CompilerOptions) {
+  return Boolean((options.incremental || options.composite) && !options.outFile);
+}
+
+function removeJsonExtension(path: string) {
+  if (path.endsWith('.json')) {
+    return path.slice(0, -'.json'.length);
+  } else {
+    return path;
+  }
+}
+
+function getTsBuildInfoEmitOutputFilePath(options: ts.CompilerOptions) {
+  if (typeof ts.getTsBuildInfoEmitOutputFilePath === 'function') {
+    // old TypeScript version doesn't provides this method
+    return ts.getTsBuildInfoEmitOutputFilePath(options);
+  }
+
+  // based on the implementation from typescript
+  const configFile = options.configFilePath as string;
+  if (!isIncrementalCompilation(options)) {
+    return undefined;
+  }
+  if (options.tsBuildInfoFile) {
+    return options.tsBuildInfoFile;
+  }
+  const outPath = options.outFile || options.out;
+  let buildInfoExtensionLess;
+  if (outPath) {
+    buildInfoExtensionLess = removeJsonExtension(outPath);
+  } else {
+    if (!configFile) {
+      return undefined;
+    }
+    const configFileExtensionLess = removeJsonExtension(configFile);
+    buildInfoExtensionLess = options.outDir
+      ? options.rootDir
+        ? resolve(options.outDir, relative(options.rootDir, configFileExtensionLess))
+        : resolve(options.outDir, basename(configFileExtensionLess))
+      : configFileExtensionLess;
+  }
+  return buildInfoExtensionLess + '.tsbuildinfo';
+}
+
+function getArtifactsFromTypeScriptConfiguration(
+  typescript: typeof ts,
+  parsedConfiguration: ts.ParsedCommandLine,
+  configFileContext: string,
+  parseConfigFileHost: ts.ParseConfigFileHost,
+  processedConfigFiles: string[] = []
+): FilesMatch {
+  const files = new Set<string>();
+  const dirs = new Set<string>();
+  if (parsedConfiguration.fileNames.length > 0) {
+    if (parsedConfiguration.options.outFile) {
+      files.add(resolve(configFileContext, parsedConfiguration.options.outFile));
+    }
+    const tsBuildInfoPath = getTsBuildInfoEmitOutputFilePath(parsedConfiguration.options);
+    if (tsBuildInfoPath) {
+      files.add(resolve(configFileContext, tsBuildInfoPath));
+    }
+
+    if (parsedConfiguration.options.outDir) {
+      dirs.add(resolve(configFileContext, parsedConfiguration.options.outDir));
+    }
+  }
+
+  for (const projectReference of parsedConfiguration.projectReferences || []) {
+    const configFile = typescript.resolveProjectReferencePath(projectReference);
+    if (processedConfigFiles.includes(configFile)) {
+      // handle circular dependencies
+      continue;
+    }
+    const parsedConfiguration = parseTypeScriptConfiguration(
+      typescript,
+      configFile,
+      dirname(configFile),
+      {},
+      parseConfigFileHost
+    );
+    const childArtifacts = getArtifactsFromTypeScriptConfiguration(
+      typescript,
+      parsedConfiguration,
+      configFileContext,
+      parseConfigFileHost,
+      [...processedConfigFiles, configFile]
+    );
+    childArtifacts.files.forEach((file) => {
+      files.add(file);
+    });
+    childArtifacts.dirs.forEach((dir) => {
+      dirs.add(dir);
+    });
+  }
+
+  const extensions = [
+    typescript.Extension.Dts,
+    typescript.Extension.Js,
+    typescript.Extension.TsBuildInfo,
+  ];
+
+  return {
+    files: Array.from(files).map((file) => normalize(file)),
+    dirs: Array.from(dirs).map((dir) => normalize(dir)),
+    extensions,
+  };
+}
+
+export {
+  parseTypeScriptConfiguration,
+  getDependenciesFromTypeScriptConfiguration,
+  getArtifactsFromTypeScriptConfiguration,
+};


### PR DESCRIPTION
When ts-loader uses project references mode, it writes down .js and .d.ts files. If it does it faster than the plugin, the typescript instance in the plugin is confused and doesn't work properly. To fix that, let's use memfs for dirs and files that are detected as project artifacts.

Related: #611