### PR TITLE
Clarify "No errors found." message

### DIFF
--- a/src/hooks/tap-done-to-async-get-issues.ts
+++ b/src/hooks/tap-done-to-async-get-issues.ts
@@ -68,7 +68,7 @@ function tapDoneToAsyncGetIssues(
       // print stats of the compilation
       config.logger.log(statsFormatter(issues, stats));
     } else {
-      config.logger.log(chalk.green('No errors found.'));
+      config.logger.log(chalk.green('No typescript errors found.'));
     }
 
     // report issues to webpack-dev-server, if it's listening

--- a/test/e2e/driver/webpack-dev-server-driver.ts
+++ b/test/e2e/driver/webpack-dev-server-driver.ts
@@ -57,7 +57,7 @@ function createWebpackDevServerDriver(
     process.stdout.on('data', (data) => {
       const content = stripAnsi(data.toString());
 
-      if (async && content.includes('No errors found.')) {
+      if (async && content.includes('No typescript errors found.')) {
         noErrorsListener.resolve();
       }
 


### PR DESCRIPTION
A really minor usability tweak, subjective, up to you if you like it.

In the context of webpack-dev-server, there are 2 async build processes, which may report success/failure:

- webpack bundle:
  - `webpack 5.72.0 compiled with 2 errors in 5492 ms`,
  - `webpack 5.72.0 compiled successfully in 55345 ms` are self-explaining.

There is _sometimes_ a cyan "Type-checking in progress..." between them, but not always.

- TypeScript checking, which may arrive later:
  - when typescript fails, it starts with non-specific red "ERROR in ./src/..." but next line start with TS error code e.g. `TS6133: `, so clear enough.
  - when typescript succeeds, the green "No errors found." message may arrive later, and doesn't explain it's specifically what kind of errors. :point_left: 

This PR tweaks the last case to say "No typescript errors found." for clarity.

![Screenshot from 2023-10-29 15-42-45](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/assets/273688/a4721948-16d0-4cdb-b74a-cea14503a7e1)


