### PR TITLE
Fix project references bug

### DIFF
--- a/src/typescript-reporter/reporter/TypeScriptReporter.ts
+++ b/src/typescript-reporter/reporter/TypeScriptReporter.ts
@@ -266,16 +266,15 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
         diagnosticsPerProject.clear();
         configurationChanged = true;
       } else {
-        const previousParsedConfiguration = parsedConfiguration;
+        const previousDependencies = dependencies;
         [parsedConfiguration, parseConfigurationDiagnostics] = parseConfiguration();
+        dependencies = getDependencies();
 
         if (
-          previousParsedConfiguration &&
-          JSON.stringify(previousParsedConfiguration.fileNames) !==
-            JSON.stringify(parsedConfiguration.fileNames)
+          previousDependencies &&
+          JSON.stringify(previousDependencies) !== JSON.stringify(dependencies)
         ) {
-          // root files changed - we need to recompute dependencies and artifacts
-          dependencies = getDependencies();
+          // dependencies changed - we need to recompute artifacts
           artifacts = getArtifacts();
           shouldUpdateRootFiles = true;
         }

--- a/test/e2e/TypeScriptGenerateTrace.spec.ts
+++ b/test/e2e/TypeScriptGenerateTrace.spec.ts
@@ -73,7 +73,7 @@ describe('TypeScript Generate Trace', () => {
 
     // update sandbox to generate trace
     await sandbox.patch(
-      'tsconfig.json',
+      'tsconfig.base.json',
       '    "rootDir": "./packages"',
       ['    "rootDir": "./packages",', '    "generateTrace": "./traces"'].join('\n')
     );

--- a/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
+++ b/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
@@ -105,6 +105,10 @@ describe('TypeScript SolutionBuilder API', () => {
     await driver.waitForNoErrors();
 
     await sandbox.write('packages/client/src/nested/additional.ts', 'export const x = 10;');
+
+    // this compilation should be successful
+    await driver.waitForNoErrors();
+
     await sandbox.patch(
       'packages/client/src/index.ts',
       'import { intersect, subtract } from "@project-references-fixture/shared";',
@@ -125,31 +129,31 @@ describe('TypeScript SolutionBuilder API', () => {
         break;
 
       case 'write-tsbuildinfo':
-        expect(await sandbox.exists('packages/shared/tsconfig.tsbuildinfo')).toEqual(true);
-        expect(await sandbox.exists('packages/client/tsconfig.tsbuildinfo')).toEqual(true);
-        expect(await sandbox.exists('packages/shared/lib')).toEqual(false);
-        expect(await sandbox.exists('packages/client/lib')).toEqual(false);
+        expect(await sandbox.exists('packages/shared/lib/tsconfig.tsbuildinfo')).toEqual(true);
+        expect(await sandbox.exists('packages/client/lib/tsconfig.tsbuildinfo')).toEqual(true);
+        expect(await sandbox.exists('packages/shared/lib')).toEqual(true);
+        expect(await sandbox.exists('packages/client/lib')).toEqual(true);
+        expect(await sandbox.exists('packages/shared/lib/index.js')).toEqual(false);
+        expect(await sandbox.exists('packages/client/lib/index.js')).toEqual(false);
 
-        expect(await sandbox.read('packages/shared/tsconfig.tsbuildinfo')).not.toEqual('');
-        expect(await sandbox.read('packages/client/tsconfig.tsbuildinfo')).not.toEqual('');
+        expect(await sandbox.read('packages/shared/lib/tsconfig.tsbuildinfo')).not.toEqual('');
+        expect(await sandbox.read('packages/client/lib/tsconfig.tsbuildinfo')).not.toEqual('');
 
-        await sandbox.remove('packages/shared/tsconfig.tsbuildinfo');
-        await sandbox.remove('packages/client/tsconfig.tsbuildinfo');
+        await sandbox.remove('packages/shared/lib');
+        await sandbox.remove('packages/client/lib');
         break;
 
       case 'write-references':
-        expect(await sandbox.exists('packages/shared/tsconfig.tsbuildinfo')).toEqual(true);
-        expect(await sandbox.exists('packages/client/tsconfig.tsbuildinfo')).toEqual(true);
+        expect(await sandbox.exists('packages/shared/lib/tsconfig.tsbuildinfo')).toEqual(true);
+        expect(await sandbox.exists('packages/client/lib/tsconfig.tsbuildinfo')).toEqual(true);
         expect(await sandbox.exists('packages/shared/lib')).toEqual(true);
         expect(await sandbox.exists('packages/client/lib')).toEqual(true);
         expect(await sandbox.exists('packages/shared/lib/index.js')).toEqual(true);
         expect(await sandbox.exists('packages/client/lib/index.js')).toEqual(true);
 
-        expect(await sandbox.read('packages/shared/tsconfig.tsbuildinfo')).not.toEqual('');
-        expect(await sandbox.read('packages/client/tsconfig.tsbuildinfo')).not.toEqual('');
+        expect(await sandbox.read('packages/shared/lib/tsconfig.tsbuildinfo')).not.toEqual('');
+        expect(await sandbox.read('packages/client/lib/tsconfig.tsbuildinfo')).not.toEqual('');
 
-        await sandbox.remove('packages/shared/tsconfig.tsbuildinfo');
-        await sandbox.remove('packages/client/tsconfig.tsbuildinfo');
         await sandbox.remove('packages/shared/lib');
         await sandbox.remove('packages/client/lib');
         break;

--- a/test/e2e/fixtures/environment/typescript-monorepo.fixture
+++ b/test/e2e/fixtures/environment/typescript-monorepo.fixture
@@ -23,7 +23,7 @@
   }
 }
 
-/// tsconfig.json
+/// tsconfig.base.json
 {
   "compilerOptions": {
     "target": "es5",
@@ -42,7 +42,12 @@
     "declarationMap": true,
     "sourceMap": true,
     "rootDir": "./packages"
-  },
+  }
+}
+
+/// tsconfig.json
+{
+  "extends": "./tsconfig.base.json",
   "files": [],
   "references": [
     { "path": "./packages/shared" },

--- a/test/e2e/fixtures/implementation/typescript-monorepo.fixture
+++ b/test/e2e/fixtures/implementation/typescript-monorepo.fixture
@@ -12,15 +12,15 @@
 
 /// packages/shared/tsconfig.json
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
+    "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo",
     "sourceRoot": "./src",
     "baseUrl": "./src"
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "lib"]
+  "include": ["src"]
 }
 
 /// packages/shared/src/intersect.ts
@@ -63,16 +63,16 @@ export {
 
 /// packages/client/tsconfig.json
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
+    "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo",
     "sourceRoot": "./src",
     "baseUrl": "./src"
   },
   "references": [{ "path": "../shared" }],
-  "include": ["src"],
-  "exclude": ["node_modules", "lib"]
+  "include": ["src"]
 }
 
 


### PR DESCRIPTION
This PR fixes 3 bugs that I found regarding project references:
 * condition `JSON.stringify(previousParsedConfiguration.fileNames) !== JSON.stringify(parsedConfiguration.fileNames)` didn't take into account project references. I changed it to always call `getDependencies()` (which takes project references into account) and compare dependencies to detect if list of files changed.
  * we were missing `realpath` method overwrite in ControlledTypeScriptSystem
  * in the situation, when there were already some files built in the real fs, controlled typescript system returned true for `fileExists` call on the initial run and false on subsequent runs. This was causing assertion in TypeScript to fail.
  
✅ Closes: #630
  