### PR TITLE
chore(package): update cosmiconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/code-frame": "^7.16.7",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",
-    "cosmiconfig": "^7.0.1",
+    "cosmiconfig": "^8.2.0",
     "deepmerge": "^4.2.2",
     "fs-extra": "^10.0.0",
     "memfs": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2861,6 +2861,16 @@ cosmiconfig@^7, cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cosmiconfig@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.2.0.tgz#f7d17c56a590856cd1e7cee98734dca272b0d8fd"
+  integrity sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==
+  dependencies:
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"


### PR DESCRIPTION
Similar to #815 except it updates yarn.lock.

cosmiconfig dropped dependency on the yarn npm package which has CVEs