### PR TITLE
Upgrade chokidar 3.4.2 to 3.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@babel/code-frame": "^7.8.3",
     "@types/json-schema": "^7.0.5",
     "chalk": "^4.1.0",
-    "chokidar": "^3.4.2",
+    "chokidar": "^3.5.2",
     "cosmiconfig": "^6.0.0",
     "deepmerge": "^4.2.2",
     "fs-extra": "^9.0.0",


### PR DESCRIPTION
- chokidar 3.4.2 to 3.5.2 upgrade for Mac ARM support version
- glob-parent chokidar's dependency upgrade to pass security vulnerability 5.1.2