### PR TITLE
fix: handle undefined paths in getModifiedTime

### DIFF
--- a/src/typescript/worker/lib/system.ts
+++ b/src/typescript/worker/lib/system.ts
@@ -114,6 +114,10 @@ export const system: ControlledTypeScriptSystem = {
       .map((dirent) => dirent.name);
   },
   getModifiedTime(path: string): Date | undefined {
+    if (typeof path !== "string") {
+      return undefined;
+    }
+
     const stats = getReadFileSystem(path).readStats(path);
 
     if (stats) {


### PR DESCRIPTION
Fixes #855 

When building projects in `tsc` build mode (with `typescript.build` set to `true`), some paths passed to `getModifiedTime` will be `undefined`. Previously, this would cause an error and prevent type-checking (see https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/855). With these changes, the modified time will just be returned as `undefined` in such cases, which allows type checking to complete successfully.