### PR TITLE
docs: update readme and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,10 @@ module.exports = {
       {
         test: /\.tsx?$/,
         loader: 'ts-loader',
-        exclude: /node_modules/,
-        options: {
-          // disable type checker - we will use it in fork plugin
-          transpileOnly: true
-        }
+        // for ts-loader < 9.3.0 you have to add transpileOnly: true option
+        // options: {
+        //   transpileOnly: true
+        // }
       }
     ]
   },
@@ -243,7 +242,8 @@ module.exports = {
         exclude: /node_modules/,
         options: {
           appendTsSuffixTo: [/\.vue$/],
-          transpileOnly: true
+          // add transpileOnly if you use ts-loader < 9.3.0 
+          // transpileOnly: true
         }
       },
       {

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module.exports = {
       {
         test: /\.tsx?$/,
         loader: 'ts-loader',
-        // for ts-loader < 9.3.0 you have to add transpileOnly: true option
+        // add transpileOnly option if you use ts-loader < 9.3.0 
         // options: {
         //   transpileOnly: true
         // }
@@ -242,7 +242,7 @@ module.exports = {
         exclude: /node_modules/,
         options: {
           appendTsSuffixTo: [/\.vue$/],
-          // add transpileOnly if you use ts-loader < 9.3.0 
+          // add transpileOnly option if you use ts-loader < 9.3.0 
           // transpileOnly: true
         }
       },

--- a/examples/babel-loader/package.json
+++ b/examples/babel-loader/package.json
@@ -4,18 +4,18 @@
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
-    "dev": "webpack-dev-server",
-    "build": "webpack -p"
+    "dev": "webpack serve --mode=development",
+    "build": "webpack --mode=production"
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",
     "@babel/preset-env": "^7.6.0",
     "@babel/preset-typescript": "^7.6.0",
     "babel-loader": "^8.0.0",
-    "fork-ts-checker-webpack-plugin": "^5.0.0-alpha.9",
-    "typescript": "^3.8.0",
-    "webpack": "^4.0.0",
-    "webpack-cli": "^3.0.0",
-    "webpack-dev-server": "^3.0.0"
+    "fork-ts-checker-webpack-plugin": "^7.2.8",
+    "typescript": "^4.6.4",
+    "webpack": "^5.72.0",
+    "webpack-cli": "^4.9.2",
+    "webpack-dev-server": "^4.8.1"
   }
 }

--- a/examples/babel-loader/webpack.config.js
+++ b/examples/babel-loader/webpack.config.js
@@ -10,7 +10,6 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        exclude: /node_modules/,
         loader: 'babel-loader',
       },
     ],
@@ -22,7 +21,7 @@ module.exports = {
           semantic: true,
           syntactic: true,
         },
-        mode: "write-references",
+        mode: 'write-references',
       },
     }),
   ],

--- a/examples/ts-loader/package.json
+++ b/examples/ts-loader/package.json
@@ -4,15 +4,15 @@
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
-    "dev": "webpack-dev-server",
-    "build": "webpack -p"
+    "dev": "webpack serve --mode=development",
+    "build": "webpack --mode=production"
   },
   "devDependencies": {
-    "fork-ts-checker-webpack-plugin": "^5.0.0-alpha.9",
-    "ts-loader": "^7.0.0",
-    "typescript": "^3.8.0",
-    "webpack": "^4.0.0",
-    "webpack-cli": "^3.0.0",
-    "webpack-dev-server": "^3.0.0"
+    "fork-ts-checker-webpack-plugin": "^7.2.8",
+    "ts-loader": "^9.2.9",
+    "typescript": "^4.6.4",
+    "webpack": "^5.72.0",
+    "webpack-cli": "^4.9.2",
+    "webpack-dev-server": "^4.8.1"
   }
 }

--- a/examples/ts-loader/webpack.config.js
+++ b/examples/ts-loader/webpack.config.js
@@ -11,10 +11,6 @@ module.exports = {
       {
         test: /\.tsx?$/,
         loader: 'ts-loader',
-        exclude: /node_modules/,
-        options: {
-          transpileOnly: true,
-        },
       },
     ],
   },


### PR DESCRIPTION
Starting from ts-loader 9.3.0 we don't have to set `transpileOnly: true` option.

See https://github.com/TypeStrong/ts-loader/pull/1451