### PR TITLE
fix: require typescript@^3.8.0 for build: true mode

### DIFF
--- a/src/typescript-reporter/TypeScriptSupport.ts
+++ b/src/typescript-reporter/TypeScriptSupport.ts
@@ -28,6 +28,14 @@ function assertTypeScriptSupport(configuration: TypeScriptReporterConfiguration)
       ].join(os.EOL)
     );
   }
+  if (configuration.build && semver.lt(typescriptVersion, '3.8.0')) {
+    throw new Error(
+      [
+        `ForkTsCheckerWebpackPlugin doesn't support build option for the current typescript version of ${typescriptVersion}.`,
+        'The minimum required version is 3.8.0.',
+      ].join(os.EOL)
+    );
+  }
 
   if (!fs.existsSync(configuration.configFile)) {
     throw new Error(

--- a/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
+++ b/test/e2e/TypeScriptSolutionBuilderApi.spec.ts
@@ -4,7 +4,7 @@ import semver from 'semver';
 
 describe('TypeScript SolutionBuilder API', () => {
   it.each([
-    { async: false, typescript: '~3.6.0', mode: 'readonly' },
+    { async: false, typescript: '~3.8.0', mode: 'readonly' },
     { async: true, typescript: '~3.8.0', mode: 'write-tsbuildinfo' },
     { async: false, typescript: '~4.0.0', mode: 'write-references' },
     { async: true, typescript: '~4.3.0', mode: 'readonly' },


### PR DESCRIPTION
SolutionBuilder API is buggy for TypeScript < 3.8.0. To reduce maintenance burden, we bump minimal TypeScript version for { build: true } mode to 3.8.0.

BREAKING CHANGE: 🧨 Minimal version of TypeScript with { build: true } mode changed from 3.6.0 to 3.8.0