### PR TITLE
fix: add new files to list of dependencies in project references

### DIFF
--- a/src/typescript/worker/get-dependencies-worker.ts
+++ b/src/typescript/worker/get-dependencies-worker.ts
@@ -2,20 +2,19 @@ import type { FilesChange } from '../../files-change';
 import type { FilesMatch } from '../../files-match';
 import { exposeRpc } from '../../rpc';
 
-import { didConfigFileChanged, didRootFilesChanged, invalidateConfig } from './lib/config';
+import {
+  didConfigFileChanged,
+  didDependenciesProbablyChanged,
+  invalidateConfig,
+} from './lib/config';
 import { getDependencies, invalidateDependencies } from './lib/dependencies';
 import { system } from './lib/system';
 
-const getDependenciesWorker = ({
-  changedFiles = [],
-  deletedFiles = [],
-}: FilesChange): FilesMatch => {
+const getDependenciesWorker = (change: FilesChange): FilesMatch => {
   system.invalidateCache();
 
-  if (didConfigFileChanged({ changedFiles, deletedFiles })) {
+  if (didConfigFileChanged(change) || didDependenciesProbablyChanged(getDependencies(), change)) {
     invalidateConfig();
-    invalidateDependencies();
-  } else if (didRootFilesChanged()) {
     invalidateDependencies();
   }
 

--- a/src/typescript/worker/lib/config.ts
+++ b/src/typescript/worker/lib/config.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import type * as ts from 'typescript';
 
 import type { FilesChange } from '../../../files-change';
+import type { FilesMatch } from '../../../files-match';
 import type { Issue } from '../../../issue';
 import { forwardSlash } from '../../../utils/path/forward-slash';
 import type { TypeScriptConfigOverwrite } from '../../type-script-config-overwrite';
@@ -169,6 +170,20 @@ export function didConfigFileChanged({ changedFiles = [], deletedFiles = [] }: F
   return [...changedFiles, ...deletedFiles]
     .map((file) => path.normalize(file))
     .includes(path.normalize(config.configFile));
+}
+
+export function didDependenciesProbablyChanged(
+  dependencies: FilesMatch,
+  { changedFiles = [], deletedFiles = [] }: FilesChange
+) {
+  const didSomeDependencyHasBeenAdded = changedFiles.some(
+    (changeFile) => !dependencies.files.includes(changeFile)
+  );
+  const didSomeDependencyHasBeenDeleted = deletedFiles.some((deletedFile) =>
+    dependencies.files.includes(deletedFile)
+  );
+
+  return didSomeDependencyHasBeenAdded || didSomeDependencyHasBeenDeleted;
 }
 
 export function didRootFilesChanged() {


### PR DESCRIPTION
Currently, there is a bug in the way we compute the list of dependencies. We use cached config to get dependencies, which results in an outdated list of dependencies.

Related: #689