### PR TITLE
fix: support "setup" attribute in <script> tag in vue 3

### DIFF
--- a/src/typescript-reporter/extension/vue/TypeScriptVueExtension.ts
+++ b/src/typescript-reporter/extension/vue/TypeScriptVueExtension.ts
@@ -112,8 +112,8 @@ function createTypeScriptVueExtension(
     } else if (isVueTemplateCompilerV3(compiler)) {
       const parsed = compiler.parse(vueSourceText);
 
-      if (parsed.descriptor && parsed.descriptor.script) {
-        const scriptV3 = parsed.descriptor.script;
+      if (parsed.descriptor && (parsed.descriptor.script || parsed.descriptor.scriptSetup)) {
+        const scriptV3 = (parsed.descriptor.script || parsed.descriptor.scriptSetup)!;
 
         // map newer version of SFCScriptBlock to the generic one
         script = {

--- a/src/typescript-reporter/extension/vue/types/vue__compiler-sfc.ts
+++ b/src/typescript-reporter/extension/vue/types/vue__compiler-sfc.ts
@@ -23,6 +23,7 @@ interface SFCDescriptor {
   filename: string;
   template: SFCBlock | null;
   script: SFCBlock | null;
+  scriptSetup: SFCBlock | null;
   styles: SFCBlock[];
   customBlocks: SFCBlock[];
 }

--- a/test/e2e/fixtures/implementation/typescript-vue.fixture
+++ b/test/e2e/fixtures/implementation/typescript-vue.fixture
@@ -92,7 +92,7 @@ h1 {
   </p>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import User, { getUserName } from '@/model/User';
 
 export default {


### PR DESCRIPTION
In Vue 3, when <script> tag has "setup" attribute, SFC parser assignes script block to a separate field called "scriptSetup"

✅ Closes: #665