### PR TITLE
fix: fix e2e type-definitions test

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-commitlint --edit "$1"
+yarn commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-lint-staged && yarn build && yarn test:unit
+yarn lint-staged && yarn build && yarn test:unit

--- a/test/e2e/fixtures/type-definitions/package.json
+++ b/test/e2e/fixtures/type-definitions/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "devDependencies": {
-    "typescript": "~3.8.0",
+    "typescript": "~4.9.0",
     "webpack": "^5.11.0"
   }
 }


### PR DESCRIPTION
This test were failing because newer version of webpack doesn't support TypeScript 3.9.0. I upgraded TypeScript version in the fixtures to fix this issue.