### PR TITLE
fix: issue-webpack-error should not add colors to file string

### DIFF
--- a/src/issue/issue-webpack-error.ts
+++ b/src/issue/issue-webpack-error.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 
-import chalk from 'chalk';
 import webpack from 'webpack';
 
 import type { FormatterPathType } from '../formatter';
@@ -26,7 +25,7 @@ class IssueWebpackError extends webpack.WebpackError {
           : relativeToContext(issue.file, process.cwd());
 
       if (issue.location) {
-        this.file += `:${chalk.green.bold(formatIssueLocation(issue.location))}`;
+        this.file += `:${formatIssueLocation(issue.location)}`;
       }
     }
 


### PR DESCRIPTION
Introduced in #641, the issue location is now coloured in green in both the terminal console and in the error sent to webpack.

No problem at all in the terminal:

<img width="938" alt="image" src="https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/assets/4232218/14c98a42-8da6-4889-bc69-daf9cddbff3d">

Having a look at the message sent through ws:

<img width="728" alt="image" src="https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/assets/4232218/b1e5d5c8-152b-4710-b743-f8652c29f7e3">

The file property contains the ANSI chalk chars corresponding to the colour applied to the issue location.

The thing is, in the webpack-dev-server overlay, the location does not come up properly:

<img width="994" alt="image" src="https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/assets/4232218/49822d05-e4b8-47fe-a991-3aa152428790">

In fact, the overlay does not seem to apply a ANSI to HTML conversion for the header of the message (file) (see. [overlay.js#L247](https://github.com/webpack/webpack-dev-server/blob/master/client-src/overlay.js#L247)) but only for the body of the message (message) (see. [overlay.js#L262](https://github.com/webpack/webpack-dev-server/blob/master/client-src/overlay.js#L262)).

I suggest that we just remove the coloured location in the error message sent to webpack.

Here is a minimum reproducible example:
https://github.com/sreucherand/webpack-ts-checker-minimal-reproducible-example

```sh
yarn
yarn start
```
