### PR TITLE
fix: ignore package.json on windows

### DIFF
--- a/src/watch/inclusive-node-watch-file-system.ts
+++ b/src/watch/inclusive-node-watch-file-system.ts
@@ -35,10 +35,14 @@ function createIsIgnored(
     excluded.some((excludedPath) => path.startsWith(excludedPath))
   );
   ignoredFunctions.push((path: string) =>
-    BUILTIN_IGNORED_DIRS.some((ignoredDir) => path.includes(`/${ignoredDir}/`))
+    BUILTIN_IGNORED_DIRS.some(
+      (ignoredDir) => path.includes(`/${ignoredDir}/`) || path.includes(`\\${ignoredDir}\\`)
+    )
   );
   ignoredFunctions.push((path: string) =>
-    BUILTIN_IGNORED_FILES.some((ignoredFile) => path.endsWith(`/${ignoredFile}`))
+    BUILTIN_IGNORED_FILES.some(
+      (ignoredFile) => path.endsWith(`/${ignoredFile}`) || path.endsWith(`\\${ignoredFile}`)
+    )
   );
 
   return function isIgnored(path: string) {

--- a/src/watch/inclusive-node-watch-file-system.ts
+++ b/src/watch/inclusive-node-watch-file-system.ts
@@ -12,8 +12,6 @@ import type { ForkTsCheckerWebpackPluginState } from '../plugin-state';
 import type { WatchFileSystem } from './watch-file-system';
 
 const BUILTIN_IGNORED_DIRS = ['node_modules', '.git', '.yarn', '.pnp'];
-// we ignore package.json file because of https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/674
-const BUILTIN_IGNORED_FILES = ['package.json'];
 
 function createIsIgnored(
   ignored: string | RegExp | (string | RegExp)[] | undefined,
@@ -37,11 +35,6 @@ function createIsIgnored(
   ignoredFunctions.push((path: string) =>
     BUILTIN_IGNORED_DIRS.some(
       (ignoredDir) => path.includes(`/${ignoredDir}/`) || path.includes(`\\${ignoredDir}\\`)
-    )
-  );
-  ignoredFunctions.push((path: string) =>
-    BUILTIN_IGNORED_FILES.some(
-      (ignoredFile) => path.endsWith(`/${ignoredFile}`) || path.endsWith(`\\${ignoredFile}`)
     )
   );
 

--- a/test/e2e/fixtures/typescript-package/package/index.d.ts
+++ b/test/e2e/fixtures/typescript-package/package/index.d.ts
@@ -1,0 +1,1 @@
+export declare function sayHello(who: string): string;

--- a/test/e2e/fixtures/typescript-package/package/index.js
+++ b/test/e2e/fixtures/typescript-package/package/index.js
@@ -1,0 +1,7 @@
+"use strict";
+exports.__esModule = true;
+exports.sayHello = void 0;
+function sayHello(who) {
+    return 'Hello ' + who + '!';
+}
+exports.sayHello = sayHello;

--- a/test/e2e/fixtures/typescript-package/package/package.json
+++ b/test/e2e/fixtures/typescript-package/package/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "typescript-nested-project",
+  "version": "1.0.0",
+  "license": "MIT",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "files": [
+    "./index.js"
+  ]
+}

--- a/test/e2e/webpack-inclusive-watcher.spec.ts
+++ b/test/e2e/webpack-inclusive-watcher.spec.ts
@@ -30,17 +30,19 @@ describe('Webpack Inclusive Watcher', () => {
       const baseDriver = createProcessDriver(process);
       const webpackDriver = createWebpackDevServerDriver(process, async);
 
-      // first compilation is successful
       await webpackDriver.waitForNoErrors();
 
       // update nested package.json file
       await sandbox.patch('package/package.json', '"1.0.0"', '"1.0.1"');
 
+      // wait for 5 seconds and fail if there is Debug Failure. in the console output
       await expect(() =>
         baseDriver.waitForStderrIncludes('Error: Debug Failure.', 5000)
       ).rejects.toEqual(
         new Error('Exceeded time on waiting for "Error: Debug Failure." to appear in the stderr.')
       );
+
+      await webpackDriver.waitForNoErrors();
     }
   );
 });

--- a/test/e2e/webpack-inclusive-watcher.spec.ts
+++ b/test/e2e/webpack-inclusive-watcher.spec.ts
@@ -1,0 +1,46 @@
+import path from 'path';
+
+import { createProcessDriver } from 'karton';
+
+import { createWebpackDevServerDriver } from './driver/webpack-dev-server-driver';
+
+describe('Webpack Inclusive Watcher', () => {
+  it.each([{ async: false }, { async: true }])(
+    'ignores package.json change for %p',
+    async ({ async }) => {
+      await sandbox.load(path.join(__dirname, 'fixtures/typescript-basic'));
+      await sandbox.load(path.join(__dirname, 'fixtures/typescript-package'));
+      await sandbox.install('yarn', { typescript: '4.6.3' });
+      await sandbox.patch('webpack.config.js', 'async: false,', `async: ${JSON.stringify(async)},`);
+
+      // add import to typescript-nested-project project
+      await sandbox.patch(
+        'src/index.ts',
+        "import { getUserName } from './model/User';",
+        [
+          "import { getUserName } from './model/User';",
+          'import { sayHello } from "../package";',
+          '',
+          "sayHello('World');",
+        ].join('\n')
+      );
+
+      // start webpack dev server
+      const process = sandbox.spawn('yarn webpack serve --mode=development');
+      const baseDriver = createProcessDriver(process);
+      const webpackDriver = createWebpackDevServerDriver(process, async);
+
+      // first compilation is successful
+      await webpackDriver.waitForNoErrors();
+
+      // update nested package.json file
+      await sandbox.patch('package/package.json', '"1.0.0"', '"1.0.1"');
+
+      await expect(() =>
+        baseDriver.waitForStderrIncludes('Error: Debug Failure.', 5000)
+      ).rejects.toEqual(
+        new Error('Exceeded time on waiting for "Error: Debug Failure." to appear in the stderr.')
+      );
+    }
+  );
+});


### PR DESCRIPTION
I used forward slash in ignored file detection which obviously does not work on Windows 🤦🏻 

In this PR I added an E2E test for the case described in #674, fixed the slash bug, and moved package.json ignore to a different place (because ignoring watch on the package.json could interfere with other plugins/loaders)

Closes: #674