### PR TITLE
chore: dont fail fast on test job matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
       matrix:
         node: [12, 14, 16]
         os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
The test job takes a lot of time and is flaky due to the nature of e2e tests. We run it on different environments, so canceling all if one of them fails doesn't make sense. It's often that one job has problems with installing dependencies or that something doesn't work on Windows.