### PR TITLE
feature: add stats on async mode

### DIFF
--- a/changelog.config.js
+++ b/changelog.config.js
@@ -7,30 +7,37 @@ module.exports = {
     feat: {
       description: 'A new feature',
       value: 'feat',
+      section: 'Features',
     },
     fix: {
       description: 'A bug fix',
       value: 'fix',
+      section: 'Bug Fixes',
     },
     refactor: {
       description: 'A code change that neither adds a feature or fixes a bug',
       value: 'refactor',
+      hidden: true,
     },
     perf: {
       description: 'A code change that improves performance',
       value: 'perf',
+      hidden: true,
     },
     test: {
       description: 'Adding missing tests',
       value: 'test',
+      hidden: true,
     },
     chore: {
       description: 'Build process, CI or auxiliary tool changes',
       value: 'chore',
+      hidden: true,
     },
     docs: {
       description: 'Documentation only changes',
       value: 'docs',
+      hidden: true,
     },
   },
 };

--- a/src/formatter/stats-formatter.ts
+++ b/src/formatter/stats-formatter.ts
@@ -1,0 +1,26 @@
+import chalk from 'chalk';
+import type { Stats } from 'webpack';
+
+import type { Issue } from '../issue';
+
+// mimics webpack's stats summary formatter
+export function statsFormatter(issues: Issue[], stats: Stats): string {
+  const errorsNumber = issues.filter((issue) => issue.severity === 'error').length;
+  const warningsNumber = issues.filter((issue) => issue.severity === 'warning').length;
+  const errorsFormatted = errorsNumber
+    ? chalk.red.bold(`${errorsNumber} ${errorsNumber === 1 ? 'error' : 'errors'}`)
+    : '';
+  const warningsFormatted = warningsNumber
+    ? chalk.yellow.bold(`${warningsNumber} ${warningsNumber === 1 ? 'warning' : 'warnings'}`)
+    : '';
+  const timeFormatted = Math.round(Date.now() - stats.startTime);
+
+  return [
+    'Found ',
+    errorsFormatted,
+    errorsFormatted && warningsFormatted ? ' and ' : '',
+    warningsFormatted,
+    ` in ${timeFormatted} ms`,
+    '.',
+  ].join('');
+}

--- a/test/e2e/driver/webpack-dev-server-driver.ts
+++ b/test/e2e/driver/webpack-dev-server-driver.ts
@@ -57,7 +57,7 @@ function createWebpackDevServerDriver(
     process.stdout.on('data', (data) => {
       const content = stripAnsi(data.toString());
 
-      if (async && content.includes('No issues found.')) {
+      if (async && content.includes('No errors found.')) {
         noErrorsListener.resolve();
       }
 


### PR DESCRIPTION
Logs stats info in the console when we have `async: true` mode. This helps track the progress 
of resolving type errors.
![image](https://user-images.githubusercontent.com/8374473/151868422-b841b995-7b13-496a-941c-06e0071abf28.png)
![image](https://user-images.githubusercontent.com/8374473/151868482-db074d9d-56e7-4a96-b1eb-06b0b97b89e6.png)


Closes: #635