### PR TITLE
fix: ignore package.json file to prevent invalid code-path

### DIFF
--- a/src/watch/inclusive-node-watch-file-system.ts
+++ b/src/watch/inclusive-node-watch-file-system.ts
@@ -12,6 +12,8 @@ import type { ForkTsCheckerWebpackPluginState } from '../plugin-state';
 import type { WatchFileSystem } from './watch-file-system';
 
 const BUILTIN_IGNORED_DIRS = ['node_modules', '.git', '.yarn', '.pnp'];
+// we ignore package.json file because of https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/674
+const BUILTIN_IGNORED_FILES = ['package.json'];
 
 function createIsIgnored(
   ignored: string | RegExp | (string | RegExp)[] | undefined,
@@ -34,6 +36,9 @@ function createIsIgnored(
   );
   ignoredFunctions.push((path: string) =>
     BUILTIN_IGNORED_DIRS.some((ignoredDir) => path.includes(`/${ignoredDir}/`))
+  );
+  ignoredFunctions.push((path: string) =>
+    BUILTIN_IGNORED_FILES.some((ignoredFile) => path.endsWith(`/${ignoredFile}`))
   );
 
   return function isIgnored(path: string) {


### PR DESCRIPTION
The error in #674 is caused by a change of the `package.json` file during the build, which triggers some code path that is valid in `WatchCompilerHostOfConfigFile` but not in `WatchCompilerHostOfFilesAndCompilerOptions` that this plugin uses (because of configOverwrite option). This PR ignores the `package.json` file in watcher as a work-around.

Closes: #674