### PR TITLE
perf: abort stale type-checks on fast recompilations

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,14 +63,15 @@
     "fs-extra": "^10.0.0",
     "memfs": "^3.4.1",
     "minimatch": "^3.0.4",
+    "node-abort-controller": "^3.0.1",
     "schema-utils": "^3.1.1",
     "semver": "^7.3.5",
     "tapable": "^2.2.1"
   },
   "peerDependencies": {
     "typescript": ">3.6.0",
-    "webpack": "^5.11.0",
-    "vue-template-compiler": "*"
+    "vue-template-compiler": "*",
+    "webpack": "^5.11.0"
   },
   "peerDependenciesMeta": {
     "vue-template-compiler": {

--- a/src/hooks/tap-done-to-async-get-issues.ts
+++ b/src/hooks/tap-done-to-async-get-issues.ts
@@ -39,7 +39,6 @@ function tapDoneToAsyncGetIssues(
       }
 
       issues = await issuesPromise;
-      debug('Got issues from getIssuesWorker.', issues?.length);
     } catch (error) {
       hooks.error.call(error, stats.compilation);
       return;
@@ -51,6 +50,8 @@ function tapDoneToAsyncGetIssues(
     ) {
       return;
     }
+
+    debug(`Got ${issues?.length || 0} issues from getIssuesWorker.`);
 
     // filter list of issues by provided issue predicate
     issues = issues.filter(config.issue.predicate);

--- a/src/hooks/tap-done-to-async-get-issues.ts
+++ b/src/hooks/tap-done-to-async-get-issues.ts
@@ -45,8 +45,10 @@ function tapDoneToAsyncGetIssues(
       return;
     }
 
-    if (!issues) {
-      // some error has been thrown or it was canceled
+    if (
+      !issues || // some error has been thrown
+      state.issuesPromise !== issuesPromise // we have a new request - don't show results for the old one
+    ) {
       return;
     }
 

--- a/src/hooks/tap-error-to-log-message.ts
+++ b/src/hooks/tap-error-to-log-message.ts
@@ -4,6 +4,7 @@ import type webpack from 'webpack';
 import type { ForkTsCheckerWebpackPluginConfig } from '../plugin-config';
 import { getPluginHooks } from '../plugin-hooks';
 import { RpcExitError } from '../rpc';
+import { AbortError } from '../utils/async/abort-error';
 
 function tapErrorToLogMessage(
   compiler: webpack.Compiler,
@@ -12,6 +13,10 @@ function tapErrorToLogMessage(
   const hooks = getPluginHooks(compiler);
 
   hooks.error.tap('ForkTsCheckerWebpackPlugin', (error) => {
+    if (error instanceof AbortError) {
+      return;
+    }
+
     config.logger.error(String(error));
 
     if (error instanceof RpcExitError) {

--- a/src/plugin-state.ts
+++ b/src/plugin-state.ts
@@ -1,11 +1,15 @@
+import type { AbortController } from 'node-abort-controller';
 import type { FullTap } from 'tapable';
 
+import type { FilesChange } from './files-change';
 import type { FilesMatch } from './files-match';
 import type { Issue } from './issue';
 
 interface ForkTsCheckerWebpackPluginState {
   issuesPromise: Promise<Issue[] | undefined>;
   dependenciesPromise: Promise<FilesMatch | undefined>;
+  abortController: AbortController | undefined;
+  aggregatedFilesChange: FilesChange | undefined;
   lastDependencies: FilesMatch | undefined;
   watching: boolean;
   initialized: boolean;
@@ -17,6 +21,8 @@ function createPluginState(): ForkTsCheckerWebpackPluginState {
   return {
     issuesPromise: Promise.resolve(undefined),
     dependenciesPromise: Promise.resolve(undefined),
+    abortController: undefined,
+    aggregatedFilesChange: undefined,
     lastDependencies: undefined,
     watching: false,
     initialized: false,

--- a/src/utils/async/abort-error.ts
+++ b/src/utils/async/abort-error.ts
@@ -1,0 +1,16 @@
+import type { AbortSignal } from 'node-abort-controller';
+
+class AbortError extends Error {
+  constructor(message = 'Task aborted.') {
+    super(message);
+    this.name = 'AbortError';
+  }
+
+  static throwIfAborted(signal: AbortSignal | undefined) {
+    if (signal?.aborted) {
+      throw new AbortError();
+    }
+  }
+}
+
+export { AbortError };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5804,6 +5804,11 @@ nerf-dart@^1.0.0:
   resolved "https://registry.yarnpkg.com/nerf-dart/-/nerf-dart-1.0.0.tgz#e6dab7febf5ad816ea81cf5c629c5a0ebde72c1a"
   integrity sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=
 
+node-abort-controller@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.0.1.tgz#f91fa50b1dee3f909afabb7e261b1e1d6b0cb74e"
+  integrity sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==
+
 node-emoji@^1.10.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.11.0.tgz#69a0150e6946e2f115e9d7ea4df7971e2628301c"


### PR DESCRIPTION
When user saves changes faster than type-checking process, we can end-up with a queue of type-checks that could be skipped. This PR ensures that we queue only 1 type-check per compilation and abort previous. 

Closes: #741