### PR TITLE
chore: run release action on every branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     needs: [build, test]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta')
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
We want to run release on backport branches. The easiest way is to run release on job on every branch - it will just skip if release is not needed