### PR TITLE
Update cosmiconfig package in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/code-frame": "^7.16.7",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",
-    "cosmiconfig": "^7.0.1",
+    "cosmiconfig": "^8.1.3",
     "deepmerge": "^4.2.2",
     "fs-extra": "^10.0.0",
     "memfs": "^3.4.1",


### PR DESCRIPTION
We have encountered a component governance problem with the older versions of the yaml packages. These packages are transitively utilized by `fork-ts-checker-webpack-plugin` package.