### PR TITLE
fix: make all peer dependencies optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,13 @@
     "eslint": {
       "optional": true
     },
+    "typescript": {
+      "optional": true
+    },
     "vue-template-compiler": {
+      "optional": true
+    },
+    "webpack": {
       "optional": true
     }
   },


### PR DESCRIPTION
This is a followup to https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/pull/507. I'm guessing CRA would want at least the `typescript` peerDependency to be optional and maybe `webpack` as well (although I'm not sure the reason for `webpack`). I could be mistaken, but I don't want the previous PR to cause any problems for CRA.