### PR TITLE
chore(node): drop support for node v12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     steps:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@
 
 ## Installation
 
-This plugin requires **Node.js >=12.13.0+**, **Webpack ^5.11.0**, **TypeScript ^3.6.0**
+This plugin requires **Node.js >=14.0.0+**, **Webpack ^5.11.0**, **TypeScript ^3.6.0**
 
 * If you depend on **TypeScript 2.1 - 2.6.2**, please use [version 4](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/tree/v4.1.4) of the plugin.
 * If you depend on **Webpack 4**, **TypeScript 2.7 - 3.5.3** or **ESLint** feature, please use [version 6](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/tree/v6.2.6) of the plugin.
+* If you depend on **Node.js 12**, please use [version 8](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/tree/v8.0.0) of the plugin.
 * If you need Vue.js support, please use [version 6](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/tree/v6.5.2) of ths plugin
 
 ```sh


### PR DESCRIPTION
This change removes "official" support for node v12, which is now unmaintained and hasn't been supported since 30th April 2022. If users still need to use node v12 they can continue using the v8 version of this package.

BREAKING CHANGE: Drop support for Node.js v12