### PR TITLE
fix: remove node_modules from built-in ignored dirs

### DIFF
--- a/src/watch/inclusive-node-watch-file-system.ts
+++ b/src/watch/inclusive-node-watch-file-system.ts
@@ -11,7 +11,7 @@ import type { ForkTsCheckerWebpackPluginState } from '../plugin-state';
 
 import type { WatchFileSystem } from './watch-file-system';
 
-const BUILTIN_IGNORED_DIRS = ['node_modules', '.git', '.yarn', '.pnp'];
+const BUILTIN_IGNORED_DIRS = ['.git'];
 
 function createIsIgnored(
   ignored: string | RegExp | (string | RegExp)[] | undefined,


### PR DESCRIPTION
This creates more issues than it helps. We use webpack watcher anyway, so ignoring these files or not will not affect watcher performance. User can always add node_modules to ignored dirs manually in webpack config.

Closes: #752