### PR TITLE
chore: blog.johnnyreilly.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ We are aware of an [issue with Vue and the incremental API](https://github.com/T
 
 The plugin supports webpack 2, 3, 4 and 5 alpha and TypeScript 2.1+ alongside tslint 4+.
 
-See also: https://blog.johnnyreilly.com/2019/03/the-big-one-point-oh.html
+See also: https://johnnyreilly.com/2019/03/06/fork-ts-checker-webpack-plugin-v1
 
 ## v1.0.0-alpha.10
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Piotr Oleś <piotrek.oles@gmail.com>",
   "contributors": [
     "Piotr Oleś <piotrek.oles@gmail.com> (https://github.com/piotr-oles)",
-    "John Reilly <johnny_reilly@hotmail.com> (https://blog.johnnyreilly.com)"
+    "John Reilly <johnny_reilly@hotmail.com> (https://johnnyreilly.com)"
   ],
   "files": [
     "lib"


### PR DESCRIPTION
Happy New Year! I hope you're happy and well.  I decided to move from blog.johnnyreilly.com to johnnyreilly.com.  I'm down going around and raising PRs that link to the old URL.  This is one!

https://github.com/johnnyreilly/blog.johnnyreilly.com/pull/393