### PR TITLE
chore: update cosmiconfig due to vulnerability in yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/code-frame": "^7.16.7",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",
-    "cosmiconfig": "^7.0.1",
+    "cosmiconfig": "^8.1.3",
     "deepmerge": "^4.2.2",
     "fs-extra": "^10.0.0",
     "memfs": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2861,6 +2861,16 @@ cosmiconfig@^7, cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cosmiconfig@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.1.3.tgz#0e614a118fcc2d9e5afc2f87d53cd09931015689"
+  integrity sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==
+  dependencies:
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"


### PR DESCRIPTION
Updates the `cosmiconfig` version due to a vulnerability in the yaml package, newer versions of `cosmiconfig` do not have this issue.

```
yaml  <2.2.2
Severity: moderate
Uncaught Exception in yaml - https://github.com/advisories/GHSA-f9xv-q969-pqx4
```

The plugin still depends on cosmiconfig v7, because commitlint is using it, but updating that should be a separate PR.