### PR TITLE
fix: ignore package json on 6.5.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      
+
       - name: Setup node
         uses: actions/setup-node@v1
         with:
@@ -40,11 +40,11 @@ jobs:
     needs: build
     strategy:
       matrix:
-        node: [10, 12] # add 14 when we drop support for webpack 4 as fsevents 1 is not compatible with node 14
+        node: [12] # add 14 when we drop support for webpack 4 as fsevents 1 is not compatible with node 14
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
-      
+
     - name: Setup node
       uses: actions/setup-node@v1
       with:
@@ -61,7 +61,7 @@ jobs:
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
-      
+
     - name: Install dependencies
       run: yarn install --frozen-lockfile
 
@@ -76,7 +76,7 @@ jobs:
 
     - name: Run e2e tests
       run: yarn test:e2e
-      
+
   release:
     runs-on: ubuntu-latest
     env:
@@ -86,7 +86,7 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta')
     steps:
       - uses: actions/checkout@v1
-      
+
       - name: Setup node
         uses: actions/setup-node@v1
         with:

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   branches: [
+    '+([0-9])?(.{+([0-9]),x}).x',
     'main',
     {
       name: 'alpha',

--- a/src/watch/InclusiveNodeWatchFileSystem.ts
+++ b/src/watch/InclusiveNodeWatchFileSystem.ts
@@ -7,6 +7,8 @@ import { clearFilesChange, updateFilesChange } from '../reporter';
 import minimatch from 'minimatch';
 
 const BUILTIN_IGNORED_DIRS = ['node_modules', '.git', '.yarn', '.pnp'];
+// we ignore package.json file because of https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/674
+const BUILTIN_IGNORED_FILES = ['package.json'];
 
 function createIsIgnored(
   ignored: WatchFileSystemOptions['ignored'] | undefined,
@@ -31,6 +33,9 @@ function createIsIgnored(
   );
   ignoredFunctions.push((path: string) =>
     BUILTIN_IGNORED_DIRS.some((ignoredDir) => path.includes(`/${ignoredDir}/`))
+  );
+  ignoredFunctions.push((path: string) =>
+    BUILTIN_IGNORED_FILES.some((ignoredFile) => path.endsWith(`/${ignoredFile}`))
   );
 
   return function isIgnored(path: string) {


### PR DESCRIPTION
This is a backport of #727 to 6.5.x version of the plugin

The error in #674 is caused by a change of the package.json file during the build, which triggers some code path that is valid in `WatchCompilerHostOfConfigFile` but not in `WatchCompilerHostOfFilesAndCompilerOptions` that this plugin uses (because of the `configOverwrite` option). This PR ignores the package.json file in watcher as a work-around.