### PR TITLE
feat: use separate workers for dependencies and issues

### DIFF
--- a/src/ForkTsCheckerWebpackPluginState.ts
+++ b/src/ForkTsCheckerWebpackPluginState.ts
@@ -3,7 +3,8 @@ import { FilesMatch, Report } from './reporter';
 import { Issue } from './issue';
 
 interface ForkTsCheckerWebpackPluginState {
-  reportPromise: Promise<Report | undefined>;
+  issuesReportPromise: Promise<Report | undefined>;
+  dependenciesReportPromise: Promise<Report | undefined>;
   issuesPromise: Promise<Issue[] | undefined>;
   dependenciesPromise: Promise<FilesMatch | undefined>;
   lastDependencies: FilesMatch | undefined;
@@ -14,7 +15,8 @@ interface ForkTsCheckerWebpackPluginState {
 
 function createForkTsCheckerWebpackPluginState(): ForkTsCheckerWebpackPluginState {
   return {
-    reportPromise: Promise.resolve(undefined),
+    issuesReportPromise: Promise.resolve(undefined),
+    dependenciesReportPromise: Promise.resolve(undefined),
     issuesPromise: Promise.resolve(undefined),
     dependenciesPromise: Promise.resolve(undefined),
     lastDependencies: undefined,

--- a/src/hooks/tapDoneToAsyncGetIssues.ts
+++ b/src/hooks/tapDoneToAsyncGetIssues.ts
@@ -22,7 +22,7 @@ function tapDoneToAsyncGetIssues(
       return;
     }
 
-    const reportPromise = state.reportPromise;
+    const reportPromise = state.issuesReportPromise;
     const issuesPromise = state.issuesPromise;
     let issues: Issue[] | undefined;
 
@@ -46,7 +46,7 @@ function tapDoneToAsyncGetIssues(
       return;
     }
 
-    if (reportPromise !== state.reportPromise) {
+    if (reportPromise !== state.issuesReportPromise) {
       // there is a newer report - ignore this one
       return;
     }

--- a/src/hooks/tapStartToConnectAndRunReporter.ts
+++ b/src/hooks/tapStartToConnectAndRunReporter.ts
@@ -12,7 +12,8 @@ import { ForkTsCheckerWebpackPlugin } from '../ForkTsCheckerWebpackPlugin';
 
 function tapStartToConnectAndRunReporter(
   compiler: webpack.Compiler,
-  reporter: ReporterRpcClient,
+  issuesReporter: ReporterRpcClient,
+  dependenciesReporter: ReporterRpcClient,
   configuration: ForkTsCheckerWebpackPluginConfiguration,
   state: ForkTsCheckerWebpackPluginState
 ) {
@@ -64,43 +65,70 @@ function tapStartToConnectAndRunReporter(
     }
 
     let resolveDependencies: (dependencies: FilesMatch | undefined) => void;
-    let rejectedDependencies: (error: Error) => void;
+    let rejectDependencies: (error: Error) => void;
     let resolveIssues: (issues: Issue[] | undefined) => void;
     let rejectIssues: (error: Error) => void;
 
     state.dependenciesPromise = new Promise((resolve, reject) => {
       resolveDependencies = resolve;
-      rejectedDependencies = reject;
+      rejectDependencies = reject;
     });
     state.issuesPromise = new Promise((resolve, reject) => {
       resolveIssues = resolve;
       rejectIssues = reject;
     });
-    const previousReportPromise = state.reportPromise;
-    state.reportPromise = ForkTsCheckerWebpackPlugin.pool.submit(
+    const previousIssuesReportPromise = state.issuesReportPromise;
+    const previousDependenciesReportPromise = state.dependenciesReportPromise;
+
+    change = await hooks.start.promise(change, compilation);
+
+    state.issuesReportPromise = ForkTsCheckerWebpackPlugin.issuesPool.submit(
       (done) =>
         new Promise(async (resolve) => {
-          change = await hooks.start.promise(change, compilation);
-
           try {
-            await reporter.connect();
+            await issuesReporter.connect();
 
-            const previousReport = await previousReportPromise;
+            const previousReport = await previousIssuesReportPromise;
             if (previousReport) {
               await previousReport.close();
             }
 
-            const report = await reporter.getReport(change);
+            const report = await issuesReporter.getReport(change);
+            resolve(report);
+
+            report.getIssues().then(resolveIssues).catch(rejectIssues).finally(done);
+          } catch (error) {
+            if (error instanceof OperationCanceledError) {
+              hooks.canceled.call(compilation);
+            } else {
+              hooks.error.call(error, compilation);
+            }
+
+            resolve(undefined);
+            resolveIssues(undefined);
+            done();
+          }
+        })
+    );
+    state.dependenciesReportPromise = ForkTsCheckerWebpackPlugin.dependenciesPool.submit(
+      (done) =>
+        new Promise(async (resolve) => {
+          try {
+            await dependenciesReporter.connect();
+
+            const previousReport = await previousDependenciesReportPromise;
+            if (previousReport) {
+              await previousReport.close();
+            }
+
+            const report = await dependenciesReporter.getReport(change);
             resolve(report);
 
             report
               .getDependencies()
               .then(resolveDependencies)
-              .catch(rejectedDependencies)
-              .finally(() => {
-                // get issues after dependencies are resolved as it can be blocking
-                report.getIssues().then(resolveIssues).catch(rejectIssues).finally(done);
-              });
+              .catch(rejectDependencies)
+              .finally(done);
           } catch (error) {
             if (error instanceof OperationCanceledError) {
               hooks.canceled.call(compilation);
@@ -110,7 +138,6 @@ function tapStartToConnectAndRunReporter(
 
             resolve(undefined);
             resolveDependencies(undefined);
-            resolveIssues(undefined);
             done();
           }
         })

--- a/src/hooks/tapStopToDisconnectReporter.ts
+++ b/src/hooks/tapStopToDisconnectReporter.ts
@@ -4,22 +4,25 @@ import { ReporterRpcClient } from '../reporter';
 
 function tapStopToDisconnectReporter(
   compiler: webpack.Compiler,
-  reporter: ReporterRpcClient,
+  issuesReporter: ReporterRpcClient,
+  dependenciesReporter: ReporterRpcClient,
   state: ForkTsCheckerWebpackPluginState
 ) {
   compiler.hooks.watchClose.tap('ForkTsCheckerWebpackPlugin', () => {
-    reporter.disconnect();
+    issuesReporter.disconnect();
+    dependenciesReporter.disconnect();
   });
 
   compiler.hooks.done.tap('ForkTsCheckerWebpackPlugin', async () => {
     if (!state.watching) {
-      await reporter.disconnect();
+      await Promise.all([issuesReporter.disconnect(), dependenciesReporter.disconnect()]);
     }
   });
 
   compiler.hooks.failed.tap('ForkTsCheckerWebpackPlugin', () => {
     if (!state.watching) {
-      reporter.disconnect();
+      issuesReporter.disconnect();
+      dependenciesReporter.disconnect();
     }
   });
 }


### PR DESCRIPTION
In order to not block the next iteration on the `getDependencies` call, we use separate worker for dependencies calculations (so `getIssues` from previous compilation will not block the next `getDependencies` call)

✅ Closes: #612, #634

It's not a perfect implementation, but the one that requires minimum code change. I will improve this in the next major version.