### PR TITLE
clarify documentation for incremental mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ setting "generateTrace" compiler option. This is an instruction from [microsoft/
 6. Open `types.json` in an editor
 7. When you see a type ID in the tracing output, go-to-line {id} to find data about that type
 
+## Enabling incremental mode
+
+You must both set "incremental": true in your `tsconfig.json` (under `compilerOptions`) and also specify mode: 'write-references' in `ForkTsCheckerWebpackPlugin` settings.
+
 
 ## Related projects
 


### PR DESCRIPTION
Thanks for the great project!  

I found it confusing that incremental mode does not work unless `mode` is set to 'write-references'.  Incremental mode is an important part of this plugin because they both aim to speed up compilation.  Clarifying this point would help new users.