### PR TITLE
refactor: add eslint rules to enforce import order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,17 +1,42 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'import', 'prettier'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:node/recommended',
-    'prettier',
   ],
   settings: {
     node: {
       tryExtensions: ['.js', '.json', '.ts', '.d.ts'],
     },
+    'import/extensions': ['.js', '.json', '.ts', '.d.ts'],
+    'import/external-module-folders': ['node_modules', 'node_modules/@types'],
+    'import/parsers': {
+      '@typescript-eslint/parser': ['.ts'],
+    },
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.json', '.ts', '.d.ts'],
+      },
+    },
+  },
+  rules: {
+    '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }],
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index', 'object'],
+        'newlines-between': 'always',
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true,
+        },
+      },
+    ],
+    'import/no-cycle': ['error'],
+    'prettier/prettier': 'error',
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "tapable": "^2.0.0"
   },
   "peerDependencies": {
-    "webpack": "^5.11.0",
-    "typescript": ">3.6.0"
+    "typescript": ">3.6.0",
+    "webpack": "^5.11.0"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^13.1.0",
@@ -89,19 +89,20 @@
     "@types/node": "^16.4.13",
     "@types/rimraf": "^3.0.1",
     "@types/semver": "^7.3.8",
-    "@typescript-eslint/eslint-plugin": "^4.29.0",
-    "@typescript-eslint/parser": "^4.29.0",
+    "@typescript-eslint/eslint-plugin": "^5.1.0",
+    "@typescript-eslint/parser": "^5.1.0",
     "commitlint": "^13.1.0",
     "cross-env": "^7.0.3",
     "eslint": "^7.32.0",
-    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "git-cz": "^4.7.6",
     "husky": "^7.0.0",
     "jest": "^27.0.6",
     "jest-circus": "^27.0.6",
     "jest-environment-node": "^27.0.6",
+    "json-schema": "^0.3.0",
     "karton": "^0.4.1",
     "lint-staged": "^11.1.2",
     "mock-fs": "^5.0.0",

--- a/src/ForkTsCheckerWebpackPlugin.ts
+++ b/src/ForkTsCheckerWebpackPlugin.ts
@@ -1,24 +1,24 @@
-import webpack from 'webpack';
-import { validate } from 'schema-utils';
-// type only dependency
-// eslint-disable-next-line node/no-extraneous-import
-import type { JSONSchema7 } from 'json-schema';
 import { cosmiconfigSync } from 'cosmiconfig';
 import merge from 'deepmerge';
-import schema from './ForkTsCheckerWebpackPluginOptions.json';
-import { ForkTsCheckerWebpackPluginOptions } from './ForkTsCheckerWebpackPluginOptions';
+import type { JSONSchema7 } from 'json-schema';
+import { validate } from 'schema-utils';
+import type webpack from 'webpack';
+// type only dependency
+// eslint-disable-next-line node/no-extraneous-import
+
 import { createForkTsCheckerWebpackPluginConfiguration } from './ForkTsCheckerWebpackPluginConfiguration';
+import type { ForkTsCheckerWebpackPluginOptions } from './ForkTsCheckerWebpackPluginOptions';
+import schema from './ForkTsCheckerWebpackPluginOptions.json';
 import { createForkTsCheckerWebpackPluginState } from './ForkTsCheckerWebpackPluginState';
-import { assertTypeScriptSupport } from './typescript-reporter/TypeScriptSupport';
-import { createTypeScriptReporterRpcClient } from './typescript-reporter/reporter/TypeScriptReporterRpcClient';
+import { getForkTsCheckerWebpackPluginHooks } from './hooks/pluginHooks';
+import { dependenciesPool, issuesPool } from './hooks/pluginPools';
+import { tapAfterCompileToAddDependencies } from './hooks/tapAfterCompileToAddDependencies';
+import { tapAfterEnvironmentToPatchWatching } from './hooks/tapAfterEnvironmentToPatchWatching';
+import { tapErrorToLogMessage } from './hooks/tapErrorToLogMessage';
 import { tapStartToConnectAndRunReporter } from './hooks/tapStartToConnectAndRunReporter';
 import { tapStopToDisconnectReporter } from './hooks/tapStopToDisconnectReporter';
-import { tapAfterCompileToAddDependencies } from './hooks/tapAfterCompileToAddDependencies';
-import { tapErrorToLogMessage } from './hooks/tapErrorToLogMessage';
-import { getForkTsCheckerWebpackPluginHooks } from './hooks/pluginHooks';
-import { tapAfterEnvironmentToPatchWatching } from './hooks/tapAfterEnvironmentToPatchWatching';
-import { createPool, Pool } from './utils/async/pool';
-import os from 'os';
+import { createTypeScriptReporterRpcClient } from './typescript-reporter/reporter/TypeScriptReporterRpcClient';
+import { assertTypeScriptSupport } from './typescript-reporter/TypeScriptSupport';
 
 class ForkTsCheckerWebpackPlugin {
   /**
@@ -28,16 +28,13 @@ class ForkTsCheckerWebpackPlugin {
   /**
    * Default pools for the plugin concurrency limit
    */
-  static readonly issuesPool: Pool = createPool(Math.max(1, os.cpus().length));
-  static readonly dependenciesPool: Pool = createPool(Math.max(1, os.cpus().length));
+  static readonly issuesPool = issuesPool;
+  static readonly dependenciesPool = dependenciesPool;
 
   /**
    * @deprecated Use ForkTsCheckerWebpackPlugin.issuesPool instead
    */
-  static get pool(): Pool {
-    // for backward compatibility
-    return ForkTsCheckerWebpackPlugin.issuesPool;
-  }
+  static readonly pool = issuesPool;
 
   private readonly options: ForkTsCheckerWebpackPluginOptions;
 

--- a/src/ForkTsCheckerWebpackPluginConfiguration.ts
+++ b/src/ForkTsCheckerWebpackPluginConfiguration.ts
@@ -1,12 +1,14 @@
-import webpack from 'webpack';
-import { ForkTsCheckerWebpackPluginOptions } from './ForkTsCheckerWebpackPluginOptions';
-import { createIssueConfiguration, IssueConfiguration } from './issue/IssueConfiguration';
-import { createFormatterConfiguration, FormatterConfiguration } from './formatter';
-import {
-  createTypeScriptReporterConfiguration,
-  TypeScriptReporterConfiguration,
-} from './typescript-reporter/TypeScriptReporterConfiguration';
-import { createLoggerConfiguration, LoggerConfiguration } from './logger/LoggerConfiguration';
+import type webpack from 'webpack';
+
+import type { ForkTsCheckerWebpackPluginOptions } from './ForkTsCheckerWebpackPluginOptions';
+import type { FormatterConfiguration } from './formatter';
+import { createFormatterConfiguration } from './formatter';
+import type { IssueConfiguration } from './issue/IssueConfiguration';
+import { createIssueConfiguration } from './issue/IssueConfiguration';
+import type { LoggerConfiguration } from './logger/LoggerConfiguration';
+import { createLoggerConfiguration } from './logger/LoggerConfiguration';
+import type { TypeScriptReporterConfiguration } from './typescript-reporter/TypeScriptReporterConfiguration';
+import { createTypeScriptReporterConfiguration } from './typescript-reporter/TypeScriptReporterConfiguration';
 
 interface ForkTsCheckerWebpackPluginConfiguration {
   async: boolean;

--- a/src/ForkTsCheckerWebpackPluginOptions.ts
+++ b/src/ForkTsCheckerWebpackPluginOptions.ts
@@ -1,7 +1,7 @@
-import { TypeScriptReporterOptions } from './typescript-reporter/TypeScriptReporterOptions';
-import { IssueOptions } from './issue/IssueOptions';
-import { FormatterOptions } from './formatter';
-import LoggerOptions from './logger/LoggerOptions';
+import type { FormatterOptions } from './formatter';
+import type { IssueOptions } from './issue/IssueOptions';
+import type LoggerOptions from './logger/LoggerOptions';
+import type { TypeScriptReporterOptions } from './typescript-reporter/TypeScriptReporterOptions';
 
 interface ForkTsCheckerWebpackPluginOptions {
   async?: boolean;

--- a/src/ForkTsCheckerWebpackPluginState.ts
+++ b/src/ForkTsCheckerWebpackPluginState.ts
@@ -1,6 +1,7 @@
-import { FullTap } from 'tapable';
-import { FilesMatch, Report } from './reporter';
-import { Issue } from './issue';
+import type { FullTap } from 'tapable';
+
+import type { Issue } from './issue';
+import type { FilesMatch, Report } from './reporter';
 
 interface ForkTsCheckerWebpackPluginState {
   issuesReportPromise: Promise<Report | undefined>;

--- a/src/formatter/BasicFormatter.ts
+++ b/src/formatter/BasicFormatter.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
-import { Formatter } from './Formatter';
+
+import type { Formatter } from './Formatter';
 
 function createBasicFormatter(): Formatter {
   return function basicFormatter(issue) {

--- a/src/formatter/CodeFrameFormatter.ts
+++ b/src/formatter/CodeFrameFormatter.ts
@@ -1,8 +1,10 @@
 import os from 'os';
-import fs from 'fs-extra';
+
 import { codeFrameColumns } from '@babel/code-frame';
-import { Formatter } from './Formatter';
+import fs from 'fs-extra';
+
 import { createBasicFormatter } from './BasicFormatter';
+import type { Formatter } from './Formatter';
 import { BabelCodeFrameOptions } from './types/babel__code-frame';
 
 function createCodeFrameFormatter(options?: BabelCodeFrameOptions): Formatter {

--- a/src/formatter/Formatter.ts
+++ b/src/formatter/Formatter.ts
@@ -1,4 +1,4 @@
-import { Issue } from '../issue';
+import type { Issue } from '../issue';
 
 type Formatter = (issue: Issue) => string;
 

--- a/src/formatter/FormatterConfiguration.ts
+++ b/src/formatter/FormatterConfiguration.ts
@@ -1,7 +1,7 @@
-import { CodeframeFormatterOptions, FormatterOptions } from './FormatterOptions';
-import { Formatter } from './Formatter';
 import { createBasicFormatter } from './BasicFormatter';
 import { createCodeFrameFormatter } from './CodeFrameFormatter';
+import type { Formatter } from './Formatter';
+import type { CodeframeFormatterOptions, FormatterOptions } from './FormatterOptions';
 
 type FormatterConfiguration = Formatter;
 

--- a/src/formatter/FormatterOptions.ts
+++ b/src/formatter/FormatterOptions.ts
@@ -1,5 +1,5 @@
-import { Formatter } from './Formatter';
-import { BabelCodeFrameOptions } from './types/babel__code-frame';
+import type { Formatter } from './Formatter';
+import type { BabelCodeFrameOptions } from './types/babel__code-frame';
 
 type FormatterType = 'basic' | 'codeframe';
 

--- a/src/formatter/WebpackFormatter.ts
+++ b/src/formatter/WebpackFormatter.ts
@@ -1,8 +1,11 @@
 import os from 'os';
+
 import chalk from 'chalk';
-import { Formatter } from './Formatter';
+
 import { formatIssueLocation } from '../issue';
 import { relativeToContext } from '../utils/path/relativeToContext';
+
+import type { Formatter } from './Formatter';
 
 function createWebpackFormatter(formatter: Formatter): Formatter {
   // mimics webpack error formatter

--- a/src/hooks/interceptDoneToGetWebpackDevServerTap.ts
+++ b/src/hooks/interceptDoneToGetWebpackDevServerTap.ts
@@ -1,6 +1,7 @@
-import webpack from 'webpack';
-import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
-import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
+import type webpack from 'webpack';
+
+import type { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
+import type { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 
 function interceptDoneToGetWebpackDevServerTap(
   compiler: webpack.Compiler,

--- a/src/hooks/pluginHooks.ts
+++ b/src/hooks/pluginHooks.ts
@@ -1,7 +1,8 @@
-import * as webpack from 'webpack';
 import { SyncHook, SyncWaterfallHook, AsyncSeriesWaterfallHook } from 'tapable';
-import { FilesChange } from '../reporter';
-import { Issue } from '../issue';
+import type * as webpack from 'webpack';
+
+import type { Issue } from '../issue';
+import type { FilesChange } from '../reporter';
 
 const compilerHookMap = new WeakMap<
   webpack.Compiler | webpack.MultiCompiler,

--- a/src/hooks/pluginPools.ts
+++ b/src/hooks/pluginPools.ts
@@ -1,0 +1,9 @@
+import * as os from 'os';
+
+import type { Pool } from '../utils/async/pool';
+import { createPool } from '../utils/async/pool';
+
+const issuesPool: Pool = createPool(Math.max(1, os.cpus().length));
+const dependenciesPool: Pool = createPool(Math.max(1, os.cpus().length));
+
+export { issuesPool, dependenciesPool };

--- a/src/hooks/tapAfterCompileToAddDependencies.ts
+++ b/src/hooks/tapAfterCompileToAddDependencies.ts
@@ -1,6 +1,7 @@
-import webpack from 'webpack';
-import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
-import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
+import type webpack from 'webpack';
+
+import type { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
+import type { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 
 function tapAfterCompileToAddDependencies(
   compiler: webpack.Compiler,

--- a/src/hooks/tapAfterCompileToGetIssues.ts
+++ b/src/hooks/tapAfterCompileToGetIssues.ts
@@ -1,9 +1,11 @@
-import webpack from 'webpack';
-import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
-import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
-import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
+import type webpack from 'webpack';
+
+import type { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
+import type { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
+import type { Issue } from '../issue';
 import { IssueWebpackError } from '../issue/IssueWebpackError';
-import { Issue } from '../issue';
+
+import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
 
 function tapAfterCompileToGetIssues(
   compiler: webpack.Compiler,

--- a/src/hooks/tapAfterEnvironmentToPatchWatching.ts
+++ b/src/hooks/tapAfterEnvironmentToPatchWatching.ts
@@ -1,7 +1,8 @@
-import webpack from 'webpack';
-import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
+import type webpack from 'webpack';
+
+import type { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 import { InclusiveNodeWatchFileSystem } from '../watch/InclusiveNodeWatchFileSystem';
-import { WatchFileSystem } from '../watch/WatchFileSystem';
+import type { WatchFileSystem } from '../watch/WatchFileSystem';
 
 function tapAfterEnvironmentToPatchWatching(
   compiler: webpack.Compiler,

--- a/src/hooks/tapDoneToAsyncGetIssues.ts
+++ b/src/hooks/tapDoneToAsyncGetIssues.ts
@@ -1,13 +1,15 @@
-import webpack from 'webpack';
 import chalk from 'chalk';
-import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
-import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
-import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
+import type webpack from 'webpack';
+
+import type { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
+import type { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
 import { createWebpackFormatter } from '../formatter/WebpackFormatter';
-import { Issue } from '../issue';
+import type { Issue } from '../issue';
 import { IssueWebpackError } from '../issue/IssueWebpackError';
 import isPending from '../utils/async/isPending';
 import wait from '../utils/async/wait';
+
+import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
 
 function tapDoneToAsyncGetIssues(
   compiler: webpack.Compiler,

--- a/src/hooks/tapErrorToLogMessage.ts
+++ b/src/hooks/tapErrorToLogMessage.ts
@@ -1,8 +1,10 @@
-import webpack from 'webpack';
-import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
-import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
-import { RpcIpcMessagePortClosedError } from '../rpc/rpc-ipc/error/RpcIpcMessagePortClosedError';
 import chalk from 'chalk';
+import type webpack from 'webpack';
+
+import type { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
+import { RpcIpcMessagePortClosedError } from '../rpc/rpc-ipc/error/RpcIpcMessagePortClosedError';
+
+import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
 
 function tapErrorToLogMessage(
   compiler: webpack.Compiler,

--- a/src/hooks/tapStartToConnectAndRunReporter.ts
+++ b/src/hooks/tapStartToConnectAndRunReporter.ts
@@ -1,14 +1,17 @@
-import webpack from 'webpack';
-import { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
-import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
-import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
-import { FilesMatch, FilesChange, getFilesChange, ReporterRpcClient } from '../reporter';
+import type webpack from 'webpack';
+
 import { OperationCanceledError } from '../error/OperationCanceledError';
-import { tapDoneToAsyncGetIssues } from './tapDoneToAsyncGetIssues';
-import { tapAfterCompileToGetIssues } from './tapAfterCompileToGetIssues';
+import type { ForkTsCheckerWebpackPluginConfiguration } from '../ForkTsCheckerWebpackPluginConfiguration';
+import type { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
+import type { Issue } from '../issue';
+import type { FilesMatch, FilesChange, ReporterRpcClient } from '../reporter';
+import { getFilesChange } from '../reporter';
+
 import { interceptDoneToGetWebpackDevServerTap } from './interceptDoneToGetWebpackDevServerTap';
-import { Issue } from '../issue';
-import { ForkTsCheckerWebpackPlugin } from '../ForkTsCheckerWebpackPlugin';
+import { getForkTsCheckerWebpackPluginHooks } from './pluginHooks';
+import { dependenciesPool, issuesPool } from './pluginPools';
+import { tapAfterCompileToGetIssues } from './tapAfterCompileToGetIssues';
+import { tapDoneToAsyncGetIssues } from './tapDoneToAsyncGetIssues';
 
 function tapStartToConnectAndRunReporter(
   compiler: webpack.Compiler,
@@ -82,7 +85,7 @@ function tapStartToConnectAndRunReporter(
 
     change = await hooks.start.promise(change, compilation);
 
-    state.issuesReportPromise = ForkTsCheckerWebpackPlugin.issuesPool.submit(
+    state.issuesReportPromise = issuesPool.submit(
       (done) =>
         // eslint-disable-next-line no-async-promise-executor
         new Promise(async (resolve) => {
@@ -111,7 +114,7 @@ function tapStartToConnectAndRunReporter(
           }
         })
     );
-    state.dependenciesReportPromise = ForkTsCheckerWebpackPlugin.dependenciesPool.submit(
+    state.dependenciesReportPromise = dependenciesPool.submit(
       (done) =>
         // eslint-disable-next-line no-async-promise-executor
         new Promise(async (resolve) => {

--- a/src/hooks/tapStopToDisconnectReporter.ts
+++ b/src/hooks/tapStopToDisconnectReporter.ts
@@ -1,6 +1,7 @@
-import webpack from 'webpack';
-import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
-import { ReporterRpcClient } from '../reporter';
+import type webpack from 'webpack';
+
+import type { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
+import type { ReporterRpcClient } from '../reporter';
 
 function tapStopToDisconnectReporter(
   compiler: webpack.Compiler,

--- a/src/issue/Issue.ts
+++ b/src/issue/Issue.ts
@@ -1,5 +1,7 @@
-import { IssueSeverity, compareIssueSeverities, isIssueSeverity } from './IssueSeverity';
-import { compareIssueLocations, IssueLocation } from './IssueLocation';
+import type { IssueLocation } from './IssueLocation';
+import { compareIssueLocations } from './IssueLocation';
+import type { IssueSeverity } from './IssueSeverity';
+import { compareIssueSeverities, isIssueSeverity } from './IssueSeverity';
 
 interface Issue {
   severity: IssueSeverity;

--- a/src/issue/IssueConfiguration.ts
+++ b/src/issue/IssueConfiguration.ts
@@ -1,11 +1,9 @@
-import webpack from 'webpack';
+import type webpack from 'webpack';
+
 import { createIssuePredicateFromIssueMatch } from './IssueMatch';
-import {
-  composeIssuePredicates,
-  createTrivialIssuePredicate,
-  IssuePredicate,
-} from './IssuePredicate';
-import { IssuePredicateOption, IssueOptions } from './IssueOptions';
+import type { IssuePredicateOption, IssueOptions } from './IssueOptions';
+import type { IssuePredicate } from './IssuePredicate';
+import { composeIssuePredicates, createTrivialIssuePredicate } from './IssuePredicate';
 
 interface IssueConfiguration {
   predicate: IssuePredicate;

--- a/src/issue/IssueLocation.ts
+++ b/src/issue/IssueLocation.ts
@@ -1,4 +1,5 @@
-import { compareIssuePositions, IssuePosition } from './IssuePosition';
+import type { IssuePosition } from './IssuePosition';
+import { compareIssuePositions } from './IssuePosition';
 
 interface IssueLocation {
   start: IssuePosition;

--- a/src/issue/IssueMatch.ts
+++ b/src/issue/IssueMatch.ts
@@ -1,8 +1,12 @@
-import { Issue } from './index';
-import { IssuePredicate } from './IssuePredicate';
-import minimatch from 'minimatch';
 import path from 'path';
+
+import minimatch from 'minimatch';
+
 import forwardSlash from '../utils/path/forwardSlash';
+
+import type { IssuePredicate } from './IssuePredicate';
+
+import type { Issue } from './index';
 
 type IssueMatch = Partial<Pick<Issue, 'severity' | 'code' | 'file'>>;
 

--- a/src/issue/IssueOptions.ts
+++ b/src/issue/IssueOptions.ts
@@ -1,5 +1,5 @@
-import { IssueMatch } from './IssueMatch';
-import { IssuePredicate } from './IssuePredicate';
+import type { IssueMatch } from './IssueMatch';
+import type { IssuePredicate } from './IssuePredicate';
 
 type IssuePredicateOption = IssuePredicate | IssueMatch | (IssuePredicate | IssueMatch)[];
 

--- a/src/issue/IssuePredicate.ts
+++ b/src/issue/IssuePredicate.ts
@@ -1,4 +1,4 @@
-import { Issue } from './index';
+import type { Issue } from './index';
 
 type IssuePredicate = (issue: Issue) => boolean;
 

--- a/src/issue/IssueWebpackError.ts
+++ b/src/issue/IssueWebpackError.ts
@@ -1,8 +1,10 @@
-import webpack from 'webpack';
-import { Issue } from './Issue';
-import { formatIssueLocation } from './IssueLocation';
-import { relativeToContext } from '../utils/path/relativeToContext';
 import chalk from 'chalk';
+import webpack from 'webpack';
+
+import { relativeToContext } from '../utils/path/relativeToContext';
+
+import type { Issue } from './Issue';
+import { formatIssueLocation } from './IssueLocation';
 
 class IssueWebpackError extends webpack.WebpackError {
   readonly hideStack = true;

--- a/src/logger/LoggerConfiguration.ts
+++ b/src/logger/LoggerConfiguration.ts
@@ -1,7 +1,8 @@
-import LoggerOptions from './LoggerOptions';
-import Logger from './Logger';
-import webpack from 'webpack';
+import type webpack from 'webpack';
+
+import type Logger from './Logger';
 import { createLogger } from './LoggerFactory';
+import type LoggerOptions from './LoggerOptions';
 
 interface LoggerConfiguration {
   infrastructure: Logger;

--- a/src/logger/LoggerFactory.ts
+++ b/src/logger/LoggerFactory.ts
@@ -1,7 +1,8 @@
-import webpack from 'webpack';
-import Logger from './Logger';
-import { createWebpackInfrastructureLogger } from './WebpackInfrastructureLogger';
+import type webpack from 'webpack';
+
+import type Logger from './Logger';
 import { createPartialLogger } from './PartialLogger';
+import { createWebpackInfrastructureLogger } from './WebpackInfrastructureLogger';
 
 type LoggerType = 'console' | 'webpack-infrastructure' | 'silent';
 

--- a/src/logger/LoggerOptions.ts
+++ b/src/logger/LoggerOptions.ts
@@ -1,5 +1,5 @@
-import { LoggerType } from './LoggerFactory';
-import Logger from './Logger';
+import type Logger from './Logger';
+import type { LoggerType } from './LoggerFactory';
 
 type LoggerOptions = {
   infrastructure?: LoggerType | Logger;

--- a/src/logger/PartialLogger.ts
+++ b/src/logger/PartialLogger.ts
@@ -1,4 +1,4 @@
-import Logger from './Logger';
+import type Logger from './Logger';
 
 type LoggerMethods = 'info' | 'log' | 'error';
 

--- a/src/logger/WebpackInfrastructureLogger.ts
+++ b/src/logger/WebpackInfrastructureLogger.ts
@@ -1,5 +1,6 @@
-import webpack from 'webpack';
-import Logger from './Logger';
+import type webpack from 'webpack';
+
+import type Logger from './Logger';
 
 interface InfrastructureLoggerProvider {
   getInfrastructureLogger(name: string): Logger;

--- a/src/reporter/AggregatedReporter.ts
+++ b/src/reporter/AggregatedReporter.ts
@@ -1,6 +1,8 @@
-import { Reporter } from './Reporter';
 import { OperationCanceledError } from '../error/OperationCanceledError';
-import { aggregateFilesChanges, FilesChange } from './FilesChange';
+
+import type { FilesChange } from './FilesChange';
+import { aggregateFilesChanges } from './FilesChange';
+import type { Reporter } from './Reporter';
 
 /**
  * This higher order reporter aggregates too frequent getReport requests to avoid unnecessary computation.

--- a/src/reporter/FilesChange.ts
+++ b/src/reporter/FilesChange.ts
@@ -1,6 +1,7 @@
+import type { Compiler } from 'webpack';
+
 import subtract from '../utils/array/substract';
 import unique from '../utils/array/unique';
-import { Compiler } from 'webpack';
 
 interface FilesChange {
   changedFiles?: string[];

--- a/src/reporter/Report.ts
+++ b/src/reporter/Report.ts
@@ -1,5 +1,6 @@
-import { FilesMatch } from './FilesMatch';
-import { Issue } from '../issue';
+import type { Issue } from '../issue';
+
+import type { FilesMatch } from './FilesMatch';
 
 interface Report {
   getDependencies(): Promise<FilesMatch>;

--- a/src/reporter/Reporter.ts
+++ b/src/reporter/Reporter.ts
@@ -1,5 +1,5 @@
-import { FilesChange } from './FilesChange';
-import { Report } from './Report';
+import type { FilesChange } from './FilesChange';
+import type { Report } from './Report';
 
 interface Reporter {
   getReport(change: FilesChange, watching: boolean): Promise<Report>;

--- a/src/reporter/reporter-rpc/ReporterRpcClient.ts
+++ b/src/reporter/reporter-rpc/ReporterRpcClient.ts
@@ -1,5 +1,9 @@
-import { Reporter } from '../Reporter';
-import { createRpcClient, RpcMessageChannel } from '../../rpc';
+import type { RpcMessageChannel } from '../../rpc';
+import { createRpcClient } from '../../rpc';
+import flatten from '../../utils/array/flatten';
+import type { FilesChange } from '../FilesChange';
+import type { Reporter } from '../Reporter';
+
 import {
   configure,
   getReport,
@@ -7,8 +11,6 @@ import {
   getIssues,
   closeReport,
 } from './ReporterRpcProcedure';
-import flatten from '../../utils/array/flatten';
-import { FilesChange } from '../FilesChange';
 
 interface ReporterRpcClient extends Reporter {
   isConnected: () => boolean;

--- a/src/reporter/reporter-rpc/ReporterRpcProcedure.ts
+++ b/src/reporter/reporter-rpc/ReporterRpcProcedure.ts
@@ -1,7 +1,7 @@
-import { RpcProcedure } from '../../rpc';
-import { FilesChange } from '../FilesChange';
-import { Issue } from '../../issue';
-import { FilesMatch } from '../FilesMatch';
+import type { Issue } from '../../issue';
+import type { RpcProcedure } from '../../rpc';
+import type { FilesChange } from '../FilesChange';
+import type { FilesMatch } from '../FilesMatch';
 
 // suppressing because it will be removed anyway
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/src/reporter/reporter-rpc/ReporterRpcService.ts
+++ b/src/reporter/reporter-rpc/ReporterRpcService.ts
@@ -1,5 +1,8 @@
-import { Reporter } from '../Reporter';
-import { createRpcService, RpcMessagePort } from '../../rpc';
+import type { RpcMessagePort } from '../../rpc';
+import { createRpcService } from '../../rpc';
+import type { Report } from '../Report';
+import type { Reporter } from '../Reporter';
+
 import {
   configure,
   getReport,
@@ -7,7 +10,6 @@ import {
   getIssues,
   closeReport,
 } from './ReporterRpcProcedure';
-import { Report } from '../Report';
 
 interface ReporterRpcService {
   isOpen: () => boolean;

--- a/src/rpc/RpcClient.ts
+++ b/src/rpc/RpcClient.ts
@@ -1,12 +1,12 @@
-import { RpcProcedure, RpcProcedurePayload, RpcProcedureResult } from './RpcProcedure';
-import { RpcMessagePort } from './RpcMessagePort';
+import { RpcRemoteError } from './error/RpcRemoteError';
 import {
   createRpcCall,
   getRpcMessageKey,
   isRpcReturnMessage,
   isRpcThrowMessage,
 } from './RpcMessage';
-import { RpcRemoteError } from './error/RpcRemoteError';
+import type { RpcMessagePort } from './RpcMessagePort';
+import type { RpcProcedure, RpcProcedurePayload, RpcProcedureResult } from './RpcProcedure';
 
 interface RpcClient {
   readonly isConnected: () => boolean;

--- a/src/rpc/RpcMessage.ts
+++ b/src/rpc/RpcMessage.ts
@@ -1,4 +1,4 @@
-import { RpcProcedure, RpcProcedurePayload, RpcProcedureResult } from './RpcProcedure';
+import type { RpcProcedure, RpcProcedurePayload, RpcProcedureResult } from './RpcProcedure';
 
 interface RpcMessage<
   TType extends string = string,

--- a/src/rpc/RpcMessageChannel.ts
+++ b/src/rpc/RpcMessageChannel.ts
@@ -1,4 +1,4 @@
-import { RpcMessagePort } from './RpcMessagePort';
+import type { RpcMessagePort } from './RpcMessagePort';
 
 interface RpcMessageChannel {
   readonly servicePort: RpcMessagePort;

--- a/src/rpc/RpcService.ts
+++ b/src/rpc/RpcService.ts
@@ -1,6 +1,6 @@
-import { RpcProcedure } from './RpcProcedure';
-import { RpcMessagePort } from './RpcMessagePort';
 import { createRpcReturn, createRpcThrow, isRpcCallMessage } from './RpcMessage';
+import type { RpcMessagePort } from './RpcMessagePort';
+import type { RpcProcedure } from './RpcProcedure';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RpcCallHandler<TPayload = any, TResult = any> = (payload: TPayload) => Promise<TResult>;

--- a/src/rpc/rpc-ipc/RpcIpcMessageChannel.ts
+++ b/src/rpc/rpc-ipc/RpcIpcMessageChannel.ts
@@ -1,4 +1,6 @@
-import { createRpcMessageChannel, RpcMessageChannel } from '../index';
+import type { RpcMessageChannel } from '../index';
+import { createRpcMessageChannel } from '../index';
+
 import { createRpcIpcForkedProcessMessagePort } from './RpcIpcMessagePort';
 
 function createRpcIpcMessageChannel(servicePath: string, memoryLimit = 2048): RpcMessageChannel {

--- a/src/rpc/rpc-ipc/RpcIpcMessagePort.ts
+++ b/src/rpc/rpc-ipc/RpcIpcMessagePort.ts
@@ -1,7 +1,10 @@
-import { ProcessLike } from './ProcessLike';
-import { RpcMessagePort, RpcMessageListener, RpcErrorListener } from '../index';
-import { ChildProcess, fork } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import { fork } from 'child_process';
+
+import type { RpcMessagePort, RpcMessageListener, RpcErrorListener } from '../index';
+
 import { RpcIpcMessagePortClosedError } from './error/RpcIpcMessagePortClosedError';
+import type { ProcessLike } from './ProcessLike';
 
 function createRpcIpcMessagePort(process: ProcessLike): RpcMessagePort {
   const messageListeners = new Set<RpcMessageListener>();

--- a/src/typescript-reporter/TypeScriptReporterConfiguration.ts
+++ b/src/typescript-reporter/TypeScriptReporterConfiguration.ts
@@ -1,13 +1,13 @@
-import webpack from 'webpack';
 import path from 'path';
+
 import semver from 'semver';
-import { TypeScriptDiagnosticsOptions } from './TypeScriptDiagnosticsOptions';
-import { TypeScriptReporterOptions } from './TypeScriptReporterOptions';
-import {
-  createTypeScriptVueExtensionConfiguration,
-  TypeScriptVueExtensionConfiguration,
-} from './extension/vue/TypeScriptVueExtensionConfiguration';
-import { TypeScriptConfigurationOverwrite } from './TypeScriptConfigurationOverwrite';
+import type webpack from 'webpack';
+
+import type { TypeScriptVueExtensionConfiguration } from './extension/vue/TypeScriptVueExtensionConfiguration';
+import { createTypeScriptVueExtensionConfiguration } from './extension/vue/TypeScriptVueExtensionConfiguration';
+import type { TypeScriptConfigurationOverwrite } from './TypeScriptConfigurationOverwrite';
+import type { TypeScriptDiagnosticsOptions } from './TypeScriptDiagnosticsOptions';
+import type { TypeScriptReporterOptions } from './TypeScriptReporterOptions';
 
 interface TypeScriptReporterConfiguration {
   enabled: boolean;

--- a/src/typescript-reporter/TypeScriptReporterOptions.ts
+++ b/src/typescript-reporter/TypeScriptReporterOptions.ts
@@ -1,6 +1,6 @@
-import { TypeScriptDiagnosticsOptions } from './TypeScriptDiagnosticsOptions';
-import { TypeScriptVueExtensionOptions } from './extension/vue/TypeScriptVueExtensionOptions';
-import { TypeScriptConfigurationOverwrite } from './TypeScriptConfigurationOverwrite';
+import type { TypeScriptVueExtensionOptions } from './extension/vue/TypeScriptVueExtensionOptions';
+import type { TypeScriptConfigurationOverwrite } from './TypeScriptConfigurationOverwrite';
+import type { TypeScriptDiagnosticsOptions } from './TypeScriptDiagnosticsOptions';
 
 type TypeScriptReporterOptions = {
   memoryLimit?: number;

--- a/src/typescript-reporter/TypeScriptSupport.ts
+++ b/src/typescript-reporter/TypeScriptSupport.ts
@@ -28,6 +28,14 @@ function assertTypeScriptSupport(configuration: TypeScriptReporterConfiguration)
       ].join(os.EOL)
     );
   }
+  if (configuration.build && semver.lt(typescriptVersion, '3.8.0')) {
+    throw new Error(
+      [
+        `ForkTsCheckerWebpackPlugin doesn't support build option for the current typescript version of ${typescriptVersion}.`,
+        'The minimum required version is 3.8.0.',
+      ].join(os.EOL)
+    );
+  }
 
   if (!fs.existsSync(configuration.configFile)) {
     throw new Error(

--- a/src/typescript-reporter/TypeScriptSupport.ts
+++ b/src/typescript-reporter/TypeScriptSupport.ts
@@ -1,8 +1,10 @@
-import * as semver from 'semver';
-import fs from 'fs-extra';
 import os from 'os';
-import { TypeScriptReporterConfiguration } from './TypeScriptReporterConfiguration';
+
+import fs from 'fs-extra';
+import * as semver from 'semver';
+
 import { assertTypeScriptVueExtensionSupport } from './extension/vue/TypeScriptVueExtensionSupport';
+import type { TypeScriptReporterConfiguration } from './TypeScriptReporterConfiguration';
 
 function assertTypeScriptSupport(configuration: TypeScriptReporterConfiguration) {
   let typescriptVersion: string | undefined;

--- a/src/typescript-reporter/extension/TypeScriptEmbeddedExtension.ts
+++ b/src/typescript-reporter/extension/TypeScriptEmbeddedExtension.ts
@@ -1,8 +1,11 @@
-import type * as ts from 'typescript';
 import { extname } from 'path';
-import { TypeScriptExtension } from './TypeScriptExtension';
-import { Issue } from '../../issue';
-import { FilesMatch } from '../../reporter';
+
+import type * as ts from 'typescript';
+
+import type { Issue } from '../../issue';
+import type { FilesMatch } from '../../reporter';
+
+import type { TypeScriptExtension } from './TypeScriptExtension';
 
 interface TypeScriptEmbeddedSource {
   sourceText: string;
@@ -51,9 +54,8 @@ function createTypeScriptEmbeddedExtension({
   type FileExists = (fileName: string) => boolean;
   function createEmbeddedFileExists(fileExists: FileExists): FileExists {
     return function embeddedFileExists(fileName) {
-      const { embeddedExtension, embeddedFileName, extension } = parsePotentiallyEmbeddedFileName(
-        fileName
-      );
+      const { embeddedExtension, embeddedFileName, extension } =
+        parsePotentiallyEmbeddedFileName(fileName);
 
       if (embeddedExtensions.includes(embeddedExtension) && fileExists(embeddedFileName)) {
         const embeddedSource = getCachedEmbeddedSource(embeddedFileName);
@@ -67,9 +69,8 @@ function createTypeScriptEmbeddedExtension({
   type ReadFile = (fileName: string, encoding?: string) => string | undefined;
   function createEmbeddedReadFile(readFile: ReadFile): ReadFile {
     return function embeddedReadFile(fileName, encoding) {
-      const { embeddedExtension, embeddedFileName, extension } = parsePotentiallyEmbeddedFileName(
-        fileName
-      );
+      const { embeddedExtension, embeddedFileName, extension } =
+        parsePotentiallyEmbeddedFileName(fileName);
 
       if (embeddedExtensions.includes(embeddedExtension)) {
         const embeddedSource = getCachedEmbeddedSource(embeddedFileName);
@@ -106,9 +107,8 @@ function createTypeScriptEmbeddedExtension({
       return {
         ...host,
         watchFile(fileName, callback, poolingInterval) {
-          const { embeddedExtension, embeddedFileName } = parsePotentiallyEmbeddedFileName(
-            fileName
-          );
+          const { embeddedExtension, embeddedFileName } =
+            parsePotentiallyEmbeddedFileName(fileName);
 
           if (embeddedExtensions.includes(embeddedExtension)) {
             return host.watchFile(
@@ -172,11 +172,8 @@ function createTypeScriptEmbeddedExtension({
       return {
         ...dependencies,
         files: dependencies.files.map((fileName) => {
-          const {
-            embeddedExtension,
-            embeddedFileName,
-            extension,
-          } = parsePotentiallyEmbeddedFileName(fileName);
+          const { embeddedExtension, embeddedFileName, extension } =
+            parsePotentiallyEmbeddedFileName(fileName);
 
           if (embeddedExtensions.includes(embeddedExtension)) {
             const embeddedSource = getCachedEmbeddedSource(embeddedFileName);

--- a/src/typescript-reporter/extension/TypeScriptExtension.ts
+++ b/src/typescript-reporter/extension/TypeScriptExtension.ts
@@ -1,6 +1,7 @@
 import type * as ts from 'typescript';
-import { Issue } from '../../issue';
-import { FilesMatch } from '../../reporter';
+
+import type { Issue } from '../../issue';
+import type { FilesMatch } from '../../reporter';
 
 interface TypeScriptHostExtension {
   extendWatchSolutionBuilderHost?<

--- a/src/typescript-reporter/extension/vue/TypeScriptVueExtension.ts
+++ b/src/typescript-reporter/extension/vue/TypeScriptVueExtension.ts
@@ -1,12 +1,12 @@
-import {
-  createTypeScriptEmbeddedExtension,
-  TypeScriptEmbeddedSource,
-} from '../TypeScriptEmbeddedExtension';
 import fs from 'fs-extra';
-import { TypeScriptExtension } from '../TypeScriptExtension';
-import { TypeScriptVueExtensionConfiguration } from './TypeScriptVueExtensionConfiguration';
-import { VueTemplateCompilerV2 } from './types/vue-template-compiler';
-import { VueTemplateCompilerV3 } from './types/vue__compiler-sfc';
+
+import type { TypeScriptEmbeddedSource } from '../TypeScriptEmbeddedExtension';
+import { createTypeScriptEmbeddedExtension } from '../TypeScriptEmbeddedExtension';
+import type { TypeScriptExtension } from '../TypeScriptExtension';
+
+import type { VueTemplateCompilerV2 } from './types/vue-template-compiler';
+import type { VueTemplateCompilerV3 } from './types/vue__compiler-sfc';
+import type { TypeScriptVueExtensionConfiguration } from './TypeScriptVueExtensionConfiguration';
 
 interface GenericScriptSFCBlock {
   content: string;

--- a/src/typescript-reporter/extension/vue/TypeScriptVueExtensionConfiguration.ts
+++ b/src/typescript-reporter/extension/vue/TypeScriptVueExtensionConfiguration.ts
@@ -1,4 +1,4 @@
-import { TypeScriptVueExtensionOptions } from './TypeScriptVueExtensionOptions';
+import type { TypeScriptVueExtensionOptions } from './TypeScriptVueExtensionOptions';
 
 interface TypeScriptVueExtensionConfiguration {
   enabled: boolean;

--- a/src/typescript-reporter/extension/vue/TypeScriptVueExtensionSupport.ts
+++ b/src/typescript-reporter/extension/vue/TypeScriptVueExtensionSupport.ts
@@ -1,4 +1,4 @@
-import { TypeScriptVueExtensionConfiguration } from './TypeScriptVueExtensionConfiguration';
+import type { TypeScriptVueExtensionConfiguration } from './TypeScriptVueExtensionConfiguration';
 
 function assertTypeScriptVueExtensionSupport(configuration: TypeScriptVueExtensionConfiguration) {
   // We need to import template compiler for vue lazily because it cannot be included it

--- a/src/typescript-reporter/file-system/FileSystem.ts
+++ b/src/typescript-reporter/file-system/FileSystem.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-unsupported-features/node-builtins
-import { Dirent, Stats } from 'fs';
+import type { Dirent, Stats } from 'fs';
 
 /**
  * Interface to abstract file system implementation details.

--- a/src/typescript-reporter/file-system/MemFileSystem.ts
+++ b/src/typescript-reporter/file-system/MemFileSystem.ts
@@ -1,8 +1,10 @@
+import type { Dirent, Stats } from 'fs';
 import { dirname } from 'path';
+
 import { fs as mem } from 'memfs';
-import { FileSystem } from './FileSystem';
+
+import type { FileSystem } from './FileSystem';
 // eslint-disable-next-line node/no-unsupported-features/node-builtins
-import { Dirent, Stats } from 'fs';
 
 /**
  * It's an implementation of FileSystem interface which reads and writes to the in-memory file system.

--- a/src/typescript-reporter/file-system/PassiveFileSystem.ts
+++ b/src/typescript-reporter/file-system/PassiveFileSystem.ts
@@ -1,4 +1,4 @@
-import { FileSystem } from './FileSystem';
+import type { FileSystem } from './FileSystem';
 
 /**
  * It's an implementation of FileSystem interface which reads from the real file system, but write to the in-memory file system.

--- a/src/typescript-reporter/file-system/RealFileSystem.ts
+++ b/src/typescript-reporter/file-system/RealFileSystem.ts
@@ -1,8 +1,10 @@
+import type { Dirent, Stats } from 'fs';
 import { dirname, basename, join, normalize } from 'path';
+
 import fs from 'fs-extra';
-import { FileSystem } from './FileSystem';
+
+import type { FileSystem } from './FileSystem';
 // eslint-disable-next-line node/no-unsupported-features/node-builtins
-import { Dirent, Stats } from 'fs';
 
 /**
  * It's an implementation of the FileSystem interface which reads and writes directly to the real file system.

--- a/src/typescript-reporter/issue/TypeScriptIssueFactory.ts
+++ b/src/typescript-reporter/issue/TypeScriptIssueFactory.ts
@@ -1,6 +1,9 @@
-import type * as ts from 'typescript';
 import * as os from 'os';
-import { deduplicateAndSortIssues, Issue, IssueLocation } from '../../issue';
+
+import type * as ts from 'typescript';
+
+import type { Issue, IssueLocation } from '../../issue';
+import { deduplicateAndSortIssues } from '../../issue';
 
 function createIssueFromTsDiagnostic(typescript: typeof ts, diagnostic: ts.Diagnostic): Issue {
   let file: string | undefined;
@@ -10,14 +13,10 @@ function createIssueFromTsDiagnostic(typescript: typeof ts, diagnostic: ts.Diagn
     file = diagnostic.file.fileName;
 
     if (diagnostic.start && diagnostic.length) {
-      const {
-        line: startLine,
-        character: startCharacter,
-      } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
-      const {
-        line: endLine,
-        character: endCharacter,
-      } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start + diagnostic.length);
+      const { line: startLine, character: startCharacter } =
+        diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+      const { line: endLine, character: endCharacter } =
+        diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start + diagnostic.length);
 
       location = {
         start: {

--- a/src/typescript-reporter/profile/TypeScriptPerformance.ts
+++ b/src/typescript-reporter/profile/TypeScriptPerformance.ts
@@ -1,5 +1,6 @@
 import type * as ts from 'typescript';
-import { Performance } from '../../profile/Performance';
+
+import type { Performance } from '../../profile/Performance';
 
 interface TypeScriptPerformance {
   enable(): void;

--- a/src/typescript-reporter/reporter/ControlledCompilerHost.ts
+++ b/src/typescript-reporter/reporter/ControlledCompilerHost.ts
@@ -1,6 +1,8 @@
-import * as ts from 'typescript';
-import { TypeScriptHostExtension } from '../extension/TypeScriptExtension';
-import { ControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
+import type * as ts from 'typescript';
+
+import type { TypeScriptHostExtension } from '../extension/TypeScriptExtension';
+
+import type { ControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
 
 function createControlledCompilerHost(
   typescript: typeof ts,

--- a/src/typescript-reporter/reporter/ControlledTypeScriptSystem.ts
+++ b/src/typescript-reporter/reporter/ControlledTypeScriptSystem.ts
@@ -1,10 +1,12 @@
-import type * as ts from 'typescript';
 import { dirname, join } from 'path';
-import { createPassiveFileSystem } from '../file-system/PassiveFileSystem';
+
+import type * as ts from 'typescript';
+
+import type { FilesMatch } from '../../reporter';
 import forwardSlash from '../../utils/path/forwardSlash';
-import { createRealFileSystem } from '../file-system/RealFileSystem';
 import { createMemFileSystem } from '../file-system/MemFileSystem';
-import { FilesMatch } from '../../reporter';
+import { createPassiveFileSystem } from '../file-system/PassiveFileSystem';
+import { createRealFileSystem } from '../file-system/RealFileSystem';
 
 interface ControlledTypeScriptSystem extends ts.System {
   // control watcher

--- a/src/typescript-reporter/reporter/ControlledWatchCompilerHost.ts
+++ b/src/typescript-reporter/reporter/ControlledWatchCompilerHost.ts
@@ -1,6 +1,8 @@
 import type * as ts from 'typescript';
-import { TypeScriptHostExtension } from '../extension/TypeScriptExtension';
-import { ControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
+
+import type { TypeScriptHostExtension } from '../extension/TypeScriptExtension';
+
+import type { ControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
 
 function createControlledWatchCompilerHost<TProgram extends ts.BuilderProgram>(
   typescript: typeof ts,

--- a/src/typescript-reporter/reporter/ControlledWatchSolutionBuilderHost.ts
+++ b/src/typescript-reporter/reporter/ControlledWatchSolutionBuilderHost.ts
@@ -1,7 +1,9 @@
 import type * as ts from 'typescript';
+
+import type { TypeScriptHostExtension } from '../extension/TypeScriptExtension';
+
+import type { ControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
 import { createControlledWatchCompilerHost } from './ControlledWatchCompilerHost';
-import { TypeScriptHostExtension } from '../extension/TypeScriptExtension';
-import { ControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
 
 function createControlledWatchSolutionBuilderHost<TProgram extends ts.BuilderProgram>(
   typescript: typeof ts,

--- a/src/typescript-reporter/reporter/TypeScriptConfigurationParser.ts
+++ b/src/typescript-reporter/reporter/TypeScriptConfigurationParser.ts
@@ -1,8 +1,10 @@
-import type * as ts from 'typescript';
 import { normalize, dirname, basename, resolve, relative } from 'path';
-import { TypeScriptConfigurationOverwrite } from '../TypeScriptConfigurationOverwrite';
-import { FilesMatch } from '../../reporter';
+
+import type * as ts from 'typescript';
+
+import type { FilesMatch } from '../../reporter';
 import forwardSlash from '../../utils/path/forwardSlash';
+import type { TypeScriptConfigurationOverwrite } from '../TypeScriptConfigurationOverwrite';
 
 function parseTypeScriptConfiguration(
   typescript: typeof ts,

--- a/src/typescript-reporter/reporter/TypeScriptReporter.ts
+++ b/src/typescript-reporter/reporter/TypeScriptReporter.ts
@@ -1,25 +1,26 @@
-import type * as ts from 'typescript';
 import path from 'path';
-import { FilesMatch, Reporter } from '../../reporter';
-import { createIssuesFromTsDiagnostics } from '../issue/TypeScriptIssueFactory';
-import { TypeScriptReporterConfiguration } from '../TypeScriptReporterConfiguration';
-import { createControlledWatchCompilerHost } from './ControlledWatchCompilerHost';
-import { TypeScriptExtension } from '../extension/TypeScriptExtension';
+
+import type * as ts from 'typescript';
+
+import { createPerformance } from '../../profile/Performance';
+import type { FilesMatch, Reporter } from '../../reporter';
+import type { TypeScriptExtension } from '../extension/TypeScriptExtension';
 import { createTypeScriptVueExtension } from '../extension/vue/TypeScriptVueExtension';
+import { createIssuesFromTsDiagnostics } from '../issue/TypeScriptIssueFactory';
+import { connectTypeScriptPerformance } from '../profile/TypeScriptPerformance';
+import type { TypeScriptReporterConfiguration } from '../TypeScriptReporterConfiguration';
+
+import { createControlledCompilerHost } from './ControlledCompilerHost';
+import type { ControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
+import { createControlledTypeScriptSystem } from './ControlledTypeScriptSystem';
+import { createControlledWatchCompilerHost } from './ControlledWatchCompilerHost';
 import { createControlledWatchSolutionBuilderHost } from './ControlledWatchSolutionBuilderHost';
-import {
-  ControlledTypeScriptSystem,
-  createControlledTypeScriptSystem,
-} from './ControlledTypeScriptSystem';
 import {
   getDependenciesFromTypeScriptConfiguration,
   getArtifactsFromTypeScriptConfiguration,
   parseTypeScriptConfiguration,
   isIncrementalCompilation,
 } from './TypeScriptConfigurationParser';
-import { createPerformance } from '../../profile/Performance';
-import { connectTypeScriptPerformance } from '../profile/TypeScriptPerformance';
-import { createControlledCompilerHost } from './ControlledCompilerHost';
 
 // write this type as it's available only in the newest TypeScript versions (^4.1.0)
 interface Tracing {
@@ -63,7 +64,7 @@ function createTypeScriptReporter(configuration: TypeScriptReporterConfiguration
   }
 
   function getConfigFilePathFromCompilerOptions(compilerOptions: ts.CompilerOptions): string {
-    return (compilerOptions.configFilePath as unknown) as string;
+    return compilerOptions.configFilePath as unknown as string;
   }
 
   function getProjectNameOfBuilderProgram(builderProgram: ts.BuilderProgram): string {

--- a/src/typescript-reporter/reporter/TypeScriptReporterRpcClient.ts
+++ b/src/typescript-reporter/reporter/TypeScriptReporterRpcClient.ts
@@ -1,7 +1,9 @@
 import path from 'path';
-import { TypeScriptReporterConfiguration } from '../TypeScriptReporterConfiguration';
-import { createReporterRpcClient, ReporterRpcClient } from '../../reporter';
+
+import type { ReporterRpcClient } from '../../reporter';
+import { createReporterRpcClient } from '../../reporter';
 import { createRpcIpcMessageChannel } from '../../rpc/rpc-ipc';
+import type { TypeScriptReporterConfiguration } from '../TypeScriptReporterConfiguration';
 
 function createTypeScriptReporterRpcClient(
   configuration: TypeScriptReporterConfiguration

--- a/src/typescript-reporter/reporter/TypeScriptReporterRpcService.ts
+++ b/src/typescript-reporter/reporter/TypeScriptReporterRpcService.ts
@@ -1,8 +1,10 @@
 import process from 'process';
-import { createTypeScriptReporter } from './TypeScriptReporter';
-import { TypeScriptReporterConfiguration } from '../TypeScriptReporterConfiguration';
-import { createRpcIpcMessagePort } from '../../rpc/rpc-ipc';
+
 import { registerReporterRpcService } from '../../reporter';
+import { createRpcIpcMessagePort } from '../../rpc/rpc-ipc';
+import type { TypeScriptReporterConfiguration } from '../TypeScriptReporterConfiguration';
+
+import { createTypeScriptReporter } from './TypeScriptReporter';
 
 const service = registerReporterRpcService<TypeScriptReporterConfiguration>(
   createRpcIpcMessagePort(process),

--- a/src/utils/path/relativeToContext.ts
+++ b/src/utils/path/relativeToContext.ts
@@ -1,5 +1,6 @@
-import forwardSlash from './forwardSlash';
 import path from 'path';
+
+import forwardSlash from './forwardSlash';
 
 function relativeToContext(file: string, context: string) {
   let fileInContext = forwardSlash(path.relative(context, file));

--- a/src/watch/InclusiveNodeWatchFileSystem.ts
+++ b/src/watch/InclusiveNodeWatchFileSystem.ts
@@ -1,10 +1,14 @@
-import { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
-import chokidar, { FSWatcher } from 'chokidar';
 import { extname } from 'path';
-import { WatchFileSystem } from './WatchFileSystem';
-import { Compiler } from 'webpack';
-import { clearFilesChange, updateFilesChange } from '../reporter';
+
+import type { FSWatcher } from 'chokidar';
+import chokidar from 'chokidar';
 import minimatch from 'minimatch';
+import type { Compiler } from 'webpack';
+
+import type { ForkTsCheckerWebpackPluginState } from '../ForkTsCheckerWebpackPluginState';
+import { clearFilesChange, updateFilesChange } from '../reporter';
+
+import type { WatchFileSystem } from './WatchFileSystem';
 
 const BUILTIN_IGNORED_DIRS = ['node_modules', '.git', '.yarn', '.pnp'];
 

--- a/src/watch/WatchFileSystem.ts
+++ b/src/watch/WatchFileSystem.ts
@@ -1,5 +1,6 @@
-import { EventEmitter } from 'events';
-import webpack from 'webpack';
+import type { EventEmitter } from 'events';
+
+import type webpack from 'webpack';
 
 // watchpack v1 and v2 internal interface
 interface Watchpack extends EventEmitter {

--- a/test/e2e/OutOfMemoryAndCosmiconfig.spec.ts
+++ b/test/e2e/OutOfMemoryAndCosmiconfig.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+
 import { createProcessDriver } from 'karton';
 
 describe('ForkTsCheckerWebpackPlugin Out Of Memory and Cosmiconfig', () => {

--- a/test/e2e/TypeScriptConfiguration.spec.ts
+++ b/test/e2e/TypeScriptConfiguration.spec.ts
@@ -1,8 +1,7 @@
 import path from 'path';
-import {
-  createWebpackDevServerDriver,
-  WebpackDevServerDriver,
-} from './driver/WebpackDevServerDriver';
+
+import type { WebpackDevServerDriver } from './driver/WebpackDevServerDriver';
+import { createWebpackDevServerDriver } from './driver/WebpackDevServerDriver';
 
 describe('TypeScript Configuration', () => {
   it.each([

--- a/test/e2e/TypeScriptContextOption.spec.ts
+++ b/test/e2e/TypeScriptContextOption.spec.ts
@@ -1,5 +1,6 @@
-import path from 'path';
 import os from 'os';
+import path from 'path';
+
 import { createWebpackDevServerDriver } from './driver/WebpackDevServerDriver';
 
 describe('TypeScript Context Option', () => {

--- a/test/e2e/TypeScriptFormatterOption.spec.ts
+++ b/test/e2e/TypeScriptFormatterOption.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+
 import { createWebpackDevServerDriver } from './driver/WebpackDevServerDriver';
 
 describe('TypeScript Formatter Option', () => {

--- a/test/e2e/TypeScriptPnpSupport.spec.ts
+++ b/test/e2e/TypeScriptPnpSupport.spec.ts
@@ -1,6 +1,8 @@
 import path from 'path';
-import { createWebpackDevServerDriver } from './driver/WebpackDevServerDriver';
+
 import semver from 'semver';
+
+import { createWebpackDevServerDriver } from './driver/WebpackDevServerDriver';
 
 describe('TypeScript PnP Support', () => {
   it.each([

--- a/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
+++ b/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
@@ -4,7 +4,7 @@ import semver from 'semver';
 
 describe('TypeScript SolutionBuilder API', () => {
   it.each([
-    { async: false, typescript: '~3.6.0', mode: 'readonly' },
+    { async: false, typescript: '~3.8.0', mode: 'readonly' },
     { async: true, typescript: '~3.8.0', mode: 'write-tsbuildinfo' },
     { async: false, typescript: '~4.0.0', mode: 'write-references' },
     { async: true, typescript: '~4.3.0', mode: 'readonly' },

--- a/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
+++ b/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
@@ -1,6 +1,8 @@
 import path from 'path';
-import { createWebpackDevServerDriver } from './driver/WebpackDevServerDriver';
+
 import semver from 'semver';
+
+import { createWebpackDevServerDriver } from './driver/WebpackDevServerDriver';
 
 describe('TypeScript SolutionBuilder API', () => {
   it.each([

--- a/test/e2e/TypeScriptVueExtension.spec.ts
+++ b/test/e2e/TypeScriptVueExtension.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+
 import { createWebpackDevServerDriver } from './driver/WebpackDevServerDriver';
 
 describe('TypeScript Vue Extension', () => {

--- a/test/e2e/TypeScriptWatchApi.spec.ts
+++ b/test/e2e/TypeScriptWatchApi.spec.ts
@@ -1,6 +1,8 @@
 import path from 'path';
-import { createWebpackDevServerDriver } from './driver/WebpackDevServerDriver';
+
 import semver from 'semver';
+
+import { createWebpackDevServerDriver } from './driver/WebpackDevServerDriver';
 
 describe('TypeScript Watch API', () => {
   it.each([{ async: false }, { async: true }])(

--- a/test/e2e/WebpackProductionBuild.spec.ts
+++ b/test/e2e/WebpackProductionBuild.spec.ts
@@ -1,5 +1,7 @@
 import path from 'path';
+
 import stripAnsi from 'strip-ansi';
+
 import { extractWebpackErrors } from './driver/WebpackErrorsExtractor';
 
 describe('Webpack Production Build', () => {

--- a/test/e2e/driver/WebpackDevServerDriver.ts
+++ b/test/e2e/driver/WebpackDevServerDriver.ts
@@ -1,7 +1,10 @@
-import { ChildProcess } from 'child_process';
+import type { ChildProcess } from 'child_process';
+
 import stripAnsi from 'strip-ansi';
+
+import type { Listener, QueuedListener } from './Listener';
+import { createQueuedListener } from './Listener';
 import { extractWebpackErrors } from './WebpackErrorsExtractor';
-import { createQueuedListener, Listener, QueuedListener } from './Listener';
 
 interface WebpackDevServerDriver {
   process: ChildProcess;

--- a/test/e2e/jest.environment.js
+++ b/test/e2e/jest.environment.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const NodeEnvironment = require('jest-environment-node');
 
 function printBlock(message) {
@@ -11,7 +12,7 @@ class E2EEnvironment extends NodeEnvironment {
     super(config);
   }
 
-  async handleTestEvent(event, state) {
+  async handleTestEvent(event) {
     switch (event.name) {
       case 'test_start':
         printBlock(`Test Start: ${event.test.name}`);

--- a/test/e2e/jest.setup.ts
+++ b/test/e2e/jest.setup.ts
@@ -1,6 +1,7 @@
-import { createSandbox, packLocalPackage } from 'karton';
 import path from 'path';
-import { Sandbox } from 'karton';
+
+import { createSandbox, packLocalPackage } from 'karton';
+import type { Sandbox } from 'karton';
 
 declare global {
   let sandbox: Sandbox;

--- a/test/unit/formatter/BasicFormatter.spec.ts
+++ b/test/unit/formatter/BasicFormatter.spec.ts
@@ -1,5 +1,5 @@
-import { Issue } from 'lib/issue';
 import { createBasicFormatter } from 'lib/formatter';
+import type { Issue } from 'lib/issue';
 
 describe('formatter/BasicFormatter', () => {
   it.each([

--- a/test/unit/formatter/CodeFrameFormatter.spec.ts
+++ b/test/unit/formatter/CodeFrameFormatter.spec.ts
@@ -1,7 +1,8 @@
 import * as os from 'os';
-import mockFs from 'mock-fs';
-import { Issue } from 'lib/issue';
+
 import { createCodeFrameFormatter } from 'lib/formatter';
+import type { Issue } from 'lib/issue';
+import mockFs from 'mock-fs';
 
 describe('formatter/CodeFrameFormatter', () => {
   beforeEach(() => {

--- a/test/unit/formatter/FormatterConfiguration.spec.ts
+++ b/test/unit/formatter/FormatterConfiguration.spec.ts
@@ -1,7 +1,9 @@
 import os from 'os';
+
+import type { FormatterOptions } from 'lib/formatter';
+import { createFormatterConfiguration } from 'lib/formatter';
+import type { Issue } from 'lib/issue';
 import mockFs from 'mock-fs';
-import { Issue } from 'lib/issue';
-import { createFormatterConfiguration, FormatterOptions } from 'lib/formatter';
 
 describe('formatter/FormatterConfiguration', () => {
   beforeEach(() => {

--- a/test/unit/formatter/WebpackFormatter.spec.ts
+++ b/test/unit/formatter/WebpackFormatter.spec.ts
@@ -1,7 +1,9 @@
 import os from 'os';
 import { join } from 'path';
-import { Issue } from 'lib/issue';
-import { createBasicFormatter, createWebpackFormatter, Formatter } from 'lib/formatter';
+
+import type { Formatter } from 'lib/formatter';
+import { createBasicFormatter, createWebpackFormatter } from 'lib/formatter';
+import type { Issue } from 'lib/issue';
 
 describe('formatter/WebpackFormatter', () => {
   const issue: Issue = {

--- a/test/unit/issue/Issue.spec.ts
+++ b/test/unit/issue/Issue.spec.ts
@@ -1,4 +1,5 @@
-import { isIssue, deduplicateAndSortIssues, Issue } from 'lib/issue';
+import type { Issue } from 'lib/issue';
+import { isIssue, deduplicateAndSortIssues } from 'lib/issue';
 
 function omit<TObject extends Record<string, unknown>>(object: TObject, keys: (keyof TObject)[]) {
   const omittedObject = Object.assign({}, object);

--- a/test/unit/typescript-reporter/TypeScriptReporterConfiguration.spec.ts
+++ b/test/unit/typescript-reporter/TypeScriptReporterConfiguration.spec.ts
@@ -1,7 +1,8 @@
-import webpack from 'webpack';
 import path from 'path';
-import { TypeScriptReporterConfiguration } from 'lib/typescript-reporter/TypeScriptReporterConfiguration';
-import { TypeScriptReporterOptions } from 'lib/typescript-reporter/TypeScriptReporterOptions';
+
+import type { TypeScriptReporterConfiguration } from 'lib/typescript-reporter/TypeScriptReporterConfiguration';
+import type { TypeScriptReporterOptions } from 'lib/typescript-reporter/TypeScriptReporterOptions';
+import type webpack from 'webpack';
 
 describe('typescript-reporter/TypeScriptsReporterConfiguration', () => {
   let compiler: webpack.Compiler;

--- a/test/unit/typescript-reporter/TypeScriptSupport.spec.ts
+++ b/test/unit/typescript-reporter/TypeScriptSupport.spec.ts
@@ -1,5 +1,6 @@
-import { TypeScriptReporterConfiguration } from 'lib/typescript-reporter/TypeScriptReporterConfiguration';
 import os from 'os';
+
+import type { TypeScriptReporterConfiguration } from 'lib/typescript-reporter/TypeScriptReporterConfiguration';
 
 describe('typescript-reporter/TypeScriptSupport', () => {
   let configuration: TypeScriptReporterConfiguration;

--- a/test/unit/typescript-reporter/issue/TypeScriptIssueFactory.spec.ts
+++ b/test/unit/typescript-reporter/issue/TypeScriptIssueFactory.spec.ts
@@ -1,5 +1,5 @@
-import * as ts from 'typescript';
 import { createIssuesFromTsDiagnostics } from 'lib/typescript-reporter/issue/TypeScriptIssueFactory';
+import * as ts from 'typescript';
 
 describe('typescript-reporter/issue/TypeScriptIssueFactory', () => {
   const TS_DIAGNOSTIC_WARNING = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1704,10 +1704,15 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
   integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
 
-"@types/json-schema@^7.0.7", "@types/json-schema@^7.0.9":
+"@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -1801,74 +1806,75 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.0.tgz#b866c9cd193bfaba5e89bade0015629ebeb27996"
-  integrity sha512-eiREtqWRZ8aVJcNru7cT/AMVnYd9a2UHsfZT8MR1dW3UUEg6jDv9EQ9Cq4CUPZesyQ58YUpoAADGv71jY8RwgA==
+"@typescript-eslint/eslint-plugin@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.1.0.tgz#381c188dfab12f7a2c7b6a8ba2402d6273eadeaa"
+  integrity sha512-bekODL3Tqf36Yz8u+ilha4zGxL9mdB6LIsIoMAvvC5FAuWo4NpZYXtCbv7B2CeR1LhI/lLtLk+q4tbtxuoVuCg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.29.0"
-    "@typescript-eslint/scope-manager" "4.29.0"
-    debug "^4.3.1"
+    "@typescript-eslint/experimental-utils" "5.1.0"
+    "@typescript-eslint/scope-manager" "5.1.0"
+    debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
-    regexpp "^3.1.0"
+    ignore "^5.1.8"
+    regexpp "^3.2.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.0.tgz#19b1417602d0e1ef325b3312ee95f61220542df5"
-  integrity sha512-FpNVKykfeaIxlArLUP/yQfv/5/3rhl1ov6RWgud4OgbqWLkEq7lqgQU9iiavZRzpzCRQV4XddyFz3wFXdkiX9w==
+"@typescript-eslint/experimental-utils@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.1.0.tgz#918a1a3d30404cc1f8edcfdf0df200804ef90d31"
+  integrity sha512-ovE9qUiZMOMgxQAESZsdBT+EXIfx/YUYAbwGUI6V03amFdOOxI9c6kitkgRvLkJaLusgMZ2xBhss+tQ0Y1HWxA==
   dependencies:
-    "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.29.0"
-    "@typescript-eslint/types" "4.29.0"
-    "@typescript-eslint/typescript-estree" "4.29.0"
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.1.0"
+    "@typescript-eslint/types" "5.1.0"
+    "@typescript-eslint/typescript-estree" "5.1.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.29.0.tgz#e5367ca3c63636bb5d8e0748fcbab7a4f4a04289"
-  integrity sha512-+92YRNHFdXgq+GhWQPT2bmjX09X7EH36JfgN2/4wmhtwV/HPxozpCNst8jrWcngLtEVd/4zAwA6BKojAlf+YqA==
+"@typescript-eslint/parser@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.1.0.tgz#6c7f837d210d2bc0a811e7ea742af414f4e00908"
+  integrity sha512-vx1P+mhCtYw3+bRHmbalq/VKP2Y3gnzNgxGxfEWc6OFpuEL7iQdAeq11Ke3Rhy8NjgB+AHsIWEwni3e+Y7djKA==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.29.0"
-    "@typescript-eslint/types" "4.29.0"
-    "@typescript-eslint/typescript-estree" "4.29.0"
-    debug "^4.3.1"
+    "@typescript-eslint/scope-manager" "5.1.0"
+    "@typescript-eslint/types" "5.1.0"
+    "@typescript-eslint/typescript-estree" "5.1.0"
+    debug "^4.3.2"
 
-"@typescript-eslint/scope-manager@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz#cf5474f87321bedf416ef65839b693bddd838599"
-  integrity sha512-HPq7XAaDMM3DpmuijxLV9Io8/6pQnliiXMQUcAdjpJJSR+fdmbD/zHCd7hMkjJn04UQtCQBtshgxClzg6NIS2w==
+"@typescript-eslint/scope-manager@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.1.0.tgz#6f1f26ad66a8f71bbb33b635e74fec43f76b44df"
+  integrity sha512-yYlyVjvn5lvwCL37i4hPsa1s0ORsjkauhTqbb8MnpvUs7xykmcjGqwlNZ2Q5QpoqkJ1odlM2bqHqJwa28qV6Tw==
   dependencies:
-    "@typescript-eslint/types" "4.29.0"
-    "@typescript-eslint/visitor-keys" "4.29.0"
+    "@typescript-eslint/types" "5.1.0"
+    "@typescript-eslint/visitor-keys" "5.1.0"
 
-"@typescript-eslint/types@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.0.tgz#c8f1a1e4441ea4aca9b3109241adbc145f7f8a4e"
-  integrity sha512-2YJM6XfWfi8pgU2HRhTp7WgRw78TCRO3dOmSpAvIQ8MOv4B46JD2chnhpNT7Jq8j0APlIbzO1Bach734xxUl4A==
+"@typescript-eslint/types@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.1.0.tgz#a8a75ddfc611660de6be17d3ad950302385607a9"
+  integrity sha512-sEwNINVxcB4ZgC6Fe6rUyMlvsB2jvVdgxjZEjQUQVlaSPMNamDOwO6/TB98kFt4sYYfNhdhTPBEQqNQZjMMswA==
 
-"@typescript-eslint/typescript-estree@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.0.tgz#af7ab547757b86c91bfdbc54ff86845410856256"
-  integrity sha512-8ZpNHDIOyqzzgZrQW9+xQ4k5hM62Xy2R4RPO3DQxMc5Rq5QkCdSpk/drka+DL9w6sXNzV5nrdlBmf8+x495QXQ==
+"@typescript-eslint/typescript-estree@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.1.0.tgz#132aea34372df09decda961cb42457433aa6e83d"
+  integrity sha512-SSz+l9YrIIsW4s0ZqaEfnjl156XQ4VRmJsbA0ZE1XkXrD3cRpzuZSVCyqeCMR3EBjF27IisWakbBDGhGNIOvfQ==
   dependencies:
-    "@typescript-eslint/types" "4.29.0"
-    "@typescript-eslint/visitor-keys" "4.29.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
+    "@typescript-eslint/types" "5.1.0"
+    "@typescript-eslint/visitor-keys" "5.1.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.0.tgz#1ff60f240def4d85ea68d4fd2e4e9759b7850c04"
-  integrity sha512-LoaofO1C/jAJYs0uEpYMXfHboGXzOJeV118X4OsZu9f7rG7Pr9B3+4HTU8+err81rADa4xfQmAxnRnPAI2jp+Q==
+"@typescript-eslint/visitor-keys@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.1.0.tgz#e01a01b27eb173092705ae983aa1451bd1842630"
+  integrity sha512-uqNXepKBg81JVwjuqAxYrXa1Ql/YDzM+8g/pS+TCPxba0wZttl8m5DkrasbfnmJGHs4lQ2jTbcZ5azGhI7kK+w==
   dependencies:
-    "@typescript-eslint/types" "4.29.0"
-    eslint-visitor-keys "^2.0.0"
+    "@typescript-eslint/types" "5.1.0"
+    eslint-visitor-keys "^3.0.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -2291,10 +2297,30 @@ array-ify@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
   integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
 
+array-includes@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.4.tgz#f5b493162c760f3539631f005ba2bb46acb45ba9"
+  integrity sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.7"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array.prototype.flat@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz#07e0975d84bbc7c48cd1879d609e682598d33e13"
+  integrity sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -2611,6 +2637,14 @@ cacache@^15.0.3, cacache@^15.0.5, cacache@^15.2.0:
     ssri "^8.0.1"
     tar "^6.0.2"
     unique-filename "^1.1.1"
+
+call-bind@^1.0.0, call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
 
 call-limit@^1.1.1:
   version "1.1.1"
@@ -3293,6 +3327,13 @@ debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -3300,7 +3341,14 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.1:
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.3.1, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -3445,6 +3493,13 @@ dir-glob@^3.0.0, dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -3629,6 +3684,32 @@ es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
+es-abstract@^1.19.0, es-abstract@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
+  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.1"
+    is-string "^1.0.7"
+    is-weakref "^1.0.1"
+    object-inspect "^1.11.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
+
 es-module-lexer@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.7.1.tgz#c2c8e0f46f2df06274cdaf0dd3f3b33e0a0b267d"
@@ -3687,10 +3768,22 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
-  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+eslint-import-resolver-node@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
+  integrity sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==
+  dependencies:
+    debug "^3.2.7"
+    resolve "^1.20.0"
+
+eslint-module-utils@^2.7.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz#b435001c9f8dd4ab7f6d0efcae4b9696d4c24b7c"
+  integrity sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==
+  dependencies:
+    debug "^3.2.7"
+    find-up "^2.1.0"
+    pkg-dir "^2.0.0"
 
 eslint-plugin-es@^3.0.0:
   version "3.0.0"
@@ -3699,6 +3792,25 @@ eslint-plugin-es@^3.0.0:
   dependencies:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
+
+eslint-plugin-import@^2.25.2:
+  version "2.25.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.2.tgz#b3b9160efddb702fc1636659e71ba1d10adbe9e9"
+  integrity sha512-qCwQr9TYfoBHOFcVGKY9C9unq05uOxxdklmBXLVvcwo68y5Hta6/GzCZEMx2zQiu0woKNEER0LE7ZgaOfBU14g==
+  dependencies:
+    array-includes "^3.1.4"
+    array.prototype.flat "^1.2.5"
+    debug "^2.6.9"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.6"
+    eslint-module-utils "^2.7.0"
+    has "^1.0.3"
+    is-core-module "^2.7.0"
+    is-glob "^4.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.5"
+    resolve "^1.20.0"
+    tsconfig-paths "^3.11.0"
 
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
@@ -3712,10 +3824,10 @@ eslint-plugin-node@^11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
-eslint-plugin-prettier@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"
-  integrity sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
+eslint-plugin-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -3762,6 +3874,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz#e32e99c6cdc2eb063f204eda5db67bfe58bb4186"
+  integrity sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==
 
 eslint@^7.32.0:
   version "7.32.0"
@@ -4030,7 +4147,7 @@ find-npm-prefix@^1.0.2:
   resolved "https://registry.yarnpkg.com/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz#8d8ce2c78b3b4b9e66c8acc6a37c231eb841cfdf"
   integrity sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==
 
-find-up@^2.0.0:
+find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
@@ -4284,6 +4401,15 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
@@ -4311,6 +4437,14 @@ get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -4421,7 +4555,7 @@ globby@^11.0.0:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.1, globby@^11.0.3:
+globby@^11.0.1, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
@@ -4490,6 +4624,11 @@ hard-rejection@^2.1.0:
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
+has-bigints@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -4504,6 +4643,18 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+
+has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has-unicode@^2.0.0, has-unicode@^2.0.1, has-unicode@~2.0.1:
   version "2.0.1"
@@ -4672,6 +4823,11 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.6.tgz#643194ad4bf2712f37852e386b6998eff0db2106"
   integrity sha512-cgXgkypZBcCnOgSihyeqbo6gjIaIyDqPQB7Ra4vhE9m6kigdGoQDMHjviFhRZo3IMlRy6yElosoviMs5YxZXUA==
 
+ignore@^5.1.8:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
 import-fresh@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
@@ -4777,6 +4933,15 @@ init-package-json@^2.0.3:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^3.0.0"
 
+internal-slot@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  dependencies:
+    get-intrinsic "^1.1.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 into-stream@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-5.1.1.tgz#f9a20a348a11f3c13face22763f2d02e127f4db8"
@@ -4818,6 +4983,13 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-bigint@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
+  integrity sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==
+  dependencies:
+    has-bigints "^1.0.1"
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
@@ -4825,10 +4997,23 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-boolean-object@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
+  integrity sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-callable@^1.1.4, is-callable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
   integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
+
+is-callable@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
+  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
 is-ci@^1.0.10:
   version "1.2.1"
@@ -4862,6 +5047,13 @@ is-core-module@^2.2.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.5.0.tgz#f754843617c70bfd29b7bd87327400cda5c18491"
   integrity sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.7.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
+  integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
   dependencies:
     has "^1.0.3"
 
@@ -4904,6 +5096,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-installed-globally@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
@@ -4917,10 +5116,22 @@ is-lambda@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
   integrity sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
 
+is-negative-zero@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
   integrity sha1-8vtjpl5JBbQGyGBydloaTceTufQ=
+
+is-number-object@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.6.tgz#6a7aaf838c7f0686a50b4553f7e54a96494e89f0"
+  integrity sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -4987,6 +5198,14 @@ is-regex@^1.1.0:
   dependencies:
     has-symbols "^1.0.1"
 
+is-regex@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
@@ -4995,6 +5214,11 @@ is-retry-allowed@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
+
+is-shared-array-buffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
+  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
 
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
@@ -5006,12 +5230,26 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
+is-string@^1.0.5, is-string@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-symbol@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
   integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
   dependencies:
     has-symbols "^1.0.1"
+
+is-symbol@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
+  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
+  dependencies:
+    has-symbols "^1.0.2"
 
 is-text-path@^1.0.1:
   version "1.0.1"
@@ -5029,6 +5267,13 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-weakref@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.1.tgz#842dba4ec17fa9ac9850df2d6efbc1737274f2a2"
+  integrity sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==
+  dependencies:
+    call-bind "^1.0.0"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -5630,6 +5875,11 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
+json-schema@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.3.0.tgz#90a9c5054bd065422c00241851ce8d59475b701b"
+  integrity sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -5648,6 +5898,13 @@ json5@2.x:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
   integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
+  dependencies:
+    minimist "^1.2.0"
+
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
 
@@ -7269,6 +7526,11 @@ object-assign@^4.1.0, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-inspect@^1.11.0, object-inspect@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
+  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
+
 object-inspect@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
@@ -7289,6 +7551,16 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
+object.assign@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
 object.getownpropertydescriptors@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
@@ -7296,6 +7568,15 @@ object.getownpropertydescriptors@^2.0.3:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
+
+object.values@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.5.tgz#959f63e3ce9ef108720333082131e4a459b716ac"
+  integrity sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0, once@~1.4.0:
   version "1.4.0"
@@ -7716,6 +7997,13 @@ pkg-conf@^2.1.0:
   dependencies:
     find-up "^2.0.0"
     load-json-file "^4.0.0"
+
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
 
 pkg-dir@^4.2.0:
   version "4.2.0"
@@ -8156,7 +8444,7 @@ regexpp@^3.0.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
   integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
 
-regexpp@^3.1.0:
+regexpp@^3.1.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -8492,6 +8780,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
@@ -8807,6 +9104,14 @@ string.prototype.trimend@^1.0.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 string.prototype.trimstart@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
@@ -8814,6 +9119,14 @@ string.prototype.trimstart@^1.0.1:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
+
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -9208,6 +9521,16 @@ ts-jest@^27.0.4:
     semver "7.x"
     yargs-parser "20.x"
 
+tsconfig-paths@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"
+  integrity sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
+
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -9315,6 +9638,16 @@ umask@^1.1.0, umask@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
+
+unbox-primitive@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
 
 unique-filename@^1.1.1:
   version "1.1.1"
@@ -9591,6 +9924,17 @@ whatwg-url@^8.5.0:
     lodash "^4.7.0"
     tr46 "^2.1.0"
     webidl-conversions "^6.1.0"
+
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
It's part 1 of the bigger effort from #670. This PR doesn't change any logic - only re-formats imports and removes 1 dependency cycle by adding `pluginPools.ts` file